### PR TITLE
[Feature] Add `CheckBlockError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,6 +3345,7 @@ dependencies = [
  "snarkvm-ledger-test-helpers",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
+ "thiserror 2.0.17",
  "time",
  "tracing",
  "tracing-subscriber",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -176,6 +176,7 @@ workspace = true
 
 [dependencies.thiserror]
 workspace = true
+features = [ "std" ]
 
 [dev-dependencies.bincode]
 workspace = true

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -174,6 +174,9 @@ workspace = true
 [dependencies.tracing]
 workspace = true
 
+[dependencies.thiserror]
+workspace = true
+
 [dev-dependencies.bincode]
 workspace = true
 

--- a/ledger/block/src/verify.rs
+++ b/ledger/block/src/verify.rs
@@ -26,7 +26,11 @@ use std::collections::HashSet;
 use rayon::prelude::*;
 
 impl<N: Network> Block<N> {
-    /// Ensures the block is correct.
+    /// Ensures the block is well-formed and consistent with the previous block.
+    ///
+    /// # Returns
+    /// - On success, the sets of transaction and solution IDs that existed in this subDAG but were already included in the previous block.
+    /// - On failure, the error that caused verification to fail, e.g., invalid block hash, invalid block authority, or invalid transmissions.
     pub fn verify(
         &self,
         previous_block: &Block<N>,

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -36,9 +36,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Currently, we do not support ratifications from the memory pool.
         ensure!(ratifications.is_empty(), "Ratifications are currently unsupported from the memory pool");
         // Construct the block template.
-        let (header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids) = self
-            .construct_block_template(&previous_block, Some(&subdag), ratifications, solutions, transactions, rng)
-            .with_context(|| "Failed to construct block template")?;
+        let (header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids) =
+            self.construct_block_template(&previous_block, Some(&subdag), ratifications, solutions, transactions, rng)?;
 
         // Construct the new quorum block.
         Block::new_quorum(
@@ -80,8 +79,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 candidate_solutions,
                 candidate_transactions,
                 rng,
-            )
-            .with_context(|| "Failed to construct block template")?;
+            )?;
 
         // Construct the new beacon block.
         Block::new_beacon(

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -19,7 +19,8 @@ use anyhow::Context;
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns a candidate for the next block in the ledger, using a committed subdag and its transmissions.
-    ///    
+    /// This candidate can then be passed to [`Ledger::advance_to_next_block`] to be added to the ledger.
+    ///
     /// # Panics
     /// This function panics if called from an async context.
     pub fn prepare_advance_to_next_quorum_block<R: Rng + CryptoRng>(
@@ -53,6 +54,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns a candidate for the next block in the ledger.
+    /// This candidate can then be passed to [`Ledger::advance_to_next_block`] to be added to the ledger.
+    ///
+    /// Note, that beacon blocks are only used for testing purposes.
+    /// Production code will most likely used `[Ledger::prepare_advance_to_next_quorum_block`] instead.
     ///
     /// # Panics
     /// This function panics if called from an async context.
@@ -96,6 +101,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Adds the given block as the next block in the ledger.
+    ///
+    /// This function expects a valid block, that either was created by a trusted source, or successfully passed
+    /// the blocks checks (e.g. [`Ledger::check_next_block`]).
+    /// Note, that it is still possible that this function returns an error for a valid block, if there are concurrent tasks
+    /// updating the ledger.
     ///
     /// # Panics
     /// This function panics if called from an async context.

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -78,30 +78,30 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// # Arguments
     /// * `block` - The block to check.
-    /// * `pending_block` - A sequence of blocks between the block to check and the current height of the ledger.
+    /// * `prefix` - A sequence of blocks between the block to check and the current height of the ledger.
+    ///
+    /// # Returns
+    /// * On success, a [`PendingBlock`] representing the block that was checked. Once the prefix of this block has been fully added to the ledger,
+    ///   the [`PendingBlock`] can then be passed to [`Self::check_block_content`] to fully verify it.
+    /// * On failure, a [`CheckBlockError`] describing the reason the block was rejected.
     ///
     /// # Notes
     /// * This does *not* check that the header of the block is correct or execute/verify any of the transmissions contained within it.
-    ///
     /// * In most cases, you want to use [`Self::check_next_block`] instead to perform a full verification.
-    ///
     /// * This will reject any blocks with a height <= the current height and any blocks with a height >= the current height + GC.
-    ///   For the former, a valid block already exists and,
-    ///   for the latter, the comittte is still unknown.
+    ///   For the former, a valid block already exists and,for the latter, the comittee is still unknown.
+    /// * This function executes atomically, in that there is guaranteed to be no concurrent updates to the ledger during its execution.
+    ///   However there are no ordering guarantees *between* multiple invocations of this function, [`Self::check_block_content`] and [`Self::advance_to_next_block`].
     pub fn check_block_subdag(
         &self,
         block: Block<N>,
-        pending_blocks: &[PendingBlock<N>],
+        prefix: &[PendingBlock<N>],
     ) -> Result<PendingBlock<N>, CheckBlockError<N>> {
-        self.check_block_subdag_inner(&block, pending_blocks)?;
+        self.check_block_subdag_inner(&block, prefix)?;
         Ok(PendingBlock(block))
     }
 
-    fn check_block_subdag_inner(
-        &self,
-        block: &Block<N>,
-        pending_blocks: &[PendingBlock<N>],
-    ) -> Result<(), CheckBlockError<N>> {
+    fn check_block_subdag_inner(&self, block: &Block<N>, prefix: &[PendingBlock<N>]) -> Result<(), CheckBlockError<N>> {
         // Grab a lock to the latest_block in the ledger, to prevent concurrent writes to the ledger,
         // and to ensure that this check is atomic.
         let latest_block = self.current_block.read();
@@ -109,21 +109,21 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // First check that the heights and hashes of the pending block sequence and of the new block are correct.
         // The hash checks should be redundant, but we perform them out of extra caution.
         let mut expected_height = latest_block.height() + 1;
-        for pending in pending_blocks {
-            if pending.height() != expected_height {
+        for prefix_block in prefix {
+            if prefix_block.height() != expected_height {
                 return Err(CheckBlockError::InvalidPrefix {
-                    height: pending.height(),
+                    height: prefix_block.height(),
                     error: Box::new(CheckBlockError::InvalidHeight {
                         expected: expected_height,
-                        actual: pending.height(),
+                        actual: prefix_block.height(),
                     }),
                 });
             }
 
-            if self.contains_block_hash(&pending.hash())? {
+            if self.contains_block_hash(&prefix_block.hash())? {
                 return Err(CheckBlockError::InvalidPrefix {
-                    height: pending.height(),
-                    error: Box::new(CheckBlockError::BlockAlreadyExists { hash: pending.hash() }),
+                    height: prefix_block.height(),
+                    error: Box::new(CheckBlockError::BlockAlreadyExists { hash: prefix_block.hash() }),
                 });
             }
 
@@ -145,7 +145,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.check_block_subdag_atomicity(block)?;
 
         // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
-        self.check_block_subdag_leaves(block, pending_blocks)?;
+        self.check_block_subdag_leaves(block, prefix)?;
 
         Ok(())
     }
@@ -169,6 +169,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// # Return Value
     /// This returns a [`Block`] on success representing the fully verified block.
+    ///
+    /// # Notes
+    /// - This check can only succeed for pending blocks that are a direct successor of the latest block in the ledger.
+    /// - Execution of this function is atomic, and there is guaranteed to be no concurrent update to the ledger during its execution.
+    /// - Even though this function may return `Ok(block)`, advancing the ledger to this block may still fail, if there was an update to the ledger
+    ///   *between* calling `check_block_content` and `advance_to_next_block`.
+    ///   If your implementation requires atomicity across these two steps, you need to implement your own locking mechanism.
     ///
     /// # Panics
     /// This function panics if called from an async context.
@@ -288,15 +295,21 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Check that leaves in the subdag point to batches in other blocks that are valid.
     ///
-    /// This does not verify that the batches are signed correctly or that the edges are valid
-    /// (only point to the previous round), as those checks already happened when the node received the batch.
-    fn check_block_subdag_leaves(&self, block: &Block<N>, previous_blocks: &[PendingBlock<N>]) -> Result<()> {
+    //
+    /// # Arguments
+    /// * `block` - The block to check.
+    /// * `prefix` - A sequence of [`PendingBlock`]s between the block to check and the current height of the ledger.
+    ///
+    /// # Notes
+    /// This only checks that leaves point to valid batch in the previous round, and *not* hat the batches are signed correctly
+    /// or that the edges are valid, as those checks already happened when the node received the batch.
+    fn check_block_subdag_leaves(&self, block: &Block<N>, prefix: &[PendingBlock<N>]) -> Result<()> {
         // Check if the block has a subdag.
         let Authority::Quorum(subdag) = block.authority() else {
             return Ok(());
         };
 
-        let previous_certs: HashSet<_> = previous_blocks
+        let previous_certs: HashSet<_> = prefix
             .iter()
             .filter_map(|block| match block.authority() {
                 Authority::Quorum(subdag) => Some(subdag.certificate_ids()),

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 
-use crate::narwhal::BatchHeader;
+use crate::{narwhal::BatchHeader, puzzle::SolutionID};
 
 use anyhow::{Context, bail};
 
@@ -48,6 +48,18 @@ pub enum CheckBlockError<N: Network> {
     /// An error related to the given prefix of pending blocks.
     #[error("Prefix of the block at height {height} is incorrect. {error}.")]
     InvalidPrefix { height: u32, error: Box<CheckBlockError<N>> },
+    #[error("The block contains solution '{solution_id}', but it already exists in the ledger")]
+    SolutionAlreadyExists { solution_id: SolutionID<N> },
+    #[error("Failed to speculate over unconfirmed transactions: {inner}")]
+    SpeculationFailed { inner: anyhow::Error },
+    #[error("Failed to verify block: {inner}")]
+    VerificationFailed { inner: anyhow::Error },
+    #[error("Prover '{prover_address}' has reached their solution limit for the current epoch")]
+    SolutionLimitReached { prover_address: Address<N> },
+    #[error("The previovus block should contain solution '{solution_id}', but it does not exist in the ledger")]
+    PreviousSolutionNotFound { solution_id: SolutionID<N> },
+    #[error("The previous block should contain solution '{transaction_id}', but it does not exist in the ledger")]
+    PreviousTransactionNotFound { transaction_id: N::TransactionID },
     #[error("{0:?}")]
     Other(anyhow::Error),
 }
@@ -148,7 +160,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// This function panics if called from an async context.
     pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
         self.check_block_subdag_inner(block, &[]).map_err(|err| err.into_anyhow())?;
-        self.check_block_content_inner(block, rng)?;
+        self.check_block_content_inner(block, rng).map_err(|err| err.into_anyhow())?;
 
         Ok(())
     }
@@ -164,20 +176,33 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// # Panics
     /// This function panics if called from an async context.
-    pub fn check_block_content<R: CryptoRng + Rng>(&self, block: PendingBlock<N>, rng: &mut R) -> Result<Block<N>> {
+    pub fn check_block_content<R: CryptoRng + Rng>(
+        &self,
+        block: PendingBlock<N>,
+        rng: &mut R,
+    ) -> Result<Block<N>, CheckBlockError<N>> {
         self.check_block_content_inner(&block.0, rng)?;
         Ok(block.0)
     }
 
     /// # Panics
     /// This function panics if called from an async context.
-    fn check_block_content_inner<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
+    fn check_block_content_inner<R: CryptoRng + Rng>(
+        &self,
+        block: &Block<N>,
+        rng: &mut R,
+    ) -> Result<(), CheckBlockError<N>> {
         let latest_block = self.current_block.read();
+
+        // Ensure, again, that the ledger has not advanced yet. This prevents cryptic errors form appearing during the block check.
+        if block.height() + 1 != latest_block.height() {
+            return Err(CheckBlockError::InvalidHeight { expected: latest_block.height() + 1, actual: block.height() });
+        }
 
         // Ensure the solutions do not already exist.
         for solution_id in block.solutions().solution_ids() {
-            if self.contains_solution_id(solution_id)? {
-                bail!("Solution ID {solution_id} already exists in the ledger");
+            if self.contains_solution_id(solution_id).map_err(CheckBlockError::other)? {
+                return Err(CheckBlockError::SolutionAlreadyExists { solution_id: *solution_id });
             }
         }
 
@@ -192,7 +217,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             block.cumulative_weight(),
             block.cumulative_proof_target(),
             block.previous_hash(),
-        )?;
+        )
+        .map_err(CheckBlockError::other)?;
 
         // Ensure speculation over the unconfirmed transactions is correct and ensure each transaction is well-formed and unique.
         let time_since_last_block = block.timestamp().saturating_sub(self.latest_timestamp());
@@ -206,20 +232,22 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 block.transactions(),
                 rng,
             )
-            .with_context(|| "Failed to speculate over unconfirmed transactions")?;
+            .map_err(|err| CheckBlockError::SpeculationFailed { inner: err })?;
 
         // Retrieve the committee lookback.
         let committee_lookback = self
-            .get_committee_lookback_for_round(block.round())?
-            .ok_or(anyhow!("Failed to fetch committee lookback for round {}", block.round()))?;
+            .get_committee_lookback_for_round(block.round())
+            .map_err(CheckBlockError::other)?
+            .ok_or(CheckBlockError::other(anyhow!("Failed to fetch committee lookback for round {}", block.round())))?;
 
         // Retrieve the previous committee lookback.
         let previous_committee_lookback = {
             // Calculate the penultimate round, which is the round before the anchor round.
             let penultimate_round = block.round().saturating_sub(1);
             // Output the committee lookback for the penultimate round.
-            self.get_committee_lookback_for_round(penultimate_round)?
-                .ok_or(anyhow!("Failed to fetch committee lookback for round {penultimate_round}"))?
+            self.get_committee_lookback_for_round(penultimate_round).map_err(CheckBlockError::other)?.ok_or(
+                CheckBlockError::Other(anyhow!("Failed to fetch committee lookback for round {penultimate_round}")),
+            )?
         };
 
         // Ensure the block is correct.
@@ -230,11 +258,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 &previous_committee_lookback,
                 &committee_lookback,
                 self.puzzle(),
-                self.latest_epoch_hash()?,
+                self.latest_epoch_hash().map_err(CheckBlockError::other)?,
                 OffsetDateTime::now_utc().unix_timestamp(),
                 ratified_finalize_operations,
             )
-            .with_context(|| "Failed to verify block")?;
+            .map_err(|err| CheckBlockError::VerificationFailed { inner: err })?;
 
         // Ensure that the provers are within their stake bounds.
         if let Some(solutions) = block.solutions().deref() {
@@ -244,7 +272,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 let num_accepted_solutions = *accepted_solutions.get(&prover_address).unwrap_or(&0);
                 // Check if the prover has reached their solution limit.
                 if self.is_solution_limit_reached(&prover_address, num_accepted_solutions) {
-                    bail!("Prover '{prover_address}' has reached their solution limit for the current epoch");
+                    return Err(CheckBlockError::SolutionLimitReached { prover_address });
                 }
                 // Track the already accepted solutions.
                 *accepted_solutions.entry(prover_address).or_insert(0) += 1;
@@ -253,15 +281,15 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Ensure that each existing solution ID from the block exists in the ledger.
         for existing_solution_id in expected_existing_solution_ids {
-            if !self.contains_solution_id(&existing_solution_id)? {
-                bail!("Solution ID '{existing_solution_id}' does not exist in the ledger");
+            if !self.contains_solution_id(&existing_solution_id).map_err(CheckBlockError::other)? {
+                return Err(CheckBlockError::PreviousSolutionNotFound { solution_id: existing_solution_id });
             }
         }
 
         // Ensure that each existing transaction ID from the block exists in the ledger.
         for existing_transaction_id in expected_existing_transaction_ids {
-            if !self.contains_transaction_id(&existing_transaction_id)? {
-                bail!("Transaction ID '{existing_transaction_id}' does not exist in the ledger");
+            if !self.contains_transaction_id(&existing_transaction_id).map_err(CheckBlockError::other)? {
+                return Err(CheckBlockError::PreviousTransactionNotFound { transaction_id: existing_transaction_id });
             }
         }
 

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -94,9 +94,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         block: &Block<N>,
         pending_blocks: &[PendingBlock<N>],
     ) -> Result<(), CheckBlockError<N>> {
+        // Grab a lock to the latest_block in the ledger, to prevent concurrent writes to the ledger,
+        // and to ensure that this check is atomic.
+        let latest_block = self.current_block.read();
+
         // First check that the heights and hashes of the pending block sequence and of the new block are correct.
         // The hash checks should be redundant, but we perform them out of extra caution.
-        let mut expected_height = self.latest_height() + 1;
+        let mut expected_height = latest_block.height() + 1;
         for pending in pending_blocks {
             if pending.height() != expected_height {
                 return Err(CheckBlockError::InvalidPrefix {
@@ -168,7 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// # Panics
     /// This function panics if called from an async context.
     fn check_block_content_inner<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
-        let latest_block = self.latest_block();
+        let latest_block = self.current_block.read();
 
         // Ensure the solutions do not already exist.
         for solution_id in block.solutions().solution_ids() {

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -41,34 +41,30 @@ impl<N: Network> Deref for PendingBlock<N> {
 pub enum CheckBlockError<N: Network> {
     #[error("Block with hash {hash} already exists in the ledger")]
     BlockAlreadyExists { hash: N::BlockHash },
-    #[error("Block has invalid height. Expected {expected}, but got {actual}.")]
+    #[error("Block has invalid height. Expected {expected}, but got {actual}")]
     InvalidHeight { expected: u32, actual: u32 },
     #[error("Block has invalid hash")]
     InvalidHash,
     /// An error related to the given prefix of pending blocks.
-    #[error("Prefix of the block at height {height} is incorrect. {error}.")]
+    #[error("Prefix of the block at height {height} is incorrect - {error:?}")]
     InvalidPrefix { height: u32, error: Box<CheckBlockError<N>> },
     #[error("The block contains solution '{solution_id}', but it already exists in the ledger")]
     SolutionAlreadyExists { solution_id: SolutionID<N> },
-    #[error("Failed to speculate over unconfirmed transactions: {inner}")]
+    #[error("Failed to speculate over unconfirmed transactions - {inner}")]
     SpeculationFailed { inner: anyhow::Error },
-    #[error("Failed to verify block: {inner}")]
+    #[error("Failed to verify block - {inner}")]
     VerificationFailed { inner: anyhow::Error },
     #[error("Prover '{prover_address}' has reached their solution limit for the current epoch")]
     SolutionLimitReached { prover_address: Address<N> },
-    #[error("The previovus block should contain solution '{solution_id}', but it does not exist in the ledger")]
+    #[error("The previous block should contain solution '{solution_id}', but it does not exist in the ledger")]
     PreviousSolutionNotFound { solution_id: SolutionID<N> },
     #[error("The previous block should contain solution '{transaction_id}', but it does not exist in the ledger")]
     PreviousTransactionNotFound { transaction_id: N::TransactionID },
-    #[error("{0:?}")]
-    Other(anyhow::Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 impl<N: Network> CheckBlockError<N> {
-    pub fn other(err: anyhow::Error) -> Self {
-        Self::Other(err)
-    }
-
     pub fn into_anyhow(self) -> anyhow::Error {
         match self {
             Self::Other(err) => err,
@@ -124,7 +120,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 });
             }
 
-            if self.contains_block_hash(&pending.hash()).map_err(CheckBlockError::other)? {
+            if self.contains_block_hash(&pending.hash())? {
                 return Err(CheckBlockError::InvalidPrefix {
                     height: pending.height(),
                     error: Box::new(CheckBlockError::BlockAlreadyExists { hash: pending.hash() }),
@@ -134,7 +130,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             expected_height += 1;
         }
 
-        if self.contains_block_hash(&block.hash()).map_err(CheckBlockError::other)? {
+        if self.contains_block_hash(&block.hash())? {
             return Err(CheckBlockError::BlockAlreadyExists { hash: block.hash() });
         }
 
@@ -143,13 +139,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
 
         // Ensure the certificates in the block subdag have met quorum requirements.
-        self.check_block_subdag_quorum(block).map_err(CheckBlockError::other)?;
+        self.check_block_subdag_quorum(block)?;
 
         // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
-        self.check_block_subdag_atomicity(block).map_err(CheckBlockError::other)?;
+        self.check_block_subdag_atomicity(block)?;
 
         // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
-        self.check_block_subdag_leaves(block, pending_blocks).map_err(CheckBlockError::other)?;
+        self.check_block_subdag_leaves(block, pending_blocks)?;
 
         Ok(())
     }
@@ -201,7 +197,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Ensure the solutions do not already exist.
         for solution_id in block.solutions().solution_ids() {
-            if self.contains_solution_id(solution_id).map_err(CheckBlockError::other)? {
+            if self.contains_solution_id(solution_id)? {
                 return Err(CheckBlockError::SolutionAlreadyExists { solution_id: *solution_id });
             }
         }
@@ -217,37 +213,31 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             block.cumulative_weight(),
             block.cumulative_proof_target(),
             block.previous_hash(),
-        )
-        .map_err(CheckBlockError::other)?;
+        )?;
 
         // Ensure speculation over the unconfirmed transactions is correct and ensure each transaction is well-formed and unique.
         let time_since_last_block = block.timestamp().saturating_sub(self.latest_timestamp());
-        let ratified_finalize_operations = self
-            .vm
-            .check_speculate(
-                state,
-                time_since_last_block,
-                block.ratifications(),
-                block.solutions(),
-                block.transactions(),
-                rng,
-            )
-            .map_err(|err| CheckBlockError::SpeculationFailed { inner: err })?;
+        let ratified_finalize_operations = self.vm.check_speculate(
+            state,
+            time_since_last_block,
+            block.ratifications(),
+            block.solutions(),
+            block.transactions(),
+            rng,
+        )?;
 
         // Retrieve the committee lookback.
         let committee_lookback = self
-            .get_committee_lookback_for_round(block.round())
-            .map_err(CheckBlockError::other)?
-            .ok_or(CheckBlockError::other(anyhow!("Failed to fetch committee lookback for round {}", block.round())))?;
+            .get_committee_lookback_for_round(block.round())?
+            .ok_or(anyhow!("Failed to fetch committee lookback for round {}", block.round()))?;
 
         // Retrieve the previous committee lookback.
         let previous_committee_lookback = {
             // Calculate the penultimate round, which is the round before the anchor round.
             let penultimate_round = block.round().saturating_sub(1);
             // Output the committee lookback for the penultimate round.
-            self.get_committee_lookback_for_round(penultimate_round).map_err(CheckBlockError::other)?.ok_or(
-                CheckBlockError::Other(anyhow!("Failed to fetch committee lookback for round {penultimate_round}")),
-            )?
+            self.get_committee_lookback_for_round(penultimate_round)?
+                .ok_or(anyhow!("Failed to fetch committee lookback for round {penultimate_round}"))?
         };
 
         // Ensure the block is correct.
@@ -258,7 +248,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 &previous_committee_lookback,
                 &committee_lookback,
                 self.puzzle(),
-                self.latest_epoch_hash().map_err(CheckBlockError::other)?,
+                self.latest_epoch_hash()?,
                 OffsetDateTime::now_utc().unix_timestamp(),
                 ratified_finalize_operations,
             )
@@ -281,14 +271,14 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Ensure that each existing solution ID from the block exists in the ledger.
         for existing_solution_id in expected_existing_solution_ids {
-            if !self.contains_solution_id(&existing_solution_id).map_err(CheckBlockError::other)? {
+            if !self.contains_solution_id(&existing_solution_id)? {
                 return Err(CheckBlockError::PreviousSolutionNotFound { solution_id: existing_solution_id });
             }
         }
 
         // Ensure that each existing transaction ID from the block exists in the ledger.
         for existing_transaction_id in expected_existing_transaction_ids {
-            if !self.contains_transaction_id(&existing_transaction_id).map_err(CheckBlockError::other)? {
+            if !self.contains_transaction_id(&existing_transaction_id)? {
                 return Err(CheckBlockError::PreviousTransactionNotFound { transaction_id: existing_transaction_id });
             }
         }

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -34,6 +34,37 @@ impl<N: Network> Deref for PendingBlock<N> {
     }
 }
 
+/// Error returned by [`Self::check_block_subdag`] and [`Self::check_block_subdag_inner`].
+///
+/// This allows parsing for begning errors, such as the block already existing in the ledger.
+#[derive(thiserror::Error, Debug)]
+pub enum CheckBlockError<N: Network> {
+    #[error("Block with hash {hash} already exists in the ledger")]
+    BlockAlreadyExists { hash: N::BlockHash },
+    #[error("Block has invalid height. Expected {expected}, but got {actual}.")]
+    InvalidHeight { expected: u32, actual: u32 },
+    #[error("Block has invalid hash")]
+    InvalidHash,
+    /// An error related to the given prefix of pending blocks.
+    #[error("Prefix of the block at height {height} is incorrect. {error}.")]
+    InvalidPrefix { height: u32, error: Box<CheckBlockError<N>> },
+    #[error("{0:?}")]
+    Other(anyhow::Error),
+}
+
+impl<N: Network> CheckBlockError<N> {
+    pub fn other(err: anyhow::Error) -> Self {
+        Self::Other(err)
+    }
+
+    pub fn into_anyhow(self) -> anyhow::Error {
+        match self {
+            Self::Other(err) => err,
+            _ => anyhow::anyhow!("{self:?}"),
+        }
+    }
+}
+
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Checks that the subDAG in a given block is valid, but does not fully verify the block.
     ///
@@ -49,46 +80,60 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// * This will reject any blocks with a height <= the current height and any blocks with a height >= the current height + GC.
     ///   For the former, a valid block already exists and,
     ///   for the latter, the comittte is still unknown.
-    pub fn check_block_subdag(&self, block: Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+    pub fn check_block_subdag(
+        &self,
+        block: Block<N>,
+        pending_blocks: &[PendingBlock<N>],
+    ) -> Result<PendingBlock<N>, CheckBlockError<N>> {
         self.check_block_subdag_inner(&block, pending_blocks)?;
         Ok(PendingBlock(block))
     }
 
-    fn check_block_subdag_inner(&self, block: &Block<N>, pending_blocks: &[PendingBlock<N>]) -> Result<()> {
+    fn check_block_subdag_inner(
+        &self,
+        block: &Block<N>,
+        pending_blocks: &[PendingBlock<N>],
+    ) -> Result<(), CheckBlockError<N>> {
         // First check that the heights and hashes of the pending block sequence and of the new block are correct.
         // The hash checks should be redundant, but we perform them out of extra caution.
         let mut expected_height = self.latest_height() + 1;
         for pending in pending_blocks {
             if pending.height() != expected_height {
-                bail!(
-                    "Pending block has invalid height. Expected {expected_height}, but got {actual}.",
-                    actual = pending.height()
-                );
+                return Err(CheckBlockError::InvalidPrefix {
+                    height: pending.height(),
+                    error: Box::new(CheckBlockError::InvalidHeight {
+                        expected: expected_height,
+                        actual: pending.height(),
+                    }),
+                });
             }
 
-            if self.contains_block_hash(&pending.hash())? {
-                bail!("Hash for pending block '{}' already exists in the ledger", block.hash())
+            if self.contains_block_hash(&pending.hash()).map_err(CheckBlockError::other)? {
+                return Err(CheckBlockError::InvalidPrefix {
+                    height: pending.height(),
+                    error: Box::new(CheckBlockError::BlockAlreadyExists { hash: pending.hash() }),
+                });
             }
 
             expected_height += 1;
         }
 
-        if self.contains_block_hash(&block.hash())? {
-            bail!("Block hash '{}' already exists in the ledger", block.hash())
+        if self.contains_block_hash(&block.hash()).map_err(CheckBlockError::other)? {
+            return Err(CheckBlockError::BlockAlreadyExists { hash: block.hash() });
         }
 
         if block.height() != expected_height {
-            bail!("Block has invalid height. Expected {expected_height}, but got {}.", block.height());
+            return Err(CheckBlockError::InvalidHeight { expected: expected_height, actual: block.height() });
         }
 
         // Ensure the certificates in the block subdag have met quorum requirements.
-        self.check_block_subdag_quorum(block)?;
+        self.check_block_subdag_quorum(block).map_err(CheckBlockError::other)?;
 
         // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
-        self.check_block_subdag_atomicity(block)?;
+        self.check_block_subdag_atomicity(block).map_err(CheckBlockError::other)?;
 
         // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
-        self.check_block_subdag_leaves(block, pending_blocks)?;
+        self.check_block_subdag_leaves(block, pending_blocks).map_err(CheckBlockError::other)?;
 
         Ok(())
     }
@@ -98,7 +143,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// # Panics
     /// This function panics if called from an async context.
     pub fn check_next_block<R: CryptoRng + Rng>(&self, block: &Block<N>, rng: &mut R) -> Result<()> {
-        self.check_block_subdag_inner(block, &[])?;
+        self.check_block_subdag_inner(block, &[]).map_err(|err| err.into_anyhow())?;
         self.check_block_content_inner(block, rng)?;
 
         Ok(())

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -52,8 +52,8 @@ pub enum CheckBlockError<N: Network> {
     #[error("Block has invalid hash")]
     InvalidHash,
     /// An error related to the given prefix of pending blocks.
-    #[error("Prefix of the block at height {height} is incorrect - {error:?}")]
-    InvalidPrefix { height: u32, error: Box<CheckBlockError<N>> },
+    #[error("The prefix as an error at index {index} - {error:?}")]
+    InvalidPrefix { index: usize, error: Box<CheckBlockError<N>> },
     #[error("The block contains solution '{solution_id}', but it already exists in the ledger")]
     SolutionAlreadyExists { solution_id: SolutionID<N> },
     #[error("Failed to speculate over unconfirmed transactions - {inner}")]
@@ -115,10 +115,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // First check that the heights and hashes of the pending block sequence and of the new block are correct.
         // The hash checks should be redundant, but we perform them out of extra caution.
         let mut expected_height = latest_block.height() + 1;
-        for prefix_block in prefix {
+        for (index, prefix_block) in prefix.iter().enumerate() {
             if prefix_block.height() != expected_height {
                 return Err(CheckBlockError::InvalidPrefix {
-                    height: prefix_block.height(),
+                    index,
                     error: Box::new(CheckBlockError::InvalidHeight {
                         expected: expected_height,
                         actual: prefix_block.height(),
@@ -128,7 +128,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
             if self.contains_block_hash(&prefix_block.hash())? {
                 return Err(CheckBlockError::InvalidPrefix {
-                    height: prefix_block.height(),
+                    index,
                     error: Box::new(CheckBlockError::BlockAlreadyExists { hash: prefix_block.hash() }),
                 });
             }

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -34,6 +34,12 @@ impl<N: Network> Deref for PendingBlock<N> {
     }
 }
 
+impl<N: Network> Debug for PendingBlock<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "PendingBlock {{ height: {}, hash: {} }}", self.height(), self.hash())
+    }
+}
+
 /// Error returned by [`Self::check_block_subdag`] and [`Self::check_block_subdag_inner`].
 ///
 /// This allows parsing for begning errors, such as the block already existing in the ledger.
@@ -198,7 +204,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let latest_block = self.current_block.read();
 
         // Ensure, again, that the ledger has not advanced yet. This prevents cryptic errors form appearing during the block check.
-        if block.height() + 1 != latest_block.height() {
+        if block.height() != latest_block.height() + 1 {
             return Err(CheckBlockError::InvalidHeight { expected: latest_block.height() + 1, actual: block.height() });
         }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -38,7 +38,7 @@ pub use helpers::*;
 pub use crate::block::*;
 
 mod check_next_block;
-pub use check_next_block::PendingBlock;
+pub use check_next_block::{CheckBlockError, PendingBlock};
 
 mod advance;
 mod check_transaction_basic;

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -121,6 +121,7 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
     genesis_block: Block<N>,
     /// The current epoch hash.
     current_epoch_hash: Arc<RwLock<Option<N::BlockHash>>>,
+
     /// The committee resulting from all the on-chain staking activity.
     ///
     /// This includes any bonding and unbonding transactions in the latest block.
@@ -137,8 +138,13 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
     /// but there are cases in which it is `None`,
     /// probably only temporarily when loading/initializing the ledger,
     current_committee: Arc<RwLock<Option<Committee<N>>>>,
-    /// The latest block.
+
+    /// The latest block that was added to the ledger.
+    ///
+    /// This lock is also used as a way to prevent concurrent updates to the ledger, and to ensure that
+    /// the ledger does not advance while certain check happen.
     current_block: Arc<RwLock<Block<N>>>,
+
     /// The recent committees of interest paired with their applicable rounds.
     ///
     /// Each entry consisting of a round `R` and a committee `C`,
@@ -147,6 +153,7 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
     /// If `L` is the lookback round distance, `C` is the active committee at round `R + L`
     /// (i.e. the committee in charge of running consensus at round `R + L`).
     committee_cache: Arc<Mutex<LruCache<u64, Committee<N>>>>,
+
     /// The cache that holds the provers and the number of solutions they have submitted for the current epoch.
     epoch_provers_cache: Arc<RwLock<IndexMap<Address<N>, u32>>>,
 }

--- a/ledger/tests/pending_blocks.rs
+++ b/ledger/tests/pending_blocks.rs
@@ -121,13 +121,13 @@ fn test_prefix_with_duplicate_block_error() {
 
     // Test a prefix that contains block2 twice.
     let result = ledger.check_block_subdag(block4.clone(), &[block2.clone(), block2.clone(), block3.clone()]);
-    assert!(matches!(result, Err(CheckBlockError::InvalidPrefix { height: 2, .. })));
+    assert!(matches!(result, Err(CheckBlockError::InvalidPrefix { index: 1, .. })));
     let CheckBlockError::InvalidPrefix { error, .. } = result.unwrap_err() else { unreachable!() };
     assert!(matches!(*error, CheckBlockError::InvalidHeight { expected: 3, actual: 2 }));
 
     // Test a prefix that misses block 2.
     let result = ledger.check_block_subdag(block4.clone(), &[block3]);
-    assert!(matches!(result, Err(CheckBlockError::InvalidPrefix { height: 3, .. })));
+    assert!(matches!(result, Err(CheckBlockError::InvalidPrefix { index: 0, .. })));
     let CheckBlockError::InvalidPrefix { error, .. } = result.unwrap_err() else { unreachable!() };
     assert!(matches!(*error, CheckBlockError::InvalidHeight { expected: 2, actual: 3 }));
 }

--- a/ledger/tests/pending_blocks.rs
+++ b/ledger/tests/pending_blocks.rs
@@ -16,7 +16,7 @@
 mod helpers;
 use helpers::{BlockOptions, CurrentNetwork, LedgerType, TestChainBuilder};
 
-use snarkvm_ledger::Ledger;
+use snarkvm_ledger::{CheckBlockError, Ledger};
 
 use aleo_std::StorageMode;
 use snarkvm_utilities::TestRng;
@@ -60,4 +60,104 @@ fn test_preprocess_block() {
     // Now the commit block should be accepted
     assert!(ledger.check_next_block(&vote_block, rng).is_ok());
     assert!(ledger.advance_to_next_block(&vote_block).is_ok());
+}
+
+#[test]
+fn test_check_block_error_display() {
+    // Test that CheckBlockError implements Display correctly
+    let error = CheckBlockError::<CurrentNetwork>::InvalidHash;
+    let display_string = format!("{error}");
+    assert_eq!(display_string, "Block has invalid hash");
+
+    let error = CheckBlockError::<CurrentNetwork>::InvalidHeight { expected: 5, actual: 3 };
+    let display_string = format!("{error}");
+    assert!(display_string.contains("Expected 5"));
+    assert!(display_string.contains("got 3"));
+}
+
+#[test]
+fn test_prefix_with_duplicate_block_error() {
+    let rng = &mut TestRng::default();
+    let mut builder = TestChainBuilder::new(4, rng);
+
+    // Construct the ledger.
+    let ledger = Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(
+        builder.genesis_block().clone(),
+        StorageMode::new_test(None),
+    )
+    .unwrap();
+
+    // Generate a block
+    let block1 = builder.generate_block(rng);
+
+    // Add block1 to ledger
+    ledger.advance_to_next_block(&block1).unwrap();
+
+    // Generate another block
+    let block2 = builder.generate_block(rng);
+
+    // So instead, test that we can't check a block with empty prefix when it's not the next block
+
+    // Generate one more block to skip block2
+    let block3 = builder.generate_block(rng);
+
+    // Try to check block3 without having block2 in prefix
+    // This will fail with InvalidHeight
+    let result = ledger.check_block_subdag(block3.clone(), &[]);
+    assert!(matches!(result, Err(CheckBlockError::InvalidHeight { expected: 2, actual: 3 })));
+
+    // Check that the check succeeds when block2 is in the prefix
+    let block2 = ledger.check_block_subdag(block2, &[]).unwrap();
+
+    // The check should still fail without the prefix.
+    let result = ledger.check_block_subdag(block3.clone(), &[]);
+    assert!(matches!(result, Err(CheckBlockError::InvalidHeight { expected: 2, actual: 3 })));
+
+    // But succeed with the prefix.
+    let block3 = ledger.check_block_subdag(block3, &[block2.clone()]).unwrap();
+
+    // Create a forth block
+    let block4 = builder.generate_block(rng);
+
+    // Test a prefix that contains block2 twice.
+    let result = ledger.check_block_subdag(block4.clone(), &[block2.clone(), block2.clone(), block3.clone()]);
+    assert!(matches!(result, Err(CheckBlockError::InvalidPrefix { height: 2, .. })));
+    let CheckBlockError::InvalidPrefix { error, .. } = result.unwrap_err() else { unreachable!() };
+    assert!(matches!(*error, CheckBlockError::InvalidHeight { expected: 3, actual: 2 }));
+
+    // Test a prefix that misses block 2.
+    let result = ledger.check_block_subdag(block4.clone(), &[block3]);
+    assert!(matches!(result, Err(CheckBlockError::InvalidPrefix { height: 3, .. })));
+    let CheckBlockError::InvalidPrefix { error, .. } = result.unwrap_err() else { unreachable!() };
+    assert!(matches!(*error, CheckBlockError::InvalidHeight { expected: 2, actual: 3 }));
+}
+
+#[test]
+fn test_check_block_content_invalid_height() {
+    let rng = &mut TestRng::default();
+    let mut builder = TestChainBuilder::new(4, rng);
+
+    // Construct the ledger.
+    let ledger = Ledger::<CurrentNetwork, LedgerType<CurrentNetwork>>::load(
+        builder.genesis_block().clone(),
+        StorageMode::new_test(None),
+    )
+    .unwrap();
+
+    // Generate two blocks
+    let blocks = builder.generate_blocks_with_opts(2, &BlockOptions { skip_votes: true, ..Default::default() }, rng);
+    let block1 = blocks[0].clone();
+
+    // Check block1 and get pending block
+    let pending1 = ledger.check_block_subdag(block1.clone(), &[]).unwrap();
+
+    // Advance ledger with block1
+    let verified1 = ledger.check_block_content(pending1.clone(), rng).unwrap();
+    ledger.advance_to_next_block(&verified1).unwrap();
+
+    // Now try to check_block_content on pending1 again
+    // This should fail because the ledger has already advanced
+    let result = ledger.check_block_content(pending1, rng);
+
+    assert!(matches!(result, Err(CheckBlockError::InvalidHeight { expected: 2, actual: 1 })));
 }


### PR DESCRIPTION
## Addition of `CheckBlockError`
This PR enables detecting race conditions when verifying a block. In particular, it returns a machine-readable `CheckBlockError` that contains an error type for the case when a block already exists in the ledger.
On the snarkOS side (see https://github.com/ProvableHQ/snarkOS/pull/4039), block sync will remove the affected pending blocks and retry when it encounters this error. This allows us to cut down on errors like `Unable to advance to the next block - Failed to speculate on transactions - Failed to post-ratify - Next round 2532 must be greater than current round 2532`.

One alternative to this approach would be to return `anyhow::Result<Option<PendingBlock>>`. I do not like this approach, as it is not really clear what `Ok(None)` means without reading the function's doc comment.
Another alternative would be to match the error message against a string, but that can easily break in the future and is generally considered bad practice.

Finally, it would be possible to use locks on the snarkOS side instead. I try to avoid locking there whenever possible to reduce the potential for deadlocks and to maintain good performance. The linked snarkOS PR still uses locks, but only when it is actually advancing the ledger.

The change is only made to `Ledger::check_block_subdag`, to ensure the existing `Ledger::check_next_block` still works as before. Maybe at some point we could consider cleaning up some of the block checking and advancement API, but now is not that time. 

### Atomic block checks
Additionally, the PR changes`Ledger::check_next_block` and `Ledger::check_block_subdag` so that it is guaranteed no concurrent block advancement happens.

The following is a new error message that appeared after the above changes, and is addressed by this:
```
ERROR snarkos_node_bft::sync: Block synchronization failed — Failed to check contents of pending block ab1y3l48teq38zm9kftznt60vpgl4ydq09f6qsx6mr269rw5qef7uqsjzd7l5 at height 342 — Failed to speculate over unconfirmed transactions — Invalid transaction found in the transactions list: Transaction 'at1zuc4zprjff66q8ftc8jtt6e9xa7ltym5ttg348jz37j6fnel3yyseqrhsc' already exists in the ledger
```

`check_next_block` and `check_block_subdag` now acquire a read-lock on `current_block`, which prevents the ledger advancing while the check is performed. In other words, they are no *atomic* operations.
On the snarkOS side, we still need to account for concurrent updates between the block check and the block advancement, but this atomicity guarantee makes it a lot easier and avoids messy errors, such as the one above.