### PR TITLE
fix: public index check in R1CS converter

### DIFF
--- a/circuit/environment/src/helpers/converter.rs
+++ b/circuit/environment/src/helpers/converter.rs
@@ -147,7 +147,7 @@ impl<F: PrimeField> R1CS<F> {
                                 let (index, _value) = index_value.as_ref();
                                 let gadget = converter.public.get(index).unwrap();
                                 assert_eq!(
-                                    snarkvm_algorithms::r1cs::Index::Public((index + 1) as usize),
+                                    snarkvm_algorithms::r1cs::Index::Public(*index as usize),
                                     gadget.get_unchecked(),
                                     "Failed during constraint translation. The public variable in the second system must match the first system (with an off-by-1 for the public case)"
                                 );


### PR DESCRIPTION
The mapping between the environment R1CS and snarkvm_algorithms::r1cs already treats public indices consistently: index 0 is the constant one, and real public inputs use the same indices 1..n in both systems. In R1CS::generate_constraints we were asserting Index::Public(index + 1) when translating linear combinations, while the converter map and the Assignment-based converter both use Index::Public(index) directly. This off-by-one check was incorrect and could cause spurious assertion failures when public variables appear in constraint terms. The change removes the +1 so that the assertion matches the actual mapping and stays consistent with the Assignment converter.