### PR TITLE
[Draft] Upgrade to rust 1.92

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ commands:
 
             export PATH="$HOME/.cargo/bin:$PATH"
             if ! command -v cargo-nextest >/dev/null 2>&1; then
-              cargo install cargo-nextest --locked --version "0.9.114"
+              cargo install cargo-nextest --locked --version "0.9.133"
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
   # The default docker image used in the main-workflow
   rust-docker:
     docker:
-      - image: cimg/rust:1.88.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+      - image: cimg/rust:1.92.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
     environment:
       RUSTFLAGS: "" # override the config.toml flags
 
@@ -51,17 +51,17 @@ commands:
                 Write-Host "rustup not found, installing..."
                 $rustupPath = "$env:TEMP\rustup-init.exe"
                 Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile $rustupPath
-                & $rustupPath -y --default-toolchain "1.88.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal
+                & $rustupPath -y --default-toolchain "1.92.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal
             } else {
-                Write-Host "rustup already installed, ensuring toolchain 1.88.0-x86_64-pc-windows-msvc is present..."
-                rustup toolchain install 1.88.0-x86_64-pc-windows-msvc
+                Write-Host "rustup already installed, ensuring toolchain 1.92.0-x86_64-pc-windows-msvc is present..."
+                rustup toolchain install 1.92.0-x86_64-pc-windows-msvc
             }
 
             # Put cargo/rustup first in PATH for this step and subsequent steps
             $Env:Path = "$Env:USERPROFILE\.cargo\bin;$Env:Path"
 
             # Select the toolchain
-            rustup default 1.88.0-x86_64-pc-windows-msvc
+            rustup default 1.92.0-x86_64-pc-windows-msvc
 
             # Verify the installation.
             cargo --version --verbose
@@ -90,7 +90,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v4.7.1-rust-1.88.0-snarkvm-cache
+        default: v4.7.1-rust-1.92.0-snarkvm-cache
     steps:
       - run:
           name: Prepare environment variables and install dependencies
@@ -134,8 +134,8 @@ commands:
               clang llvm-dev llvm lld pkg-config xz-utils make libssl-dev libssl-dev
       - restore_cache:
           keys:
-            - v4.7.1-rust-1.88.0-deps-{{ checksum "Cargo.lock" }}-
-            - v4.7.1-rust-1.88.0-deps-
+            - v4.7.1-rust-1.92.0-deps-{{ checksum "Cargo.lock" }}-
+            - v4.7.1-rust-1.92.0-deps-
       - restore_cache:
           keys:
             - << parameters.cache_key >>
@@ -145,11 +145,11 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v4.7.1-rust-1.88.0-snarkvm-cache
+        default: v4.7.1-rust-1.92.0-snarkvm-cache
     steps:
       - run: set +e
       - save_cache:
-          key: v4.7.1-rust-1.88.0-deps-{{ checksum "Cargo.lock" }}
+          key: v4.7.1-rust-1.92.0-deps-{{ checksum "Cargo.lock" }}
           paths:
             - /home/circleci/.cache/sccache
             - /home/circleci/.cargo/registry
@@ -188,7 +188,7 @@ commands:
           condition: << parameters.use_cache >>
           steps:
             - setup_environment:
-                cache_key: v4.7.1-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+                cache_key: v4.7.1-rust-1.92.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
 
       - run:
           name: Install debian packages (always)
@@ -436,7 +436,7 @@ commands:
           condition: << parameters.use_cache >>
           steps:
             - clear_environment:
-                cache_key: v4.7.1-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+                cache_key: v4.7.1-rust-1.92.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
 
   install_rust_nightly:
     description: "Install Rust nightly toolchain"
@@ -1054,7 +1054,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-wasm-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-wasm-cache
       - run:
           no_output_timeout: 30m
           command: |
@@ -1075,7 +1075,7 @@ jobs:
             # Run the tests
             cd wasm && wasm-pack test --node
       - clear_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-wasm-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-wasm-cache
 
   check-fmt:
     executor: rust-docker
@@ -1084,13 +1084,13 @@ jobs:
       - checkout
       - install_rust_nightly
       - setup_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-fmt-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-fmt-cache
       - run:
           name: Check style
           no_output_timeout: 35m
           command: cargo +nightly fmt --all -- --check
       - clear_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-fmt-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-fmt-cache
 
   check-unused-dependencies:
     executor: rust-docker
@@ -1098,7 +1098,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.1-rust-1.88.0-machete-cache
+          cache_key: v4.7.1-rust-1.92.0-machete-cache
       - run:
           name: Check for unused dependencies
           no_output_timeout: 10m
@@ -1109,7 +1109,7 @@ jobs:
             fi
             cargo machete
       - clear_environment:
-          cache_key: v4.7.1-rust-1.88.0-machete-cache
+          cache_key: v4.7.1-rust-1.92.0-machete-cache
 
   check-cargo-audit:
     executor: rust-docker
@@ -1117,7 +1117,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.1-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.7.1-rust-1.92.0-cargo-audit-cache
       - run:
           name:  Check for security vulnerabilities
           no_output_timeout: 10m
@@ -1125,7 +1125,7 @@ jobs:
             cargo install cargo-audit@0.22.0 --locked --force
             cargo audit -D warnings
       - clear_environment:
-          cache_key: v4.7.1-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.7.1-rust-1.92.0-cargo-audit-cache
 
   check-cargo-semver-checks:
     executor: rust-docker
@@ -1134,14 +1134,14 @@ jobs:
       - checkout:
           method: full
       - setup_environment:
-          cache_key: v4.7.1-rust-1.88.0-cargo-semver-checks-cache
+          cache_key: v4.7.1-rust-1.92.0-cargo-semver-checks-cache
       - run:
           name: Check for semver violations
           no_output_timeout: 15m
           command: |
             bash ./.circleci/semver-checks.sh
       - clear_environment:
-          cache_key: v4.7.1-rust-1.88.0-cargo-semver-checks-cache
+          cache_key: v4.7.1-rust-1.92.0-cargo-semver-checks-cache
 
   check-clippy:
     executor: rust-docker
@@ -1149,7 +1149,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-clippy-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-clippy-cache
       - run:
           name: Check Clippy (default features)
           timeout: 20m
@@ -1161,7 +1161,7 @@ jobs:
           command: |
             cargo clippy --workspace --all-targets --all-features -- -D warnings
       - clear_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-clippy-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-clippy-cache
 
   check-all-targets:
     executor: rust-docker
@@ -1169,13 +1169,13 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-all-targets-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-all-targets-cache
       - run:
           name: Check all targets
           no_output_timeout: 35m
           command: cargo check --release --workspace --all-targets
       - clear_environment:
-          cache_key: v4.7.1-rust-1.88.0-snarkvm-all-targets-cache
+          cache_key: v4.7.1-rust-1.92.0-snarkvm-all-targets-cache
 
   verify-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
   # The default docker image used in the main-workflow
   rust-docker:
     docker:
-      - image: cimg/rust:1.88.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+      - image: cimg/rust:1.92.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
 
 commands:
   check_windows:
@@ -50,17 +50,17 @@ commands:
                 Write-Host "rustup not found, installing..."
                 $rustupPath = "$env:TEMP\rustup-init.exe"
                 Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile $rustupPath
-                & $rustupPath -y --default-toolchain "1.88.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal
+                & $rustupPath -y --default-toolchain "1.92.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal
             } else {
-                Write-Host "rustup already installed, ensuring toolchain 1.88.0-x86_64-pc-windows-msvc is present..."
-                rustup toolchain install 1.88.0-x86_64-pc-windows-msvc
+                Write-Host "rustup already installed, ensuring toolchain 1.92.0-x86_64-pc-windows-msvc is present..."
+                rustup toolchain install 1.92.0-x86_64-pc-windows-msvc
             }
 
             # Put cargo/rustup first in PATH for this step and subsequent steps
             $Env:Path = "$Env:USERPROFILE\.cargo\bin;$Env:Path"
 
             # Select the toolchain
-            rustup default 1.88.0-x86_64-pc-windows-msvc
+            rustup default 1.92.0-x86_64-pc-windows-msvc
 
             # Verify the installation.
             cargo --version --verbose
@@ -90,7 +90,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v4.2.0-rust-1.88.0-snarkvm-cache
+        default: v4.2.0-rust-1.92.0-snarkvm-cache
 
     steps:
       - run:
@@ -143,8 +143,8 @@ commands:
 
       - restore_cache:
           keys:
-            - v4.2.0-rust-1.88.0-deps-{{ checksum "Cargo.lock" }}-
-            - v4.2.0-rust-1.88.0-deps-
+            - v4.2.0-rust-1.92.0-deps-{{ checksum "Cargo.lock" }}-
+            - v4.2.0-rust-1.92.0-deps-
 
       - restore_cache:
           keys:
@@ -155,11 +155,11 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v4.2.0-rust-1.88.0-snarkvm-cache
+        default: v4.2.0-rust-1.92.0-snarkvm-cache
     steps:
       - run: set +e
       - save_cache:
-          key: v4.2.0-rust-1.88.0-deps-{{ checksum "Cargo.lock" }}-{{ epoch }}
+          key: v4.2.0-rust-1.92.0-deps-{{ checksum "Cargo.lock" }}-{{ epoch }}
           paths:
             - /home/circleci/.cache/sccache
             - /home/circleci/.cargo/registry
@@ -193,7 +193,7 @@ commands:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+          cache_key: v4.2.0-rust-1.92.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
 
 
       - run:
@@ -397,7 +397,7 @@ commands:
           path: target/nextest/ci
 
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+          cache_key: v4.2.0-rust-1.92.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
 
 
   install_rust_nightly:
@@ -1018,7 +1018,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-wasm-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-wasm-cache
       - run:
           no_output_timeout: 30m
           command: |
@@ -1035,7 +1035,7 @@ jobs:
             # Run the tests
             cd wasm && wasm-pack test --node
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-wasm-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-wasm-cache
 
   check-fmt:
     executor: rust-docker
@@ -1044,13 +1044,13 @@ jobs:
       - checkout
       - install_rust_nightly
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-fmt-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-fmt-cache
       - run:
           name: Check style
           no_output_timeout: 35m
           command: cargo +nightly fmt --all -- --check
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-fmt-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-fmt-cache
 
   check-unused-dependencies:
     executor: rust-docker
@@ -1058,7 +1058,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-machete-cache
+          cache_key: v4.2.0-rust-1.92.0-machete-cache
       - run:
           name: Check for unused dependencies
           no_output_timeout: 10m
@@ -1069,7 +1069,7 @@ jobs:
             fi
             cargo machete
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-machete-cache
+          cache_key: v4.2.0-rust-1.92.0-machete-cache
 
   check-cargo-audit:
     executor: rust-docker
@@ -1077,7 +1077,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.2.0-rust-1.92.0-cargo-audit-cache
       - run:
           name:  Check for security vulnerabilities
           no_output_timeout: 10m
@@ -1085,7 +1085,7 @@ jobs:
             cargo install cargo-audit@0.21.2 --locked
             cargo audit -D warnings
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.2.0-rust-1.92.0-cargo-audit-cache
 
   check-cargo-semver-checks:
     executor: rust-docker
@@ -1094,7 +1094,7 @@ jobs:
       - checkout:
           method: full
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-cargo-semver-checks-cache
+          cache_key: v4.2.0-rust-1.92.0-cargo-semver-checks-cache
       - run:
           name: Check for semver violations
           no_output_timeout: 15m
@@ -1102,7 +1102,7 @@ jobs:
             bash ./.circleci/semver-checks.sh
 
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-cargo-semver-checks-cache
+          cache_key: v4.2.0-rust-1.92.0-cargo-semver-checks-cache
 
   check-clippy:
     executor: rust-docker
@@ -1110,7 +1110,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-clippy-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-clippy-cache
       - run:
           name: Check Clippy (default features)
           timeout: 20m
@@ -1122,7 +1122,7 @@ jobs:
           command: |
             cargo clippy --workspace --all-targets --all-features -- -D warnings
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-clippy-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-clippy-cache
 
   check-all-targets:
     executor: rust-docker
@@ -1130,13 +1130,13 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-all-targets-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-all-targets-cache
       - run:
           name: Check all targets
           no_output_timeout: 35m
           command: cargo check --release --workspace --all-targets
       - clear_environment:
-          cache_key: v4.2.0-rust-1.88.0-snarkvm-all-targets-cache
+          cache_key: v4.2.0-rust-1.92.0-snarkvm-all-targets-cache
 
   verify-windows:
     executor:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 include = [ "Cargo.toml", "vm", "README.md", "LICENSE.md" ]
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.88.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
+rust-version = "1.92.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
 
 [workspace]
 members = [

--- a/algorithms/src/lib.rs
+++ b/algorithms/src/lib.rs
@@ -15,6 +15,9 @@
 
 #![warn(unsafe_code)]
 #![allow(clippy::module_inception)]
+#![allow(clippy::manual_is_multiple_of)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::unused_enumerate_index)]
 #![allow(clippy::type_complexity)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -43,8 +43,8 @@ impl Ord for BucketPosition {
     }
 }
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for BucketPosition {
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         self.bucket_index.partial_cmp(&other.bucket_index)
     }

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -440,12 +440,12 @@ impl<E: PairingEngine> KZG10<E> {
             if enforced_degree_bounds.binary_search(&bound).is_err() {
                 Err(PCError::UnsupportedDegreeBound(bound))
             } else if bound < p.degree() || bound > max_degree {
-                return Err(PCError::IncorrectDegreeBound {
+                Err(PCError::IncorrectDegreeBound {
                     poly_degree: p.degree(),
                     degree_bound: p.degree_bound().unwrap(),
                     max_degree,
                     label: p.label().to_string(),
-                });
+                })
             } else {
                 Ok(())
             }

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -136,10 +136,10 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             .max_by_key(|d| d.size())
             .ok_or(anyhow!("could not find max domain"))?;
         let mut max_non_zero_domain = Some(new_candidate);
-        if let Some(max_candidate) = max_candidate {
-            if max_candidate.size() > new_candidate.size() {
-                max_non_zero_domain = Some(max_candidate);
-            }
+        if let Some(max_candidate) = max_candidate
+            && max_candidate.size() > new_candidate.size()
+        {
+            max_non_zero_domain = Some(max_candidate);
         }
         Ok(NonZeroDomains { max_non_zero_domain, domain_a, domain_b, domain_c })
     }

--- a/circuit/account/src/lib.rs
+++ b/circuit/account/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 
 extern crate snarkvm_console_account as console;

--- a/circuit/algorithms/src/keccak/hash.rs
+++ b/circuit/algorithms/src/keccak/hash.rs
@@ -27,7 +27,7 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> Hash for Keccak<E, TY
         // and the bit rate is the width (1600 in our case) minus the capacity.
         let bitrate = PERMUTATION_WIDTH - 2 * VARIANT;
         debug_assert!(bitrate < PERMUTATION_WIDTH, "The bitrate must be less than the permutation width");
-        debug_assert!(bitrate % 8 == 0, "The bitrate must be a multiple of 8");
+        debug_assert!(bitrate.is_multiple_of(8), "The bitrate must be a multiple of 8");
 
         // Ensure the input is not empty.
         if input.is_empty() {

--- a/circuit/environment/src/lib.rs
+++ b/circuit/environment/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::type_complexity)]
 
 extern crate snarkvm_console_network as console;

--- a/circuit/program/src/data/literal/cast/boolean.rs
+++ b/circuit/program/src/data/literal/cast/boolean.rs
@@ -93,7 +93,7 @@ mod tests {
         mode: Mode,
         _: &mut TestRng,
     ) -> (console_root::types::Boolean<MainnetV0>, Boolean<Circuit>) {
-        (console_root::types::Boolean::new(i % 2 == 0), Boolean::new(mode, i % 2 == 0))
+        (console_root::types::Boolean::new(i.is_multiple_of(2)), Boolean::new(mode, i.is_multiple_of(2)))
     }
 
     impl_check_cast!(cast, Boolean<Circuit>, console_root::types::Boolean::<MainnetV0>);

--- a/circuit/program/src/data/literal/cast/boolean.rs
+++ b/circuit/program/src/data/literal/cast/boolean.rs
@@ -79,7 +79,7 @@ mod tests {
         mode: Mode,
         _: &mut TestRng,
     ) -> (console_root::types::Boolean<MainnetV0>, Boolean<Circuit>) {
-        (console_root::types::Boolean::new(i % 2 == 0), Boolean::new(mode, i % 2 == 0))
+        (console_root::types::Boolean::new(i.is_multiple_of(2)), Boolean::new(mode, i.is_multiple_of(2)))
     }
 
     impl_check_cast!(cast, Boolean<Circuit>, console_root::types::Boolean::<MainnetV0>);

--- a/circuit/program/src/data/literal/cast_lossy/boolean.rs
+++ b/circuit/program/src/data/literal/cast_lossy/boolean.rs
@@ -90,7 +90,7 @@ mod tests {
         mode: Mode,
         _: &mut TestRng,
     ) -> (console_root::types::Boolean<MainnetV0>, Boolean<Circuit>) {
-        (console_root::types::Boolean::new(i % 2 == 0), Boolean::new(mode, i % 2 == 0))
+        (console_root::types::Boolean::new(i.is_multiple_of(2)), Boolean::new(mode, i.is_multiple_of(2)))
     }
 
     check_cast_lossy!(cast_lossy, Boolean<Circuit>, console_root::types::Boolean::<MainnetV0>);

--- a/circuit/program/src/lib.rs
+++ b/circuit/program/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 

--- a/circuit/types/address/src/lib.rs
+++ b/circuit/types/address/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 
 extern crate snarkvm_console_types_address as console;

--- a/circuit/types/boolean/src/lib.rs
+++ b/circuit/types/boolean/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![forbid(unsafe_code)]
 #![allow(clippy::too_many_arguments)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 
 extern crate snarkvm_console_types_boolean as console;

--- a/circuit/types/field/src/lib.rs
+++ b/circuit/types/field/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 

--- a/circuit/types/group/src/lib.rs
+++ b/circuit/types/group/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 

--- a/circuit/types/integers/src/lib.rs
+++ b/circuit/types/integers/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 

--- a/circuit/types/scalar/src/lib.rs
+++ b/circuit/types/scalar/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 

--- a/circuit/types/string/src/helpers/from_bits.rs
+++ b/circuit/types/string/src/helpers/from_bits.rs
@@ -45,7 +45,7 @@ impl<E: Environment> StringType<E> {
     fn inject_size_in_bytes(mode: Mode, bits: &[Boolean<E>]) -> Field<E> {
         // Ensure the bits are byte-aligned.
         let num_bits = bits.len();
-        if num_bits % 8 != 0 {
+        if !num_bits.is_multiple_of(8) {
             E::halt(format!("Attempted to instantiate a {num_bits}-bit string, which is not byte-aligned"))
         }
 

--- a/circuit/types/string/src/lib.rs
+++ b/circuit/types/string/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 
 extern crate snarkvm_console_types_string as console;

--- a/console/account/src/lib.rs
+++ b/console/account/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 #![warn(clippy::cast_possible_truncation)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]

--- a/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -43,7 +43,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
             let padding = BHP_CHUNK_SIZE - (input.len() % BHP_CHUNK_SIZE);
             let mut padded_input = vec![false; input.len() + padding];
             padded_input[..input.len()].copy_from_slice(input);
-            ensure!((padded_input.len() % BHP_CHUNK_SIZE) == 0, "Input must be a multiple of {BHP_CHUNK_SIZE}");
+            ensure!(padded_input.len().is_multiple_of(BHP_CHUNK_SIZE), "Input must be a multiple of {BHP_CHUNK_SIZE}");
             Cow::Owned(padded_input)
         } else {
             Cow::Borrowed(input)

--- a/console/algorithms/src/blake2xs/mod.rs
+++ b/console/algorithms/src/blake2xs/mod.rs
@@ -44,7 +44,7 @@ impl Blake2Xs {
         for node_offset in 0..num_rounds {
             // Calculate the digest length for this round.
             let is_final_round = node_offset == num_rounds - 1;
-            let has_remainder = xof_digest_length % 32 != 0;
+            let has_remainder = !xof_digest_length.is_multiple_of(32);
             let digest_length = match is_final_round && has_remainder {
                 true => (xof_digest_length % 32) as usize,
                 false => 32,

--- a/console/algorithms/src/lib.rs
+++ b/console/algorithms/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(clippy::manual_is_multiple_of)]
 #![allow(clippy::too_many_arguments)]
 #![warn(clippy::cast_possible_truncation)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]

--- a/console/collections/src/kary_merkle_tree/tests/mod.rs
+++ b/console/collections/src/kary_merkle_tree/tests/mod.rs
@@ -26,7 +26,6 @@ macro_rules! run_tests {
         $( assert!(run_test::<$i, $i>($rng).is_ok()); )*
     };
 }
-use run_tests;
 
 /// Runs the following test:
 /// 1. Construct the Merkle tree for the leaves.

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 
 mod environment;

--- a/console/program/src/data/dynamic/future/parse.rs
+++ b/console/program/src/data/dynamic/future/parse.rs
@@ -217,14 +217,14 @@ impl<N: Network> Display for DynamicFuture<N> {
         let function_name_id = Identifier::<N>::from_field(&self.function_name);
 
         // If all conversions succeed, display human-readable format.
-        if let (Ok(name), Ok(network), Ok(function)) = (program_name_id, program_network_id, function_name_id) {
-            if let Ok(program_id) = ProgramID::try_from((name, network)) {
-                return write!(
-                    f,
-                    "{{ _program_id: {program_id}, _function_name: {function}, _checksum: {} }}",
-                    self.checksum()
-                );
-            }
+        if let (Ok(name), Ok(network), Ok(function)) = (program_name_id, program_network_id, function_name_id)
+            && let Ok(program_id) = ProgramID::try_from((name, network))
+        {
+            return write!(
+                f,
+                "{{ _program_id: {program_id}, _function_name: {function}, _checksum: {} }}",
+                self.checksum()
+            );
         }
 
         // Fall back to raw field format.

--- a/console/program/src/lib.rs
+++ b/console/program/src/lib.rs
@@ -15,6 +15,8 @@
 
 #![forbid(unsafe_code)]
 #![allow(clippy::too_many_arguments)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![warn(clippy::cast_possible_truncation)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 

--- a/console/types/address/src/lib.rs
+++ b/console/types/address/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 mod bitwise;
 mod bytes;

--- a/console/types/boolean/src/lib.rs
+++ b/console/types/boolean/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 mod bitwise;
 mod bytes;

--- a/console/types/field/src/lib.rs
+++ b/console/types/field/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 mod arithmetic;
 mod bitwise;

--- a/console/types/group/src/lib.rs
+++ b/console/types/group/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 mod arithmetic;
 mod bitwise;

--- a/console/types/integers/src/lib.rs
+++ b/console/types/integers/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 mod arithmetic;
 mod bitwise;

--- a/console/types/scalar/src/lib.rs
+++ b/console/types/scalar/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 mod arithmetic;
 mod bitwise;

--- a/console/types/string/src/lib.rs
+++ b/console/types/string/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 mod bitwise;
 mod bytes;

--- a/console/types/string/src/lib.rs
+++ b/console/types/string/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
 #![warn(clippy::cast_possible_truncation)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 pub mod identifier_literal;
 pub use identifier_literal::{IdentifierLiteral, SIZE_IN_BITS, SIZE_IN_BYTES};

--- a/fields/src/fp12_2over3over2.rs
+++ b/fields/src/fp12_2over3over2.rs
@@ -247,12 +247,13 @@ impl<P: Fp12Parameters> Field for Fp12<P> {
     #[inline]
     fn from_random_bytes_with_flags<F: Flags>(bytes: &[u8]) -> Option<(Self, F)> {
         let split_at = bytes.len() / 2;
-        if let Some(c0) = Fp6::<P::Fp6Params>::from_random_bytes(&bytes[..split_at]) {
-            if let Some((c1, flags)) = Fp6::<P::Fp6Params>::from_random_bytes_with_flags::<F>(&bytes[split_at..]) {
-                return Some((Fp12::new(c0, c1), flags));
-            }
+        if let Some(c0) = Fp6::<P::Fp6Params>::from_random_bytes(&bytes[..split_at])
+            && let Some((c1, flags)) = Fp6::<P::Fp6Params>::from_random_bytes_with_flags::<F>(&bytes[split_at..])
+        {
+            Some((Fp12::new(c0, c1), flags))
+        } else {
+            None
         }
-        None
     }
 
     #[inline]

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -133,12 +133,13 @@ impl<P: Fp2Parameters> Field for Fp2<P> {
     #[inline]
     fn from_random_bytes_with_flags<F: Flags>(bytes: &[u8]) -> Option<(Self, F)> {
         let split_at = bytes.len() / 2;
-        if let Some(c0) = P::Fp::from_random_bytes(&bytes[..split_at]) {
-            if let Some((c1, flags)) = P::Fp::from_random_bytes_with_flags::<F>(&bytes[split_at..]) {
-                return Some((Fp2::new(c0, c1), flags));
-            }
+        if let Some(c0) = P::Fp::from_random_bytes(&bytes[..split_at])
+            && let Some((c1, flags)) = P::Fp::from_random_bytes_with_flags::<F>(&bytes[split_at..])
+        {
+            Some((Fp2::new(c0, c1), flags))
+        } else {
+            None
         }
-        None
     }
 
     #[inline]

--- a/fields/src/fp6_3over2.rs
+++ b/fields/src/fp6_3over2.rs
@@ -195,16 +195,14 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     #[inline]
     fn from_random_bytes_with_flags<F: Flags>(bytes: &[u8]) -> Option<(Self, F)> {
         let split_at = bytes.len() / 3;
-        if let Some(c0) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[..split_at]) {
-            if let Some(c1) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[split_at..2 * split_at]) {
-                if let Some((c2, flags)) =
-                    Fp2::<P::Fp2Params>::from_random_bytes_with_flags::<F>(&bytes[2 * split_at..])
-                {
-                    return Some((Fp6::new(c0, c1, c2), flags));
-                }
-            }
+        if let Some(c0) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[..split_at])
+            && let Some(c1) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[split_at..2 * split_at])
+            && let Some((c2, flags)) = Fp2::<P::Fp2Params>::from_random_bytes_with_flags::<F>(&bytes[2 * split_at..])
+        {
+            Some((Fp6::new(c0, c1, c2), flags))
+        } else {
+            None
         }
-        None
     }
 
     #[inline]

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -25,8 +25,6 @@ use crate::{
     PrimeField,
     SquareRootField,
     Zero,
-    impl_add_sub_from_field_ref,
-    impl_mul_div_from_field_ref,
 };
 use snarkvm_utilities::{
     FromBytes,

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -25,8 +25,6 @@ use crate::{
     PrimeField,
     SquareRootField,
     Zero,
-    impl_add_sub_from_field_ref,
-    impl_mul_div_from_field_ref,
 };
 use snarkvm_utilities::{
     FromBytes,

--- a/fields/src/traits/fft_field.rs
+++ b/fields/src/traits/fft_field.rs
@@ -90,7 +90,7 @@ pub trait FftField: Field + From<u128> + From<u64> + From<u32> + From<u16> + Fro
     fn k_adicity(k: usize, mut n: usize) -> u32 {
         let mut r = 0;
         while n > 1 {
-            if n % k == 0 {
+            if n.is_multiple_of(k) {
                 r += 1;
                 n /= k;
             } else {

--- a/ledger/block/src/transaction/merkle.rs
+++ b/ledger/block/src/transaction/merkle.rs
@@ -50,14 +50,14 @@ impl<N: Network> Transaction<N> {
             }
             Self::Execute(_, _, execution, fee) => {
                 // Check if the ID is the transition ID for the fee.
-                if let Some(fee) = fee {
-                    if *id == **fee.id() {
-                        // Return the transaction leaf.
-                        return Ok(TransactionLeaf::new_execution(
-                            u16::try_from(execution.len())?, // The last index.
-                            *id,
-                        ));
-                    }
+                if let Some(fee) = fee
+                    && *id == **fee.id()
+                {
+                    // Return the transaction leaf.
+                    return Ok(TransactionLeaf::new_execution(
+                        u16::try_from(execution.len())?, // The last index.
+                        *id,
+                    ));
                 }
 
                 // Iterate through the transitions in the execution.

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -140,7 +140,7 @@ impl<N: Network> Subdag<N> {
             "Subdag cannot exceed the maximum number of rounds"
         );
         // Ensure the anchor round is even.
-        ensure!(subdag.iter().next_back().map_or(0, |(r, _)| *r) % 2 == 0, "Anchor round must be even");
+        ensure!(subdag.iter().next_back().map_or(0, |(r, _)| *r).is_multiple_of(2), "Anchor round must be even");
         // Ensure there is only one leader certificate.
         ensure!(subdag.iter().next_back().map_or(0, |(_, c)| c.len()) == 1, "Subdag cannot have multiple leaders");
         // Ensure the rounds are sequential.

--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -252,10 +252,10 @@ impl<N: Network> Puzzle<N> {
         // Compute the proof target.
         let proof_target = self.get_proof_target_from_partial_solution(&partial_solution)?;
         // Check that the minimum proof target is met.
-        if let Some(minimum_proof_target) = minimum_proof_target {
-            if proof_target < minimum_proof_target {
-                bail!("Solution was below the minimum proof target ({proof_target} < {minimum_proof_target})")
-            }
+        if let Some(minimum_proof_target) = minimum_proof_target
+            && proof_target < minimum_proof_target
+        {
+            bail!("Solution was below the minimum proof target ({proof_target} < {minimum_proof_target})")
         }
 
         // Construct the solution.

--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -240,10 +240,10 @@ impl<N: Network> Puzzle<N> {
         // Compute the proof target.
         let proof_target = self.get_proof_target_from_partial_solution(&partial_solution)?;
         // Check that the minimum proof target is met.
-        if let Some(minimum_proof_target) = minimum_proof_target {
-            if proof_target < minimum_proof_target {
-                bail!("Solution was below the minimum proof target ({proof_target} < {minimum_proof_target})")
-            }
+        if let Some(minimum_proof_target) = minimum_proof_target
+            && proof_target < minimum_proof_target
+        {
+            bail!("Solution was below the minimum proof target ({proof_target} < {minimum_proof_target})")
         }
 
         // Construct the solution.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -156,7 +156,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // If the block is the start of a new epoch, or the epoch hash has not been set,
         // update the current epoch hash and clear the epoch prover cache.
-        if block.height() % N::NUM_BLOCKS_PER_EPOCH == 0 || self.current_epoch_hash.read().is_none() {
+        if block.height().is_multiple_of(N::NUM_BLOCKS_PER_EPOCH) || self.current_epoch_hash.read().is_none() {
             // Update and log the current epoch hash.
             match self.get_epoch_hash(block.height()).ok() {
                 Some(epoch_hash) => {

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -141,7 +141,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // If the block is the start of a new epoch, or the epoch hash has not been set,
         // update the current epoch hash and clear the epoch prover cache.
-        if block.height() % N::NUM_BLOCKS_PER_EPOCH == 0 || self.current_epoch_hash.read().is_none() {
+        if block.height().is_multiple_of(N::NUM_BLOCKS_PER_EPOCH) || self.current_epoch_hash.read().is_none() {
             // Update and log the current epoch hash.
             match self.get_epoch_hash(block.height()).ok() {
                 Some(epoch_hash) => {

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -54,7 +54,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     pub fn get_committee_lookback_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.
-        let previous_round = match round % 2 == 0 {
+        let previous_round = match round.is_multiple_of(2) {
             true => round.saturating_sub(1),
             false => round.saturating_sub(2),
         };

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -53,7 +53,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     pub fn get_committee_lookback_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.
-        let previous_round = match round % 2 == 0 {
+        let previous_round = match round.is_multiple_of(2) {
             true => round.saturating_sub(1),
             false => round.saturating_sub(2),
         };

--- a/ledger/src/test_helpers/chain_builder.rs
+++ b/ledger/src/test_helpers/chain_builder.rs
@@ -393,7 +393,7 @@ impl<N: Network> TestChainBuilder<N> {
                 cert_count += 1;
 
                 // Check if this batch was an anchor.
-                if round % 2 == 0 {
+                if round.is_multiple_of(2) {
                     let leader = committee.get_leader(round).unwrap();
                     if leader == Address::try_from(private_key_1).unwrap() {
                         created_anchor = true;
@@ -402,7 +402,7 @@ impl<N: Network> TestChainBuilder<N> {
             }
 
             // Anchor was confirmed by more than a third of the validators.
-            if created_anchor && round % 2 == 0 && self.last_block_round < round {
+            if created_anchor && round.is_multiple_of(2) && self.last_block_round < round {
                 self.last_block_round = round;
                 break;
             }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2175,7 +2175,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &first_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&first_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2219,7 +2219,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &second_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&second_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2267,7 +2267,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &first_withdrawal_private_key,
             ("credits.aleo", "unbond_public"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&first_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
             ]
@@ -2285,7 +2285,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &second_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&second_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2474,7 +2474,7 @@ finalize foo:
         let mut confirmed_transaction_ids = transactions.iter().map(Transaction::id).collect::<Vec<_>>();
 
         // Randomly insert the aborted transactions.
-        let mut aborted_transactions = vec![aborted_transfer.clone(), aborted_deployment.clone()];
+        let mut aborted_transactions = [aborted_transfer.clone(), aborted_deployment.clone()];
         aborted_transactions.shuffle(rng);
 
         // Randomly insert the aborted transactions.
@@ -3954,7 +3954,7 @@ function create_and_consume:
     let record = block.records().collect_vec().last().unwrap().1.decrypt(&view_key).unwrap();
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("child.aleo", "burn"), vec![Value::Record(record)].iter(), None, 0, None, rng)
+        .execute(&private_key, ("child.aleo", "burn"), [Value::Record(record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();
@@ -4003,7 +4003,7 @@ function create_and_consume:
         .execute(
             &private_key,
             ("parent.aleo", "consume_without_call"),
-            vec![Value::Record(mint_record.clone())].iter(),
+            [Value::Record(mint_record.clone())].iter(),
             None,
             0,
             None,
@@ -4027,7 +4027,7 @@ function create_and_consume:
     // Call the `consume` function.
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("parent.aleo", "consume"), vec![Value::Record(mint_record)].iter(), None, 0, None, rng)
+        .execute(&private_key, ("parent.aleo", "consume"), [Value::Record(mint_record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2005,7 +2005,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &first_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&first_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2049,7 +2049,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &second_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&second_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2097,7 +2097,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &first_withdrawal_private_key,
             ("credits.aleo", "unbond_public"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&first_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
             ]
@@ -2115,7 +2115,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &second_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&second_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2304,7 +2304,7 @@ finalize foo:
         let mut confirmed_transaction_ids = transactions.iter().map(Transaction::id).collect::<Vec<_>>();
 
         // Randomly insert the aborted transactions.
-        let mut aborted_transactions = vec![aborted_transfer.clone(), aborted_deployment.clone()];
+        let mut aborted_transactions = [aborted_transfer.clone(), aborted_deployment.clone()];
         aborted_transactions.shuffle(rng);
 
         // Randomly insert the aborted transactions.
@@ -3679,7 +3679,7 @@ function create_and_consume:
     let record = block.records().collect_vec().last().unwrap().1.decrypt(&view_key).unwrap();
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("child.aleo", "burn"), vec![Value::Record(record)].iter(), None, 0, None, rng)
+        .execute(&private_key, ("child.aleo", "burn"), [Value::Record(record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();
@@ -3728,7 +3728,7 @@ function create_and_consume:
         .execute(
             &private_key,
             ("parent.aleo", "consume_without_call"),
-            vec![Value::Record(mint_record.clone())].iter(),
+            [Value::Record(mint_record.clone())].iter(),
             None,
             0,
             None,
@@ -3752,7 +3752,7 @@ function create_and_consume:
     // Call the `consume` function.
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("parent.aleo", "consume"), vec![Value::Record(mint_record)].iter(), None, 0, None, rng)
+        .execute(&private_key, ("parent.aleo", "consume"), [Value::Record(mint_record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -868,11 +868,12 @@ pub trait BlockStorage<N: Network>: 'static + Clone + Send + Sync {
 
         let Some(confirmed) = transactions.find_confirmed_transaction_for_unconfirmed_transaction_id(transaction_id)
         else {
-            if let Some(aborted_ids) = self.get_block_aborted_transaction_ids(&block_hash)? {
-                if aborted_ids.contains(transaction_id) {
-                    bail!("Transaction '{transaction_id}' was aborted in block '{block_hash}'");
-                }
+            if let Some(aborted_ids) = self.get_block_aborted_transaction_ids(&block_hash)?
+                && aborted_ids.contains(transaction_id)
+            {
+                bail!("Transaction '{transaction_id}' was aborted in block '{block_hash}'");
             }
+
             bail!("Missing transaction '{transaction_id}' in block storage");
         };
         Ok(Some(confirmed.transaction().clone()))

--- a/ledger/store/src/helpers/rocksdb/internal/tests.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/tests.rs
@@ -183,7 +183,7 @@ fn test_iterator_ordering() {
     map.insert(4, "e".to_string()).expect("Failed to insert");
 
     // Define the expected order of the iterator.
-    let expected_order = vec![
+    let expected_order = &[
         (1, "h".to_string()),
         (2, "g".to_string()),
         (3, "f".to_string()),

--- a/ledger/store/src/lib.rs
+++ b/ledger/store/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![warn(clippy::cast_possible_truncation)]
 
 extern crate snarkvm_console as console;

--- a/ledger/store/src/program/committee.rs
+++ b/ledger/store/src/program/committee.rs
@@ -197,10 +197,10 @@ pub trait CommitteeStorage<N: Network>: 'static + Clone + Send + Sync {
         if is_latest_committee {
             while next_current_round > 0 {
                 // If the next current height is less than the current height, then we have found the next current round.
-                if let Some(next_current_height) = self.get_height_for_round(next_current_round)? {
-                    if next_current_height < current_height {
-                        break;
-                    }
+                if let Some(next_current_height) = self.get_height_for_round(next_current_round)?
+                    && next_current_height < current_height
+                {
+                    break;
                 }
                 // Otherwise, decrement the next current round.
                 next_current_round = next_current_round.saturating_sub(1);

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -806,19 +806,19 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
         }
 
         let spm_guard = self.slipstream_plugin_manager.read();
-        if let Some(mgr) = spm_guard.as_ref() {
-            if mgr.has_subscribers(BroadcastEventKind::StakingReward) {
-                // Address serializes to a fixed 32-byte array; this cannot fail.
-                let staker_bytes = staker.to_bytes_le().expect("Address::to_bytes_le is infallible");
-                let validator_bytes = validator.to_bytes_le().expect("Address::to_bytes_le is infallible");
-                mgr.broadcast(BroadcastEvent::StakingReward {
-                    staker: &staker_bytes,
-                    validator: &validator_bytes,
-                    reward,
-                    new_stake,
-                    block_height,
-                });
-            }
+        if let Some(mgr) = spm_guard.as_ref()
+            && mgr.has_subscribers(BroadcastEventKind::StakingReward)
+        {
+            // Address serializes to a fixed 32-byte array; this cannot fail.
+            let staker_bytes = staker.to_bytes_le().expect("Address::to_bytes_le is infallible");
+            let validator_bytes = validator.to_bytes_le().expect("Address::to_bytes_le is infallible");
+            mgr.broadcast(BroadcastEvent::StakingReward {
+                staker: &staker_bytes,
+                validator: &validator_bytes,
+                reward,
+                new_stake,
+                block_height,
+            });
         }
     }
 

--- a/ledger/store/src/transition/output.rs
+++ b/ledger/store/src/transition/output.rs
@@ -272,13 +272,13 @@ pub trait OutputStorage<N: Network>: Clone + Send + Sync {
                 self.reverse_id_map().remove(&output_id)?;
 
                 // If the output is a record, remove the record nonce and record sender.
-                if let Some(record) = self.record_map().get_confirmed(&output_id)? {
-                    if let Some(record) = &record.1 {
-                        // Remove the record nonce.
-                        self.record_nonce_map().remove(record.nonce())?;
-                        // Remove the record sender, if it exists.
-                        self.record_sender_map().remove(record.nonce())?;
-                    }
+                if let Some(record) = self.record_map().get_confirmed(&output_id)?
+                    && let Some(record) = &record.1
+                {
+                    // Remove the record nonce.
+                    self.record_nonce_map().remove(record.nonce())?;
+                    // Remove the record sender, if it exists.
+                    self.record_sender_map().remove(record.nonce())?;
                 }
 
                 // Remove the output.

--- a/ledger/store/src/transition/output.rs
+++ b/ledger/store/src/transition/output.rs
@@ -230,13 +230,13 @@ pub trait OutputStorage<N: Network>: Clone + Send + Sync {
                 self.reverse_id_map().remove(&output_id)?;
 
                 // If the output is a record, remove the record nonce and record sender.
-                if let Some(record) = self.record_map().get_confirmed(&output_id)? {
-                    if let Some(record) = &record.1 {
-                        // Remove the record nonce.
-                        self.record_nonce_map().remove(record.nonce())?;
-                        // Remove the record sender, if it exists.
-                        self.record_sender_map().remove(record.nonce())?;
-                    }
+                if let Some(record) = self.record_map().get_confirmed(&output_id)?
+                    && let Some(record) = &record.1
+                {
+                    // Remove the record nonce.
+                    self.record_nonce_map().remove(record.nonce())?;
+                    // Remove the record sender, if it exists.
+                    self.record_sender_map().remove(record.nonce())?;
                 }
 
                 // Remove the output.

--- a/ledger/tests/pending_blocks.rs
+++ b/ledger/tests/pending_blocks.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::cloned_ref_to_slice_refs)]
+
 mod helpers;
 use helpers::{BlockOptions, CurrentNetwork, LedgerType, TestChainBuilder};
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel="1.88"
+channel="1.92"
 components=["cargo", "rustc", "clippy", "rustfmt"]

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![allow(clippy::too_many_arguments)]
 // #![warn(clippy::cast_possible_truncation)]
 // TODO (howardwu): Update the return type on `execute` after stabilizing the interface.

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -493,13 +493,7 @@ pub(crate) mod test_helpers {
 
         // Generate the Authorization
         let authorization = process
-            .authorize::<CurrentAleo, _>(
-                &private_key,
-                &program_id,
-                &function_name,
-                vec![destination, amount].iter(),
-                rng,
-            )
+            .authorize::<CurrentAleo, _>(&private_key, &program_id, &function_name, [destination, amount].iter(), rng)
             .unwrap();
 
         // Assert there is only 1 transition

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -423,13 +423,7 @@ pub(crate) mod test_helpers {
 
         // Generate the Authorization
         let authorization = process
-            .authorize::<CurrentAleo, _>(
-                &private_key,
-                &program_id,
-                &function_name,
-                vec![destination, amount].iter(),
-                rng,
-            )
+            .authorize::<CurrentAleo, _>(&private_key, &program_id, &function_name, [destination, amount].iter(), rng)
             .unwrap();
 
         // Assert there is only 1 transition

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -193,10 +193,10 @@ impl<N: Network> FinalizeTypes<N> {
             // ensure that the program ID is imported by the current program.
             match operand {
                 Operand::Checksum(program_id) | Operand::Edition(program_id) | Operand::ProgramOwner(program_id) => {
-                    if let Some(program_id) = program_id {
-                        if stack.get_external_stack(program_id).is_err() {
-                            bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
-                        }
+                    if let Some(program_id) = program_id
+                        && stack.get_external_stack(program_id).is_err()
+                    {
+                        bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
                     }
                 }
                 _ => {}

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -195,10 +195,10 @@ impl<N: Network> FinalizeTypes<N> {
             // ensure that the program ID is imported by the current program.
             match operand {
                 Operand::Checksum(program_id) | Operand::Edition(program_id) | Operand::ProgramOwner(program_id) => {
-                    if let Some(program_id) = program_id {
-                        if stack.get_external_stack(program_id).is_err() {
-                            bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
-                        }
+                    if let Some(program_id) = program_id
+                        && stack.get_external_stack(program_id).is_err()
+                    {
+                        bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
                     }
                 }
                 _ => {}

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -184,16 +184,16 @@ impl<N: Network> RegisterTypes<N> {
                 future_registers.pop();
                 // Check only the register operands that are `future` types.
                 for operand in async_.operands() {
-                    if let Operand::Register(register) = operand {
-                        if matches!(
+                    if let Operand::Register(register) = operand
+                        && matches!(
                             register_types.get_type(stack, register)?,
                             RegisterType::Future(_) | RegisterType::DynamicFuture
-                        ) {
-                            ensure!(
-                                future_registers.swap_remove(&register.clone()),
-                                "Could not find future register '{register}' produced before the 'async' instruction.",
-                            );
-                        }
+                        )
+                    {
+                        ensure!(
+                            future_registers.swap_remove(&register.clone()),
+                            "Could not find future register '{register}' produced before the 'async' instruction.",
+                        );
                     }
                 }
                 // Ensure that all the futures created are consumed in the async call.

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -179,10 +179,10 @@ impl<N: Network> RegisterTypes<N> {
                 future_registers.pop();
                 // Check only the register operands that are `future` types.
                 for operand in async_.operands() {
-                    if let Operand::Register(register) = operand {
-                        if let Ok(RegisterType::Future(locator)) = register_types.get_type(stack, register) {
-                            assert!(future_registers.swap_remove(&(register.clone(), locator)));
-                        }
+                    if let Operand::Register(register) = operand
+                        && let Ok(RegisterType::Future(locator)) = register_types.get_type(stack, register)
+                    {
+                        assert!(future_registers.swap_remove(&(register.clone(), locator)));
                     }
                 }
                 // Ensure that all the futures created are consumed in the async call.

--- a/synthesizer/process/src/tests/test_serializers.rs
+++ b/synthesizer/process/src/tests/test_serializers.rs
@@ -143,7 +143,7 @@ function test_serde_equivalence:
             assert_eq!(bits.len(), num_bits as usize, "The number of bits does not match the expected size");
 
             // Construct the inputs.
-            let inputs = vec![Value::Plaintext(plaintext.clone())];
+            let inputs = [Value::Plaintext(plaintext.clone())];
 
             // Generate an authorization.
             let authorization =

--- a/synthesizer/process/src/tests/test_serializers.rs
+++ b/synthesizer/process/src/tests/test_serializers.rs
@@ -141,7 +141,7 @@ function test_serde_equivalence:
             assert_eq!(bits.len(), num_bits as usize, "The number of bits does not match the expected size");
 
             // Construct the inputs.
-            let inputs = vec![Value::Plaintext(plaintext.clone())];
+            let inputs = [Value::Plaintext(plaintext.clone())];
 
             // Generate an authorization.
             let authorization =

--- a/synthesizer/program/src/finalize/mod.rs
+++ b/synthesizer/program/src/finalize/mod.rs
@@ -98,10 +98,10 @@ impl<N: Network> FinalizeCore<N> {
     /// Returns `true` if the finalize scope contains an identifier type in its inputs or commands.
     pub fn contains_identifier_type(&self) -> Result<bool> {
         for input_type in self.input_types() {
-            if let FinalizeType::Plaintext(plaintext_type) = input_type {
-                if plaintext_type.contains_identifier_type()? {
-                    return Ok(true);
-                }
+            if let FinalizeType::Plaintext(plaintext_type) = input_type
+                && plaintext_type.contains_identifier_type()?
+            {
+                return Ok(true);
             }
         }
         // Check commands for identifier types in cast destinations.

--- a/synthesizer/program/src/function/mod.rs
+++ b/synthesizer/program/src/function/mod.rs
@@ -120,10 +120,10 @@ impl<N: Network> FunctionCore<N> {
                 return Ok(true);
             }
         }
-        if let Some(finalize) = &self.finalize_logic {
-            if finalize.contains_identifier_type()? {
-                return Ok(true);
-            }
+        if let Some(finalize) = &self.finalize_logic
+            && finalize.contains_identifier_type()?
+        {
+            return Ok(true);
         }
         Ok(false)
     }

--- a/synthesizer/program/src/function/parse.rs
+++ b/synthesizer/program/src/function/parse.rs
@@ -59,11 +59,11 @@ impl<N: Network> Parser for FunctionCore<N> {
                 eprintln!("{error}");
                 return Err(error);
             }
-            if let Some(finalize) = &finalize {
-                if let Err(error) = function.add_finalize(finalize.clone()) {
-                    eprintln!("{error}");
-                    return Err(error);
-                }
+            if let Some(finalize) = &finalize
+                && let Err(error) = function.add_finalize(finalize.clone())
+            {
+                eprintln!("{error}");
+                return Err(error);
             }
             Ok::<_, Error>(function)
         })(string)

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![allow(clippy::too_many_arguments)]
 #![warn(clippy::cast_possible_truncation)]
 
@@ -910,10 +912,10 @@ impl<N: Network> ProgramCore<N> {
         let mut record_names_iter = record_names.iter();
         let mut previous_record_name = record_names_iter.next();
         for record_name in record_names_iter {
-            if let Some(previous) = previous_record_name {
-                if record_name.starts_with(previous) {
-                    bail!("Record name '{previous}' can't be a prefix of record name '{record_name}'.");
-                }
+            if let Some(previous) = previous_record_name
+                && record_name.starts_with(previous)
+            {
+                bail!("Record name '{previous}' can't be a prefix of record name '{record_name}'.");
             }
             previous_record_name = Some(record_name);
         }
@@ -1268,12 +1270,11 @@ impl<N: Network> ProgramCore<N> {
             {
                 return Ok(true);
             }
-            if let Some(finalize) = function.finalize_logic() {
-                if finalize.inputs().iter().any(|input| matches!(input.finalize_type(), FinalizeType::DynamicFuture))
-                    || finalize.commands().iter().any(is_v14_command)
-                {
-                    return Ok(true);
-                }
+            if let Some(finalize) = function.finalize_logic()
+                && (finalize.inputs().iter().any(|input| matches!(input.finalize_type(), FinalizeType::DynamicFuture))
+                    || finalize.commands().iter().any(is_v14_command))
+            {
+                return Ok(true);
             }
             if function.contains_identifier_type()? {
                 return Ok(true);

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![allow(clippy::too_many_arguments)]
 #![warn(clippy::cast_possible_truncation)]
 
@@ -852,10 +854,10 @@ impl<N: Network> ProgramCore<N> {
         let mut record_names_iter = record_names.iter();
         let mut previous_record_name = record_names_iter.next();
         for record_name in record_names_iter {
-            if let Some(previous) = previous_record_name {
-                if record_name.starts_with(previous) {
-                    bail!("Record name '{previous}' can't be a prefix of record name '{record_name}'.");
-                }
+            if let Some(previous) = previous_record_name
+                && record_name.starts_with(previous)
+            {
+                bail!("Record name '{previous}' can't be a prefix of record name '{record_name}'.");
             }
             previous_record_name = Some(record_name);
         }

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -25,7 +25,7 @@ pub use operation::*;
 mod bytes;
 mod parse;
 
-use crate::{RegistersCircuit, RegistersSigner, RegistersTrait, StackTrait, instruction};
+use crate::{RegistersCircuit, RegistersSigner, RegistersTrait, StackTrait};
 use console::{
     network::Network,
     prelude::{

--- a/synthesizer/snark/src/lib.rs
+++ b/synthesizer/snark/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
 #![allow(clippy::too_many_arguments)]
 #![warn(clippy::cast_possible_truncation)]
 

--- a/synthesizer/src/lib.rs
+++ b/synthesizer/src/lib.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 #![forbid(unsafe_code)]
+#![allow(mismatched_lifetime_syntaxes)]
+#![allow(clippy::cloned_ref_to_slice_refs)]
 #![warn(clippy::cast_possible_truncation)]
 // TODO (howardwu): Update the return type on `execute` after stabilizing the interface.
 #![allow(clippy::type_complexity)]

--- a/synthesizer/src/restrictions/mod.rs
+++ b/synthesizer/src/restrictions/mod.rs
@@ -246,10 +246,10 @@ impl<N: Network> Restrictions<N> {
                                     Input::Constant(_, Some(plaintext)) | Input::Public(_, Some(plaintext)) => {
                                         match plaintext {
                                             Plaintext::Literal(literal, _) => {
-                                                if let Some(range) = arguments.get(literal) {
-                                                    if range.contains(block_height) {
-                                                        return true;
-                                                    }
+                                                if let Some(range) = arguments.get(literal)
+                                                    && range.contains(block_height)
+                                                {
+                                                    return true;
                                                 }
                                             }
                                             Plaintext::Struct(..) | Plaintext::Array(..) => continue,
@@ -265,10 +265,10 @@ impl<N: Network> Restrictions<N> {
                                     Output::Constant(_, Some(plaintext)) | Output::Public(_, Some(plaintext)) => {
                                         match plaintext {
                                             Plaintext::Literal(literal, _) => {
-                                                if let Some(range) = arguments.get(literal) {
-                                                    if range.contains(block_height) {
-                                                        return true;
-                                                    }
+                                                if let Some(range) = arguments.get(literal)
+                                                    && range.contains(block_height)
+                                                {
+                                                    return true;
                                                 }
                                             }
                                             Plaintext::Struct(..) | Plaintext::Array(..) => continue,

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -1105,7 +1105,7 @@ constructor:
             .execute(
                 &caller_private_key,
                 (format!("test_{}.aleo", Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1), "test"),
-                vec![Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
+                [Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
                 None,
                 0,
                 None,

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -1071,7 +1071,7 @@ finalize test:
             .execute(
                 &caller_private_key,
                 (format!("test_{}.aleo", Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1), "test"),
-                vec![Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
+                [Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
                 None,
                 0,
                 None,

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -969,10 +969,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // If the transaction is a deployment, ensure that it is not another deployment in the block from the same public fee payer.
         if let Transaction::Deploy(_, _, _, _, fee) = transaction {
             // If any public deployment payer has already deployed in this block, abort the transaction.
-            if let Some(payer) = fee.payer() {
-                if deployment_payers.contains(&payer) {
-                    return Some(format!("Another deployment in the block from the same public fee payer {payer}"));
-                }
+            if let Some(payer) = fee.payer()
+                && deployment_payers.contains(&payer)
+            {
+                return Some(format!("Another deployment in the block from the same public fee payer {payer}"));
             }
         }
 
@@ -3515,7 +3515,7 @@ finalize compute:
 
         // Generate the next block.
         let next_block =
-            sample_next_block(&vm, validators.keys().next().unwrap(), &vec![transaction], &block, &mut vec![], rng)
+            sample_next_block(&vm, validators.keys().next().unwrap(), &[transaction], &block, &mut vec![], rng)
                 .unwrap();
 
         // Add the next block.
@@ -3553,15 +3553,9 @@ finalize compute:
             .unwrap();
 
         // Generate the next block.
-        let next_block = sample_next_block(
-            &vm,
-            validators.keys().next().unwrap(),
-            &vec![transaction],
-            &next_block,
-            &mut vec![],
-            rng,
-        )
-        .unwrap();
+        let next_block =
+            sample_next_block(&vm, validators.keys().next().unwrap(), &[transaction], &next_block, &mut vec![], rng)
+                .unwrap();
 
         // Add the next block.
         vm.add_next_block(&next_block).unwrap();

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -926,10 +926,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // If the transaction is a deployment, ensure that it is not another deployment in the block from the same public fee payer.
         if let Transaction::Deploy(_, _, _, _, fee) = transaction {
             // If any public deployment payer has already deployed in this block, abort the transaction.
-            if let Some(payer) = fee.payer() {
-                if deployment_payers.contains(&payer) {
-                    return Some(format!("Another deployment in the block from the same public fee payer {payer}"));
-                }
+            if let Some(payer) = fee.payer()
+                && deployment_payers.contains(&payer)
+            {
+                return Some(format!("Another deployment in the block from the same public fee payer {payer}"));
             }
         }
 
@@ -3478,7 +3478,7 @@ finalize compute:
 
         // Generate the next block.
         let next_block =
-            sample_next_block(&vm, validators.keys().next().unwrap(), &vec![transaction], &block, &mut vec![], rng)
+            sample_next_block(&vm, validators.keys().next().unwrap(), &[transaction], &block, &mut vec![], rng)
                 .unwrap();
 
         // Add the next block.
@@ -3516,15 +3516,9 @@ finalize compute:
             .unwrap();
 
         // Generate the next block.
-        let next_block = sample_next_block(
-            &vm,
-            validators.keys().next().unwrap(),
-            &vec![transaction],
-            &next_block,
-            &mut vec![],
-            rng,
-        )
-        .unwrap();
+        let next_block =
+            sample_next_block(&vm, validators.keys().next().unwrap(), &[transaction], &next_block, &mut vec![], rng)
+                .unwrap();
 
         // Add the next block.
         vm.add_next_block(&next_block).unwrap();

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -3147,13 +3147,7 @@ function check:
 
         // Generate the authorization that will contain multiple transitions
         let authorization = process
-            .authorize::<CurrentAleo, _>(
-                &private_key,
-                grandparent_program.id(),
-                &function_name,
-                vec![input].iter(),
-                rng,
-            )
+            .authorize::<CurrentAleo, _>(&private_key, grandparent_program.id(), &function_name, [input].iter(), rng)
             .unwrap();
 
         // Assert the Authorization has more than 1 transitions

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -3213,13 +3213,7 @@ function check:
 
         // Generate the authorization that will contain multiple transitions
         let authorization = process
-            .authorize::<CurrentAleo, _>(
-                &private_key,
-                grandparent_program.id(),
-                &function_name,
-                vec![input].iter(),
-                rng,
-            )
+            .authorize::<CurrentAleo, _>(&private_key, grandparent_program.id(), &function_name, [input].iter(), rng)
             .unwrap();
 
         // Assert the Authorization has more than 1 transitions

--- a/synthesizer/src/vm/tests/test_v14/compare_calls_to_credits.rs
+++ b/synthesizer/src/vm/tests/test_v14/compare_calls_to_credits.rs
@@ -560,7 +560,7 @@ fn test_compare_transfer_public_to_private() {
         )
         .unwrap();
 
-    let dynamic_inputs = vec![Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
+    let dynamic_inputs = [Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
     let dynamic_tx = vm
         .execute(
             &caller_private_key,

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -576,13 +576,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         "Invalid deployment transaction '{id}' - the existing program does not have a constructor, but the deployment program does"
                                     );
                                     // If the consensus version is V10 or greater, then check that each function's **record** output registers match the existing program.
-                                    if consensus_version >= ConsensusVersion::V10 {
-                                        if let Err(e) = check_output_register_indices_unchanged(
+                                    if consensus_version >= ConsensusVersion::V10
+                                        && let Err(e) = check_output_register_indices_unchanged(
                                             existing_program,
                                             deployment.program(),
-                                        ) {
-                                            bail!("Invalid deployment transaction '{id}' - {e}")
-                                        }
+                                        )
+                                    {
+                                        bail!("Invalid deployment transaction '{id}' - {e}")
                                     }
                                 }
                             }

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -349,12 +349,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                     "Invalid deployment transaction '{id}' - the existing program does not have a constructor, but the deployment program does"
                                 );
                                 // If the consensus version is V10 or greater, then check that each function's **record** output registers match the existing program.
-                                if consensus_version >= ConsensusVersion::V10 {
-                                    if let Err(e) =
+                                if consensus_version >= ConsensusVersion::V10
+                                    && let Err(e) =
                                         check_output_register_indices_unchanged(existing_program, deployment.program())
-                                    {
-                                        bail!("Invalid deployment transaction '{id}' - {e}")
-                                    }
+                                {
+                                    bail!("Invalid deployment transaction '{id}' - {e}")
                                 }
                             }
                         }

--- a/synthesizer/tests/test_process_execute.rs
+++ b/synthesizer/tests/test_process_execute.rs
@@ -147,7 +147,6 @@ fn run_test(process: Process<CurrentNetwork>, test: &ProgramTest) -> serde_yaml:
                                     response
                                         .outputs()
                                         .iter()
-                                        .cloned()
                                         .map(|output| serde_yaml::Value::String(output.to_string()))
                                         .collect_vec(),
                                 ),

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -89,7 +89,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
             .execute(
                 &genesis_private_key,
                 ("credits.aleo", "transfer_public"),
-                vec![
+                [
                     Value::Plaintext(Plaintext::from(Literal::Address(Address::try_from(key).unwrap()))),
                     Value::Plaintext(Plaintext::from(Literal::U64(U64::new(1_000_000_000_000)))),
                 ]
@@ -605,7 +605,7 @@ fn split<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>(
     amount: u64,
     rng: &mut R,
 ) -> (Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>, Vec<Transaction<CurrentNetwork>>) {
-    let inputs = vec![Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
+    let inputs = [Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
     let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs.iter(), None, 0, None, rng).unwrap();
     let records = transaction
         .records()

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -85,7 +85,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
             .execute(
                 &genesis_private_key,
                 ("credits.aleo", "transfer_public"),
-                vec![
+                [
                     Value::Plaintext(Plaintext::from(Literal::Address(Address::try_from(key).unwrap()))),
                     Value::Plaintext(Plaintext::from(Literal::U64(U64::new(1_000_000_000_000)))),
                 ]
@@ -585,7 +585,7 @@ fn split<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>(
     amount: u64,
     rng: &mut R,
 ) -> (Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>, Vec<Transaction<CurrentNetwork>>) {
-    let inputs = vec![Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
+    let inputs = [Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
     let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs.iter(), None, 0, None, rng).unwrap();
     let records = transaction
         .records()

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -525,7 +525,7 @@ pub fn bits_from_bytes_le(bytes: &[u8]) -> impl DoubleEndedIterator<Item = bool>
 
 #[inline]
 pub fn bytes_from_bits_le(bits: &[bool]) -> Vec<u8> {
-    let desired_size = if bits.len() % 8 == 0 { bits.len() / 8 } else { bits.len() / 8 + 1 };
+    let desired_size = if bits.len().is_multiple_of(8) { bits.len() / 8 } else { bits.len() / 8 + 1 };
 
     let mut bytes = Vec::with_capacity(desired_size);
     for bits in bits.chunks(8) {


### PR DESCRIPTION
Aims to upgrade snarkVM to Rust 1.92 as proposed in #3029. snarkVM had a somewhat large number of new lints failing. I disabled some of them and fixed others.