### PR TITLE
[Perf] Tweak parallelism for some operations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ commands:
 
             export PATH="$HOME/.cargo/bin:$PATH"
             if ! command -v cargo-nextest >/dev/null 2>&1; then
-              cargo install cargo-nextest --locked
+              cargo install cargo-nextest --locked --version "0.9.117"
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ commands:
 
             export PATH="$HOME/.cargo/bin:$PATH"
             if ! command -v cargo-nextest >/dev/null 2>&1; then
-              cargo install cargo-nextest --locked --version "0.9.117"
+              cargo install cargo-nextest --locked --version "0.9.114"
             fi
 
       - run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,6 @@ snarkVM is a big project, so (non-)adherence to best practices related to perfor
   * `&[T]` instead of `&Vec<T>`
   * `&str` instead of `&String`
   * `&Path` instead of `&PathBuf`
-- if a lot of computational power is needed, consider parallelizing that workload with [`rayon`](https://crates.io/crates/rayon) - it's not always a viable solution, but can yield great performance improvements when used in the right context
+- if a lot of computational power is needed, consider parallelizing that workload with [`rayon`](https://crates.io/crates/rayon) - it's not always a viable solution, but can yield great performance improvements when used in the right context; the [`cfg_*` macros](https://github.com/ProvableHQ/snarkVM/blob/staging/utilities/src/parallel.rs) should be used in crates which also have a `serial` feature, so that `rayon` can be applied conditionally
 - for `struct`s that can be compared/discerned based on some specific field(s), consider hand-written implementations of `PartialEq` **and** `Hash` ([they must match](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq)) for faster comparison and hashing
 - if possible, ensure that the results of your changes are not detrimental to performance using [`criterion`](https://crates.io/crates/criterion) (for smaller, fine-grained adjustments) and [`valgrind --tool={cachegrind | massif}`](https://valgrind.org/info/tools.html) (for larger-scale changes)

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -41,12 +41,10 @@ use rand::Rng;
 use std::{borrow::Cow, fmt};
 
 use anyhow::{Result, ensure};
+use itertools::Itertools;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
-
-#[cfg(feature = "serial")]
-use itertools::Itertools;
 
 /// Returns the ceiling of the base-2 logarithm of `x`.
 ///
@@ -285,7 +283,7 @@ impl<F: FftField> EvaluationDomain<F> {
             }
 
             batch_inversion(u.as_mut_slice());
-            cfg_iter_mut!(u).zip_eq(ls).for_each(|(tau_minus_r, l)| {
+            cfg_iter_mut!(u, 1_000).zip_eq(ls).for_each(|(tau_minus_r, l)| {
                 *tau_minus_r = l * *tau_minus_r;
             });
             u
@@ -422,7 +420,7 @@ impl<F: FftField> EvaluationDomain<F> {
 
         let pc = self.precompute_ifft();
         self.ifft_helper_in_place_with_pc(x_s, FFTOrder::II, &pc);
-        cfg_iter_mut!(x_s).for_each(|val| *val *= self.size_inv);
+        cfg_iter_mut!(x_s, 1_000).for_each(|val| *val *= self.size_inv);
     }
 
     pub(crate) fn in_order_coset_ifft_in_place<T: DomainCoeff<F>>(&self, x_s: &mut [T]) {
@@ -500,7 +498,7 @@ impl<F: FftField> EvaluationDomain<F> {
         }
 
         self.ifft_helper_in_place_with_pc(x_s, FFTOrder::II, pre_comp);
-        cfg_iter_mut!(x_s).for_each(|val| *val *= self.size_inv);
+        cfg_iter_mut!(x_s, 1_000).for_each(|val| *val *= self.size_inv);
     }
 
     pub(crate) fn out_order_ifft_in_place_with_pc<T: DomainCoeff<F>>(
@@ -509,7 +507,7 @@ impl<F: FftField> EvaluationDomain<F> {
         pre_comp: &IFFTPrecomputation<F>,
     ) {
         self.ifft_helper_in_place_with_pc(x_s, FFTOrder::OI, pre_comp);
-        cfg_iter_mut!(x_s).for_each(|val| *val *= self.size_inv);
+        cfg_iter_mut!(x_s, 1_000).for_each(|val| *val *= self.size_inv);
     }
 
     #[allow(unused)]
@@ -762,8 +760,8 @@ impl<F: FftField> EvaluationDomain<F> {
             // the roots lookup is done a significant amount of times
             // Which also implies a large lookup stride.
             let (roots, step) = if num_chunks >= MIN_NUM_CHUNKS_FOR_COMPACTION && gap < xi.len() / 2 {
-                cfg_iter_mut!(compacted_roots[..gap])
-                    .zip(cfg_iter!(roots_cache[..(gap * num_chunks)]).step_by(num_chunks))
+                cfg_iter_mut!(compacted_roots[..gap], 1_000)
+                    .zip(cfg_iter!(roots_cache[..(gap * num_chunks)], 1_000).step_by(num_chunks))
                     .for_each(|(a, b)| *a = *b);
                 (&compacted_roots[..gap], 1)
             } else {

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -41,7 +41,6 @@ use rand::Rng;
 use std::{borrow::Cow, fmt};
 
 use anyhow::{Result, ensure};
-use itertools::Itertools;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -24,6 +24,7 @@ use rayon::prelude::*;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, serialize::*};
 
+use itertools::Itertools;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 use super::domain::IFFTPrecomputation;
@@ -88,7 +89,7 @@ impl<F: PrimeField> Evaluations<F> {
     }
 
     pub fn evaluate_with_coeffs(&self, lagrange_coefficients_at_point: &[F]) -> F {
-        cfg_iter!(self.evaluations).zip_eq(lagrange_coefficients_at_point).map(|(a, b)| *a * b).sum()
+        cfg_iter!(self.evaluations, 1_000).zip_eq(lagrange_coefficients_at_point).map(|(a, b)| *a * b).sum()
     }
 }
 

--- a/algorithms/src/fft/evaluations.rs
+++ b/algorithms/src/fft/evaluations.rs
@@ -24,7 +24,6 @@ use rayon::prelude::*;
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::{cfg_iter, cfg_iter_mut, serialize::*};
 
-use itertools::Itertools;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 use super::domain::IFFTPrecomputation;

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -154,7 +154,7 @@ impl<F: PrimeField> DensePolynomial<F> {
     pub fn mul_by_vanishing_poly(&self, domain: EvaluationDomain<F>) -> DensePolynomial<F> {
         let mut shifted = vec![F::zero(); domain.size()];
         shifted.extend_from_slice(&self.coeffs);
-        crate::cfg_iter_mut!(shifted[..self.coeffs.len()]).zip_eq(&self.coeffs).for_each(|(s, c)| *s -= c);
+        shifted[..self.coeffs.len()].iter_mut().zip_eq(&self.coeffs).for_each(|(s, c)| *s -= c);
         DensePolynomial::from_coefficients_vec(shifted)
     }
 
@@ -228,12 +228,12 @@ impl<'a, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> {
             // return
         } else if self.degree() >= other.degree() {
             // Zip safety: `self` and `other` could have different lengths.
-            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a += b);
+            cfg_iter_mut!(self.coeffs, 1_000).zip(&other.coeffs).for_each(|(a, b)| *a += b);
         } else {
             // Add the necessary number of zero coefficients.
             self.coeffs.resize(other.coeffs.len(), F::zero());
             // Zip safety: `self` and `other` have the same length.
-            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a += b);
+            cfg_iter_mut!(self.coeffs, 1_000).zip(&other.coeffs).for_each(|(a, b)| *a += b);
         }
         // If the leading coefficient ends up being zero, pop it off.
         while let Some(true) = self.coeffs.last().map(|c| c.is_zero()) {
@@ -271,14 +271,14 @@ impl<'a, F: Field> AddAssign<(F, &'a DensePolynomial<F>)> for DensePolynomial<F>
             // return
         } else if self.degree() >= other.degree() {
             // Zip safety: `self` and `other` could have different lengths.
-            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| {
+            cfg_iter_mut!(self.coeffs, 1_000).zip(&other.coeffs).for_each(|(a, b)| {
                 *a += f * b;
             });
         } else {
             // Add the necessary number of zero coefficients.
             self.coeffs.resize(other.coeffs.len(), F::zero());
             // Zip safety: `self` and `other` have the same length after the resize.
-            cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| {
+            cfg_iter_mut!(self.coeffs, 1_000).zip(&other.coeffs).for_each(|(a, b)| {
                 *a += f * b;
             });
         }
@@ -317,13 +317,13 @@ impl<'a, F: Field> Sub<&'a DensePolynomial<F>> for &'_ DensePolynomial<F> {
         } else if self.degree() >= other.degree() {
             let mut result = self.clone();
             // Zip safety: `result` and `other` could have different degrees.
-            cfg_iter_mut!(result.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a -= b);
+            cfg_iter_mut!(result.coeffs, 1_000).zip(&other.coeffs).for_each(|(a, b)| *a -= b);
             result
         } else {
             let mut result = self.clone();
             result.coeffs.resize(other.coeffs.len(), F::zero());
             // Zip safety: `result` and `other` have the same length after the resize.
-            cfg_iter_mut!(result.coeffs).zip(&other.coeffs).for_each(|(a, b)| {
+            cfg_iter_mut!(result.coeffs, 1_000).zip(&other.coeffs).for_each(|(a, b)| {
                 *a -= b;
             });
             result
@@ -483,7 +483,7 @@ impl<F: Field> Mul<F> for &'_ DensePolynomial<F> {
 impl<F: Field> MulAssign<F> for DensePolynomial<F> {
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul_assign(&mut self, other: F) {
-        cfg_iter_mut!(self).for_each(|c| *c *= other);
+        self.iter_mut().for_each(|c| *c *= other);
     }
 }
 

--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -281,7 +281,7 @@ impl<F: PrimeField> Polynomial<'_, F> {
                         .chunks(domain.size())
                         .map(|d| Evaluations::from_vec_and_domain(domain.fft(d), domain))
                         .fold(Evaluations::from_vec_and_domain(vec![F::zero(); domain.size()], domain), |mut acc, e| {
-                            cfg_iter_mut!(acc.evaluations).zip(e.evaluations).for_each(|(a, e)| *a += e);
+                            acc.evaluations.iter_mut().zip(e.evaluations).for_each(|(a, e)| *a += e);
                             acc
                         })
                 } else {

--- a/algorithms/src/fft/polynomial/multiplier.rs
+++ b/algorithms/src/fft/polynomial/multiplier.rs
@@ -19,7 +19,7 @@ use crate::fft::domain::{FFTPrecomputation, IFFTPrecomputation};
 
 /// A struct that helps multiply a batch of polynomials
 use super::*;
-use snarkvm_utilities::{ExecutionPool, cfg_into_iter, cfg_iter, cfg_iter_mut, cfg_reduce_with};
+use snarkvm_utilities::{ExecutionPool, cfg_into_iter, cfg_iter, cfg_reduce_with};
 
 #[derive(Default)]
 pub struct PolyMultiplier<'a, F: PrimeField> {

--- a/algorithms/src/fft/polynomial/multiplier.rs
+++ b/algorithms/src/fft/polynomial/multiplier.rs
@@ -123,7 +123,7 @@ impl<'a, F: PrimeField> PolyMultiplier<'a, F> {
                 let results = pool.execute_all();
                 let iter = cfg_into_iter!(results);
                 let mut result = cfg_reduce_with!(iter, |mut a, b| {
-                    cfg_iter_mut!(a).zip(b).for_each(|(a, b)| *a *= b);
+                    a.iter_mut().zip(b).for_each(|(a, b)| *a *= b);
                     a
                 })
                 .unwrap();

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -471,7 +471,7 @@ fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField>(p: &DensePolynomial<
 
 fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInteger> {
     let to_bigint_time = start_timer!(|| "Converting polynomial coeffs to bigints");
-    let coeffs = cfg_iter!(p).map(|s| s.to_bigint()).collect::<Vec<_>>();
+    let coeffs = p.iter().map(|s| s.to_bigint()).collect::<Vec<_>>();
     end_timer!(to_bigint_time);
     coeffs
 }

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -25,7 +25,7 @@ use crate::{
     },
 };
 use snarkvm_fields::{Field, PrimeField};
-use snarkvm_utilities::{cfg_into_iter, cfg_iter, cfg_iter_mut, serialize::*};
+use snarkvm_utilities::{cfg_into_iter, serialize::*};
 
 use anyhow::{Result, anyhow, ensure};
 

--- a/algorithms/src/snark/varuna/ahp/matrices.rs
+++ b/algorithms/src/snark/varuna/ahp/matrices.rs
@@ -29,7 +29,6 @@ use snarkvm_utilities::{cfg_into_iter, cfg_iter, cfg_iter_mut, serialize::*};
 
 use anyhow::{Result, anyhow, ensure};
 
-#[cfg(feature = "serial")]
 use itertools::Itertools;
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -188,8 +187,8 @@ pub(crate) fn matrix_evals<F: PrimeField>(
     let non_zero_entries = row_indices.len();
 
     // Zip safety: we intentionally only multiply the first non_zero_entries
-    cfg_iter_mut!(row_col_indices).zip(&col_indices).for_each(|(rc, &col)| *rc *= col);
-    cfg_iter_mut!(row_col_vals).zip(&row_col_indices).for_each(|(v, rc)| *v *= rc);
+    row_col_indices.iter_mut().zip(&col_indices).for_each(|(rc, &col)| *rc *= col);
+    row_col_vals.iter_mut().zip(&row_col_indices).for_each(|(v, rc)| *v *= rc);
 
     // Fill up the evaluations to the next power of two with entries at row 0 (1
     // in R_i), column 0 (1 in C_i) and value 0,
@@ -249,7 +248,10 @@ impl<F: PrimeField> MatrixArithmetization<F> {
             row_col.clone().interpolate()
         } else {
             ensure!(matrix_evals.row.evaluations.len() == matrix_evals.col.evaluations.len());
-            let row_col_evals: Vec<F> = cfg_iter!(matrix_evals.row.evaluations)
+            let row_col_evals: Vec<F> = matrix_evals
+                .row
+                .evaluations
+                .iter()
                 .zip_eq(&matrix_evals.col.evaluations)
                 .map(|(&r, &c)| r * c)
                 .collect();

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
@@ -175,7 +175,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         job_pool.add_job(|| {
             let a_poly_time = start_timer!(|| format!("Computing a poly for {label}"));
             let a_poly = {
-                let evals = cfg_iter!(row_col_val.evaluations).map(|v| v_R_i_alpha_v_C_i_beta * v).collect();
+                let evals = row_col_val.evaluations.iter().map(|v| v_R_i_alpha_v_C_i_beta * v).collect();
                 EvaluationsOnDomain::from_vec_and_domain(evals, non_zero_domain)
                     .interpolate_with_pc(ifft_precomputation)
             };
@@ -187,7 +187,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             let b_poly_time = start_timer!(|| format!("Computing b poly for {label}"));
             let alpha_beta = alpha * beta;
             let b_poly = {
-                let evals: Vec<F> = cfg_iter!(row_on_K.evaluations)
+                let evals: Vec<F> = row_on_K
+                    .evaluations
+                    .iter()
                     .zip_eq(&col_on_K.evaluations)
                     .map(|(&r, &c)| R_size * C_size * (alpha_beta - beta * r - alpha * c + r * c))
                     .collect();
@@ -200,15 +202,13 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let [a_poly, b_poly]: [_; 2] = job_pool.execute_all().try_into().unwrap();
 
         let f_evals_time = start_timer!(|| format!("Computing f evals on K for {label}"));
-        let mut inverses: Vec<_> = cfg_iter!(row_on_K.evaluations)
-            .zip_eq(&col_on_K.evaluations)
-            .map(|(r, c)| (alpha - r) * (beta - c))
-            .collect();
+        let mut inverses: Vec<_> =
+            row_on_K.evaluations.iter().zip_eq(&col_on_K.evaluations).map(|(r, c)| (alpha - r) * (beta - c)).collect();
 
         let matrix_sumcheck_constants = v_R_i_alpha_v_C_i_beta * constraint_domain.size_inv * variable_domain.size_inv;
         batch_inversion_and_mul(&mut inverses, &matrix_sumcheck_constants);
 
-        cfg_iter_mut!(inverses).zip_eq(&row_col_val.evaluations).for_each(|(inv, v)| *inv *= v);
+        inverses.iter_mut().zip_eq(&row_col_val.evaluations).for_each(|(inv, v)| *inv *= v);
         let f_evals_on_K = inverses;
 
         end_timer!(f_evals_time);

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
@@ -32,16 +32,13 @@ use crate::{
     },
 };
 use snarkvm_fields::{PrimeField, batch_inversion_and_mul};
-use snarkvm_utilities::{ExecutionPool, cfg_iter, cfg_iter_mut};
+use snarkvm_utilities::ExecutionPool;
 
 use anyhow::Result;
 use core::convert::TryInto;
 use itertools::Itertools;
 use rand::RngCore;
 use std::collections::BTreeMap;
-
-#[cfg(not(feature = "serial"))]
-use rayon::prelude::*;
 
 type Sum<F> = F;
 type Lhs<F> = DensePolynomial<F>;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -68,7 +68,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 let assignments = constraints
                     .iter()
                     .zip(circuit_rand_assignments)
-                    .map(|(instance, rand_assignments)| {
+                    .enumerate()
+                    .map(|(_i, (instance, rand_assignments))| {
                         let constraint_time = start_timer!(|| format!(
                             "Generating constraints and witnesses for {:?} and index {_i}",
                             circuit.id

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -68,7 +68,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             .iter()
             .zip_eq(randomizing_assignments.into_iter())
             .map(|((circuit, constraints), circuit_rand_assignments)| {
-                let assignments = cfg_iter!(constraints)
+                let assignments = constraints
+                    .iter()
                     .zip(circuit_rand_assignments)
                     .enumerate()
                     .map(|(_i, (instance, rand_assignments))| {
@@ -123,7 +124,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                         Self::formatted_public_input_is_admissible(&padded_public_variables)?;
 
                         let eval_z_a_time = start_timer!(|| format!("For {:?}, evaluating z_A_{_i}", circuit.id));
-                        let z_a = cfg_iter!(circuit.a)
+                        let z_a = circuit
+                            .a
+                            .iter()
                             .map(|row| {
                                 inner_product(&padded_public_variables, &private_variables, row, num_public_variables)
                             })
@@ -131,7 +134,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                         end_timer!(eval_z_a_time);
 
                         let eval_z_b_time = start_timer!(|| format!("For {:?}, evaluating z_B_{_i}", circuit.id));
-                        let z_b = cfg_iter!(circuit.b)
+                        let z_b = circuit
+                            .b
+                            .iter()
                             .map(|row| {
                                 inner_product(&padded_public_variables, &private_variables, row, num_public_variables)
                             })
@@ -139,7 +144,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                         end_timer!(eval_z_b_time);
 
                         let eval_z_c_time = start_timer!(|| format!("For {:?}, evaluating z_C_{_i}", circuit.id));
-                        let z_c = cfg_iter!(circuit.c)
+                        let z_c = circuit
+                            .c
+                            .iter()
                             .map(|row| {
                                 inner_product(&padded_public_variables, &private_variables, row, num_public_variables)
                             })

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -28,10 +28,7 @@ use itertools::Itertools;
 use rand::{CryptoRng, Rng};
 use std::collections::BTreeMap;
 
-use snarkvm_utilities::{cfg_iter, dev_println};
-
-#[cfg(not(feature = "serial"))]
-use rayon::prelude::*;
+use snarkvm_utilities::dev_println;
 
 mod fifth;
 mod first;
@@ -71,8 +68,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 let assignments = constraints
                     .iter()
                     .zip(circuit_rand_assignments)
-                    .enumerate()
-                    .map(|(_i, (instance, rand_assignments))| {
+                    .map(|(instance, rand_assignments)| {
                         let constraint_time = start_timer!(|| format!(
                             "Generating constraints and witnesses for {:?} and index {_i}",
                             circuit.id

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
@@ -109,7 +109,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                     multiplier_2.add_polynomial(z_a, "z_a");
                     multiplier_2.add_polynomial(z_b, "z_b");
                     let mut rowcheck = multiplier_2.multiply().unwrap();
-                    cfg_iter_mut!(rowcheck.coeffs).zip(&z_c.coeffs).for_each(|(ab, c)| *ab -= c);
+                    rowcheck.coeffs.iter_mut().zip(&z_c.coeffs).for_each(|(ab, c)| *ab -= c);
 
                     instance_lhs += &(&rowcheck * instance_combiner);
 

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
@@ -31,7 +31,7 @@ use crate::{
 use anyhow::Result;
 use rand::RngCore;
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{ExecutionPool, cfg_into_iter, cfg_iter_mut, cfg_reduce};
+use snarkvm_utilities::{ExecutionPool, cfg_into_iter, cfg_reduce};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -270,8 +270,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 let input_domain = &circuit_specific_state.input_domain;
                 let assignments_i: Vec<_> = w_polys
                     .iter()
-                    .enumerate()
                     .zip_eq(x_polys)
+                    .enumerate()
                     .map(|(_j, (w_poly, x_poly))| {
                         let z_time = start_timer!(move || format!("Compute z poly for circuit {} {}", circuit.id, _j));
                         let mut assignment =

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -271,7 +271,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             .map(|((circuit, circuit_specific_state), w_polys)| {
                 let x_polys = &circuit_specific_state.x_polys;
                 let input_domain = &circuit_specific_state.input_domain;
-                let assignments_i: Vec<_> = cfg_iter!(w_polys)
+                let assignments_i: Vec<_> = w_polys
+                    .iter()
                     .zip_eq(x_polys)
                     .enumerate()
                     .map(|(_j, (w_poly, x_poly))| {
@@ -341,7 +342,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         // L^C_col(k)(X) will be 1
         let m_at_alpha_evals_time = start_timer!(|| format!("Compute m_at_alpha_evals parallel for {_matrix_label}"));
         let l_at_alpha = constraint_domain.evaluate_all_lagrange_coefficients(alpha);
-        let m_at_alpha_evals: Vec<_> = cfg_iter!(matrix_transpose)
+        let m_at_alpha_evals: Vec<_> = matrix_transpose
+            .iter()
             .map(|col| col.iter().map(|(val, row_index)| *val * l_at_alpha[*row_index]).sum::<F>())
             .collect();
         end_timer!(m_at_alpha_evals_time);

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -35,15 +35,12 @@ use crate::{
     },
 };
 use snarkvm_fields::PrimeField;
-use snarkvm_utilities::{ExecutionPool, cfg_iter};
+use snarkvm_utilities::ExecutionPool;
 
 use anyhow::{Result, ensure};
 use itertools::Itertools;
 use rand::RngCore;
 use std::collections::BTreeMap;
-
-#[cfg(not(feature = "serial"))]
-use rayon::prelude::*;
 
 struct LinevalInstance<F: PrimeField> {
     h_1_i: DensePolynomial<F>,
@@ -274,8 +271,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 let assignments_i: Vec<_> = w_polys
                     .iter()
                     .zip_eq(x_polys)
-                    .enumerate()
-                    .map(|(_j, (w_poly, x_poly))| {
+                    .map(|(w_poly, x_poly)| {
                         let z_time = start_timer!(move || format!("Compute z poly for circuit {} {}", circuit.id, _j));
                         let mut assignment =
                             w_poly.0.polynomial().as_dense().unwrap().mul_by_vanishing_poly(*input_domain);

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -270,8 +270,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 let input_domain = &circuit_specific_state.input_domain;
                 let assignments_i: Vec<_> = w_polys
                     .iter()
+                    .enumerate()
                     .zip_eq(x_polys)
-                    .map(|(w_poly, x_poly)| {
+                    .map(|(_j, (w_poly, x_poly))| {
                         let z_time = start_timer!(move || format!("Compute z poly for circuit {} {}", circuit.id, _j));
                         let mut assignment =
                             w_poly.0.polynomial().as_dense().unwrap().mul_by_vanishing_poly(*input_domain);

--- a/algorithms/src/snark/varuna/ahp/selectors.rs
+++ b/algorithms/src/snark/varuna/ahp/selectors.rs
@@ -16,7 +16,7 @@
 use super::verifier::QueryPoints;
 use crate::fft::{DensePolynomial, EvaluationDomain};
 use snarkvm_fields::{PrimeField, batch_inversion};
-use snarkvm_utilities::{cfg_into_iter, cfg_iter_mut};
+use snarkvm_utilities::cfg_into_iter;
 
 use anyhow::{Result, ensure};
 use itertools::Itertools;

--- a/algorithms/src/snark/varuna/ahp/selectors.rs
+++ b/algorithms/src/snark/varuna/ahp/selectors.rs
@@ -97,7 +97,7 @@ pub(crate) fn apply_randomized_selector<F: PrimeField>(
         ensure!(remainder.is_zero(), "Failed to divide by vanishing polynomial - non-zero remainder ({remainder:?})");
 
         let multiplier = combiner * src_domain.size_as_field_element * target_domain.size_inv;
-        cfg_iter_mut!(h_i.coeffs).for_each(|c| *c *= multiplier);
+        h_i.coeffs.iter_mut().for_each(|c| *c *= multiplier);
 
         end_timer!(selector_time);
         Ok((h_i, None))
@@ -114,7 +114,7 @@ pub(crate) fn apply_randomized_selector<F: PrimeField>(
         let selector_time = start_timer!(|| "Compute selector with remainder witness");
 
         let multiplier = combiner * src_domain.size_as_field_element * target_domain.size_inv;
-        cfg_iter_mut!(poly.coeffs).for_each(|c| *c *= multiplier);
+        poly.coeffs.iter_mut().for_each(|c| *c *= multiplier);
 
         let (h_i, mut xg_i) = poly.divide_by_vanishing_poly(*src_domain)?;
         xg_i = xg_i.mul_by_vanishing_poly(*target_domain);

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -18,7 +18,7 @@ use crate::{
     traits::{AffineCurve, ProjectiveCurve, ShortWeierstrassParameters as Parameters},
 };
 use snarkvm_fields::{Field, One, Zero, impl_add_sub_from_field_ref};
-use snarkvm_utilities::{FromBytes, ToBytes, cfg_iter_mut, rand::Uniform};
+use snarkvm_utilities::{FromBytes, ToBytes, rand::Uniform};
 
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},
@@ -29,8 +29,6 @@ use rand::{
     Rng,
     distributions::{Distribution, Standard},
 };
-#[cfg(not(feature = "serial"))]
-use rayon::prelude::*;
 use std::io::{Read, Result as IoResult, Write};
 
 #[derive(Copy, Clone, Debug)]

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -209,7 +209,7 @@ impl<P: Parameters> ProjectiveCurve for Projective<P> {
             g.z = tmp * s;
             tmp = newtmp;
         }
-        cfg_iter_mut!(v).filter(|g| !g.is_normalized()).for_each(|g| {
+        v.iter_mut().filter(|g| !g.is_normalized()).for_each(|g| {
             // Perform affine transformations
             let z2 = g.z.square(); // 1/z
             g.x *= &z2; // x/z^2

--- a/utilities/src/parallel.rs
+++ b/utilities/src/parallel.rs
@@ -98,6 +98,16 @@ macro_rules! cfg_iter {
 
         result
     }};
+
+    ($e: expr, $min: expr) => {{
+        #[cfg(not(feature = "serial"))]
+        let result = $e.par_iter().with_min_len($min);
+
+        #[cfg(feature = "serial")]
+        let result = $e.iter();
+
+        result
+    }};
 }
 
 /// Creates parallel iterator over mut refs if `parallel` feature is enabled.
@@ -106,6 +116,16 @@ macro_rules! cfg_iter_mut {
     ($e: expr) => {{
         #[cfg(not(feature = "serial"))]
         let result = $e.par_iter_mut();
+
+        #[cfg(feature = "serial")]
+        let result = $e.iter_mut();
+
+        result
+    }};
+
+    ($e: expr, $min: expr) => {{
+        #[cfg(not(feature = "serial"))]
+        let result = $e.par_iter_mut().with_min_len($min);
 
         #[cfg(feature = "serial")]
         let result = $e.iter_mut();


### PR DESCRIPTION
The fact that the node's CPU tends to be underutilized during some operations has been raised in relation to different features of snarkOS and the other users of snarkVM. I have long suspected that this is caused by imperfect granularity of work relayed to `rayon`, and I was finally able to pinpoint some of those operations, some of which are so trivial that any parallelism is an overkill; others only benefit from it when the applicable collections are large (which is where the extensions to the `cfg_iter(_mut)` macros comes in).

I investigated this using an auxiliary Varuna benchmark that I had locally, aiming to minimize the CPU time dedicated to:
- `crossbeam_deque::deque::Stealer<T>::steal` (down from 16.24% to 2.34%)
- `rayon_core::registry::WorkerThread::find_work` (down from 16.21% to 2.16%)

All the time saved on those calls can be dedicated to meaningful work instead.

The changes in this PR result in solid benchmark improvements (the ones not listed were unaffected):
```
####### algorithms/varuna #######

snark_circuit_setup_100 time:   [9.1197 ms 9.1410 ms 9.1631 ms]
                        change: [−6.0887% −5.7727% −5.4809%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_circuit_setup_1000
                        time:   [17.336 ms 17.365 ms 17.395 ms]
                        change: [−6.9117% −6.6065% −6.2756%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_circuit_setup_10000
                        time:   [97.402 ms 97.523 ms 97.646 ms]
                        change: [−11.556% −11.097% −10.628%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_prove_v1          time:   [106.02 ms 106.33 ms 106.66 ms]
                        change: [−4.0327% −3.5677% −3.1310%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_prove_v2          time:   [108.31 ms 108.67 ms 109.05 ms]
                        change: [−3.9355% −3.5076% −3.0207%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_verify            time:   [3.8178 ms 3.8396 ms 3.8610 ms]
                        change: [−9.1858% −8.6957% −8.2324%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_batch_prove       time:   [44.657 ms 44.740 ms 44.825 ms]
                        change: [−15.822% −15.580% −15.345%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_batch_verify      time:   [12.806 ms 12.826 ms 12.848 ms]
                        change: [−7.8945% −7.6645% −7.4354%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_certificate_prove_1000
                        time:   [8.9146 ms 8.9312 ms 8.9481 ms]
                        change: [−9.9636% −9.6981% −9.4262%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_certificate_prove_10000
                        time:   [25.765 ms 25.841 ms 25.919 ms]
                        change: [−4.6587% −4.2711% −3.8520%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_certificate_prove_100000
                        time:   [114.37 ms 114.64 ms 114.92 ms]
                        change: [−2.6501% −2.3278% −2.0124%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_certificate_verify_100
                        time:   [2.4245 ms 2.4323 ms 2.4398 ms]
                        change: [−10.008% −9.3381% −8.5408%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_certificate_verify_1000
                        time:   [3.8512 ms 3.8620 ms 3.8732 ms]
                        change: [−6.9053% −6.4634% −5.9935%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_certificate_verify_10000
                        time:   [15.276 ms 15.331 ms 15.387 ms]
                        change: [−3.7874% −3.2666% −2.7544%] (p = 0.00 < 0.05)
                        Performance has improved.

####### ledger/transaction #######

Transaction::Deploy     time:   [2.9276 s 2.9400 s 2.9526 s]
                        change: [−2.9600% −2.2036% −1.3444%] (p = 0.00 < 0.05)
                        Performance has improved.


Transaction::Execute(transfer_private)
                        time:   [2.8295 s 2.8368 s 2.8440 s]
                        change: [−3.2469% −2.6332% −1.9227%] (p = 0.00 < 0.05)
                        Performance has improved.

LimitedWriter::new - too_big.aleo
                        time:   [822.48 µs 823.59 µs 825.25 µs]
                        change: [−3.8458% −3.5066% −3.1483%] (p = 0.00 < 0.05)
                        Performance has improved.

Transaction::Execute(too_big.aleo) - verify
                        time:   [805.77 µs 806.17 µs 806.59 µs]
                        change: [−3.7737% −3.6114% −3.4741%] (p = 0.00 < 0.05)
                        Performance has improved.
```

These were executed on a fast, 16-core (32 logical) CPU, and would most likely be more pronounced on machines with more cores.

This work only targeted the calls to `cfg_iter` and `cfg_iter_mut`; while it's already a solid improvement, further gains are likely possible when targeting different benchmarks and macros.

CC @niklaslong 