### PR TITLE
[Fix] Make `prepare_next_quorum_block` atomic

### DIFF
--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -266,10 +266,14 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         {
             true => (None, vec![], Field::<N>::zero(), 0u128),
             false => {
-                // Retrieve the latest epoch hash.
-                let latest_epoch_hash = self.latest_epoch_hash()?;
+                // Retrieve the latest epoch hash directly from the previous block.
+                // (so we avoid read-locking current_block again)
+                let latest_epoch_hash = match self.current_epoch_hash.read().as_ref() {
+                    Some(epoch_hash) => *epoch_hash,
+                    None => self.get_epoch_hash(previous_block.height())?,
+                };
                 // Retrieve the latest proof target.
-                let latest_proof_target = self.latest_proof_target();
+                let latest_proof_target = previous_block.proof_target();
                 // Separate the candidate solutions into valid and aborted solutions.
                 let mut accepted_solutions: IndexMap<Address<N>, u64> = IndexMap::new();
                 let (valid_candidate_solutions, aborted_candidate_solutions) =

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -76,7 +76,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         ensure!(candidate_ratifications.is_empty(), "Ratifications are currently unsupported from the memory pool");
 
         // Retrieve the latest block as the previous block (for the next block).
-        // Hold this lock while perparing the template, so that the latest block does not change mid-speculation.
+        // Hold this lock while preparing the template, so that the latest block does not change mid-speculation.
         let previous_block = self.current_block.read();
 
         // Construct the block template.
@@ -108,14 +108,19 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     ///
     /// This function expects a valid block, that either was created by a trusted source, or successfully passed
     /// the blocks checks (e.g. [`Ledger::check_next_block`]).
-    /// Note, that it is still possible that this function returns an error for a valid block, if there are concurrent tasks
-    /// updating the ledger.
+    ///
+    /// # Concurrency
+    /// It is guaranteed that at most one call this function is executing at any time and that no reads to the Ledger
+    /// (e.g, by [`Self::prepare_next_beacon_block`] or [`Self::check_next_block`]) execute while the ledger is advancing.
+    /// However, it is still possible that a *previously* valid block is rejected by a call to this function,
+    /// if the ledger advanced between calling `prepare_next_*_block` and passing it to this function.
     ///
     /// # Panics
     /// This function panics if called from an async context.
     pub fn advance_to_next_block(&self, block: &Block<N>) -> Result<()> {
-        // Acquire the write lock on the current block.
+        // Acquire a write lock to current_block to prevent current updates or reads to the block or state root.
         let mut current_block = self.current_block.write();
+
         // Check again for any possible race conditions.
         if current_block.is_genesis()? {
             // current block is initialized as the genesis block, but the ledger will
@@ -236,6 +241,12 @@ where
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Constructs a block template for the next block in the ledger.
+    ///
+    /// # Concurrency
+    /// This function assumes that `previous_block` is identical to [`Self::current_block`]. To ensure this,
+    /// you should hold a read (or write) lock to the latter while calling this function.
+    /// Otherwise, it would be possible that the state root is inconsistent with the previous block, and for the
+    /// returned block template to be invalid.
     ///
     /// # Panics
     /// This function panics if called from an async context.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -289,7 +289,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                         let prover_address = solution.address();
                         let num_accepted_solutions = accepted_solutions.get(&prover_address).copied().unwrap_or(0);
                         // Check if the prover has reached their solution limit.
-                        if self.is_solution_limit_reached(&prover_address, num_accepted_solutions) {
+                        if self.is_solution_limit_reached_inner(previous_block, &prover_address, num_accepted_solutions)
+                        {
                             return false;
                         }
                         // Check if the solution is valid and update the number of accepted solutions.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -30,7 +30,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         rng: &mut R,
-    ) -> Result<Block<N>> {
+    ) -> Result<Block<N>, CheckBlockError<N>> {
         // Retrieve the latest block as the previous block (for the next block).
         // Hold this lock while preparing the template, so that the latest block does not change mid-speculation.
         let previous_block = self.current_block.read();
@@ -38,7 +38,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Decouple the transmissions into ratifications, solutions, and transactions.
         let (ratifications, solutions, transactions) = decouple_transmissions(transmissions.into_iter())?;
         // Currently, we do not support ratifications from the memory pool.
-        ensure!(ratifications.is_empty(), "Ratifications are currently unsupported from the memory pool");
+        if !ratifications.is_empty() {
+            return Err(anyhow!("Ratifications are currently unsupported from the memory pool").into());
+        }
         // Construct the block template.
         let (header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids) =
             self.construct_block_template(&previous_block, Some(&subdag), ratifications, solutions, transactions, rng)?;
@@ -54,6 +56,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             transactions,
             aborted_transaction_ids,
         )
+        .map_err(|e| CheckBlockError::Other(e))
     }
 
     /// Returns a candidate for the next block in the ledger.
@@ -71,9 +74,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         candidate_solutions: Vec<Solution<N>>,
         candidate_transactions: Vec<Transaction<N>>,
         rng: &mut R,
-    ) -> Result<Block<N>> {
+    ) -> Result<Block<N>, CheckBlockError<N>> {
         // Currently, we do not support ratifications from the memory pool.
-        ensure!(candidate_ratifications.is_empty(), "Ratifications are currently unsupported from the memory pool");
+        if !candidate_ratifications.is_empty() {
+            return Err(anyhow!("Ratifications are currently unsupported from the memory pool").into());
+        }
 
         // Retrieve the latest block as the previous block (for the next block).
         // Hold this lock while preparing the template, so that the latest block does not change mid-speculation.
@@ -102,6 +107,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             aborted_transaction_ids,
             rng,
         )
+        .map_err(|e| CheckBlockError::Other(e))
     }
 
     /// Adds the given block as the next block in the ledger.
@@ -259,8 +265,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         candidate_solutions: Vec<Solution<N>>,
         candidate_transactions: Vec<Transaction<N>>,
         rng: &mut R,
-    ) -> Result<(Header<N>, Ratifications<N>, Solutions<N>, Vec<SolutionID<N>>, Transactions<N>, Vec<N::TransactionID>)>
-    {
+    ) -> Result<
+        (Header<N>, Ratifications<N>, Solutions<N>, Vec<SolutionID<N>>, Transactions<N>, Vec<N::TransactionID>),
+        CheckBlockError<N>,
+    > {
         // Construct the solutions.
         let (solutions, aborted_solutions, solutions_root, combined_proof_target) = match candidate_solutions.is_empty()
         {
@@ -333,7 +341,16 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Compute the next round number.
         let next_round = match subdag {
-            Some(subdag) => subdag.anchor_round(),
+            Some(subdag) => {
+                if previous_block.round() >= subdag.anchor_round() {
+                    return Err(CheckBlockError::InvalidRound {
+                        new: subdag.anchor_round(),
+                        previous: previous_block.round(),
+                    });
+                }
+
+                subdag.anchor_round()
+            }
             None => previous_block.round().saturating_add(1),
         };
         // Compute the next height.
@@ -383,7 +400,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             N::ANCHOR_HEIGHT,
             N::BLOCK_TIME,
             combined_proof_target,
-            u64::try_from(latest_cumulative_proof_target)?,
+            u64::try_from(latest_cumulative_proof_target)
+                .map_err(|e| anyhow!("Failed to convert cumulative proof target to u64 - {e}"))?,
             latest_coinbase_target,
         )?;
 

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -21,6 +21,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns a candidate for the next block in the ledger, using a committed subdag and its transmissions.
     /// This candidate can then be passed to [`Ledger::advance_to_next_block`] to be added to the ledger.
     ///
+    /// The function will prevent concurrent update to the ledger, and may block if an update is currently in progress.
+    ///
     /// # Panics
     /// This function panics if called from an async context.
     pub fn prepare_advance_to_next_quorum_block<R: Rng + CryptoRng>(
@@ -30,7 +32,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         rng: &mut R,
     ) -> Result<Block<N>> {
         // Retrieve the latest block as the previous block (for the next block).
-        let previous_block = self.latest_block();
+        // Hold this lock while perparing the template, so that the latest block does not change mid-speculation.
+        let previous_block = self.current_block.read();
 
         // Decouple the transmissions into ratifications, solutions, and transactions.
         let (ratifications, solutions, transactions) = decouple_transmissions(transmissions.into_iter())?;
@@ -73,7 +76,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         ensure!(candidate_ratifications.is_empty(), "Ratifications are currently unsupported from the memory pool");
 
         // Retrieve the latest block as the previous block (for the next block).
-        let previous_block = self.latest_block();
+        // Hold this lock while perparing the template, so that the latest block does not change mid-speculation.
+        let previous_block = self.current_block.read();
 
         // Construct the block template.
         let (header, ratifications, solutions, aborted_solution_ids, transactions, aborted_transaction_ids) = self

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -32,7 +32,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         rng: &mut R,
     ) -> Result<Block<N>> {
         // Retrieve the latest block as the previous block (for the next block).
-        // Hold this lock while perparing the template, so that the latest block does not change mid-speculation.
+        // Hold this lock while preparing the template, so that the latest block does not change mid-speculation.
         let previous_block = self.current_block.read();
 
         // Decouple the transmissions into ratifications, solutions, and transactions.

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -49,6 +49,8 @@ pub enum CheckBlockError<N: Network> {
     BlockAlreadyExists { hash: N::BlockHash },
     #[error("Block has invalid height. Expected {expected}, but got {actual}")]
     InvalidHeight { expected: u32, actual: u32 },
+    #[error("Block has invalid round. Was {new}, but must be greater than previous round ({previous})")]
+    InvalidRound { new: u64, previous: u64 },
     #[error("Block has invalid hash")]
     InvalidHash,
     /// An error related to the given prefix of pending blocks.
@@ -206,6 +208,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Ensure, again, that the ledger has not advanced yet. This prevents cryptic errors form appearing during the block check.
         if block.height() != latest_block.height() + 1 {
             return Err(CheckBlockError::InvalidHeight { expected: latest_block.height() + 1, actual: block.height() });
+        }
+        // Also ensure the round is valid, otherwise speculation on transactions will fail with a cryptic error.
+        if block.round() <= latest_block.round() {
+            return Err(CheckBlockError::InvalidRound { new: block.round(), previous: latest_block.round() });
         }
 
         // Ensure the solutions do not already exist.

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -148,7 +148,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.check_block_subdag_quorum(block)?;
 
         // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
-        self.check_block_subdag_atomicity(block)?;
+        self.check_block_subdag_atomicity(block, &latest_block)?;
 
         // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
         self.check_block_subdag_leaves(block, prefix)?;
@@ -253,6 +253,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 .ok_or(anyhow!("Failed to fetch committee lookback for round {penultimate_round}"))?
         };
 
+        // Get the latest epoch hash.
+        let latest_epoch_hash = match self.current_epoch_hash.read().as_ref() {
+            Some(epoch_hash) => *epoch_hash,
+            None => self.get_epoch_hash(latest_block.height())?,
+        };
+
         // Ensure the block is correct.
         let (expected_existing_solution_ids, expected_existing_transaction_ids) = block
             .verify(
@@ -261,7 +267,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 &previous_committee_lookback,
                 &committee_lookback,
                 self.puzzle(),
-                self.latest_epoch_hash()?,
+                latest_epoch_hash,
                 OffsetDateTime::now_utc().unix_timestamp(),
                 ratified_finalize_operations,
             )
@@ -403,7 +409,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Checks that the block subdag can not be split into multiple valid subdags.
     ///
     /// Called by [`Self::check_block_subdag`]
-    fn check_block_subdag_atomicity(&self, block: &Block<N>) -> Result<()> {
+    fn check_block_subdag_atomicity(&self, block: &Block<N>, latest_block: &Block<N>) -> Result<()> {
+        let latest_round = latest_block.round();
+
         // Returns `true` if there is a path from the previous certificate to the current certificate.
         fn is_linked<N: Network>(
             subdag: &Subdag<N>,
@@ -432,8 +440,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         };
 
         // Iterate over the rounds to find possible leader certificates.
-        for round in (self.latest_round().saturating_add(2)..=subdag.anchor_round().saturating_sub(2)).rev().step_by(2)
-        {
+        for round in (latest_round.saturating_add(2)..=subdag.anchor_round().saturating_sub(2)).rev().step_by(2) {
             // Retrieve the previous committee lookback.
             let previous_committee_lookback = self
                 .get_committee_lookback_for_round(round)?

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -203,15 +203,20 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         block: &Block<N>,
         rng: &mut R,
     ) -> Result<(), CheckBlockError<N>> {
-        let latest_block = self.current_block.read();
+        // Grab lock to the previous block here, to ensure it does not change mid-check.
+        let previous_block = self.current_block.read();
 
         // Ensure, again, that the ledger has not advanced yet. This prevents cryptic errors form appearing during the block check.
-        if block.height() != latest_block.height() + 1 {
-            return Err(CheckBlockError::InvalidHeight { expected: latest_block.height() + 1, actual: block.height() });
+        if block.height() != previous_block.height() + 1 {
+            return Err(CheckBlockError::InvalidHeight {
+                expected: previous_block.height() + 1,
+                actual: block.height(),
+            });
         }
+
         // Also ensure the round is valid, otherwise speculation on transactions will fail with a cryptic error.
-        if block.round() <= latest_block.round() {
-            return Err(CheckBlockError::InvalidRound { new: block.round(), previous: latest_block.round() });
+        if block.round() <= previous_block.round() {
+            return Err(CheckBlockError::InvalidRound { new: block.round(), previous: previous_block.round() });
         }
 
         // Ensure the solutions do not already exist.
@@ -235,7 +240,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         )?;
 
         // Ensure speculation over the unconfirmed transactions is correct and ensure each transaction is well-formed and unique.
-        let time_since_last_block = block.timestamp().saturating_sub(self.latest_timestamp());
+        let time_since_last_block = block.timestamp().saturating_sub(previous_block.timestamp());
         let ratified_finalize_operations = self.vm.check_speculate(
             state,
             time_since_last_block,
@@ -262,13 +267,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Get the latest epoch hash.
         let latest_epoch_hash = match self.current_epoch_hash.read().as_ref() {
             Some(epoch_hash) => *epoch_hash,
-            None => self.get_epoch_hash(latest_block.height())?,
+            None => self.get_epoch_hash(previous_block.height())?,
         };
 
         // Ensure the block is correct.
         let (expected_existing_solution_ids, expected_existing_transaction_ids) = block
             .verify(
-                &latest_block,
+                &previous_block,
                 self.latest_state_root(),
                 &previous_committee_lookback,
                 &committee_lookback,
@@ -286,7 +291,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 let prover_address = solution.address();
                 let num_accepted_solutions = *accepted_solutions.get(&prover_address).unwrap_or(&0);
                 // Check if the prover has reached their solution limit.
-                if self.is_solution_limit_reached(&prover_address, num_accepted_solutions) {
+                if self.is_solution_limit_reached_inner(&previous_block, &prover_address, num_accepted_solutions) {
                     return Err(CheckBlockError::SolutionLimitReached { prover_address });
                 }
                 // Track the already accepted solutions.

--- a/ledger/src/is_solution_limit_reached.rs
+++ b/ledger/src/is_solution_limit_reached.rs
@@ -83,12 +83,26 @@ pub fn maximum_allowed_solutions_per_epoch<N: Network>(prover_stake: u64, curren
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Returns the number of remaining solutions a prover can submit in the current epoch.
+    ///
+    /// # Locking
+    /// This function may deadlock if called while holding a write lock to the current block.
     pub fn num_remaining_solutions(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> u64 {
+        self.num_remaining_solutions_inner(&self.current_block.read(), prover_address, additional_solutions_in_block)
+    }
+
+    /// Internal version of [`Self::num_remaining_solutions`] to be used when already holding a lock to the current block.
+    pub(super) fn num_remaining_solutions_inner(
+        &self,
+        latest_block: &Block<N>,
+        prover_address: &Address<N>,
+        additional_solutions_in_block: u64,
+    ) -> u64 {
         // Fetch the prover's stake.
         let prover_stake = self.get_bonded_amount(prover_address).unwrap_or(0);
 
         // Determine the maximum number of solutions allowed based on this prover's stake.
-        let maximum_allowed_solutions = maximum_allowed_solutions_per_epoch::<N>(prover_stake, self.latest_timestamp());
+        let maximum_allowed_solutions =
+            maximum_allowed_solutions_per_epoch::<N>(prover_stake, latest_block.timestamp());
 
         // Fetch the number of solutions the prover has earned rewards for in the current epoch.
         let prover_num_solutions_in_epoch = *self.epoch_provers_cache.read().get(prover_address).unwrap_or(&0);
@@ -101,9 +115,23 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns `true` if the given prover address has reached their solution limit for the current epoch.
+    ///
+    /// # Locking
+    /// This function may deadlock if called while holding a write lock to the current block.
     pub fn is_solution_limit_reached(&self, prover_address: &Address<N>, additional_solutions_in_block: u64) -> bool {
+        self.is_solution_limit_reached_inner(&self.current_block.read(), prover_address, additional_solutions_in_block)
+    }
+
+    /// Internal version of [`Self::is_solution_limit_reached`] to be used when already holding a lock to the current block.
+    pub(super) fn is_solution_limit_reached_inner(
+        &self,
+        latest_block: &Block<N>,
+        prover_address: &Address<N>,
+        additional_solutions_in_block: u64,
+    ) -> bool {
         // Calculate the number of remaining solutions for the prover.
-        let num_remaining_solutions = self.num_remaining_solutions(prover_address, additional_solutions_in_block);
+        let num_remaining_solutions =
+            self.num_remaining_solutions_inner(latest_block, prover_address, additional_solutions_in_block);
 
         // If the number of remaining solutions is zero, the limit is reached.
         num_remaining_solutions == 0

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -133,8 +133,10 @@ pub struct InnerLedger<N: Network, C: ConsensusStorage<N>> {
     vm: VM<N, C>,
     /// The genesis block.
     genesis_block: Block<N>,
+
     /// The current epoch hash.
     current_epoch_hash: RwLock<Option<N::BlockHash>>,
+
     /// The committee resulting from all the on-chain staking activity.
     ///
     /// This includes any bonding and unbonding transactions in the latest block.
@@ -154,9 +156,10 @@ pub struct InnerLedger<N: Network, C: ConsensusStorage<N>> {
 
     /// The latest block that was added to the ledger.
     ///
-    /// This lock is also used as a way to prevent concurrent updates to the ledger, and to ensure that
-    /// the ledger does not advance while certain check happen.
+    /// This lock is also to ensure *atomicity* of calls to `[Ledger::advance`], i.e., to guarantee that
+    /// there cannot be multiple concurrent ledger advancements and that ledger state cannot be read while advancement happens.
     current_block: RwLock<Block<N>>,
+
     /// The recent committees of interest paired with their applicable rounds.
     ///
     /// Each entry consisting of a round `R` and a committee `C`,

--- a/synthesizer/src/vm/helpers/sequential_op.rs
+++ b/synthesizer/src/vm/helpers/sequential_op.rs
@@ -32,7 +32,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Sequentially process incoming operations.
             while let Ok(request) = request_rx.recv() {
                 let SequentialOperationRequest { op, response_tx } = request;
-                debug!("Sequentially processing operation '{op}'");
+                trace!("Sequentially processing operation '{op}'");
 
                 // Perform the queued operation.
                 let ret = match op {
@@ -54,7 +54,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
     /// Sends the given operation to the thread used for sequential processing.
     pub fn run_sequential_operation(&self, op: SequentialOperation<N>) -> Option<SequentialOperationResult<N>> {
-        debug!("Queuing operation '{op}' for sequential processing");
+        trace!("Queuing operation '{op}' for sequential processing");
 
         // Prepare a oneshot channel to obtain the result of the queued operation.
         let (response_tx, response_rx) = oneshot::channel();


### PR DESCRIPTION
This will avoid certain race conditions when preparing a block template. 

Concretely, in the current design the following is possible:
* There is a thread t that calls `Ledger::prepare_next_beacon_block` which reads the value of `current_block`
* There is another thread t' that calls `Ledger::advance_to_next_block`, which updates `current_block` and the state root.
* If t now continues execution and reads the state root, it will return a block and not an error, but the block will be invalid, i.e. the state root is incorrect.

This is problematic for two reasons:
* `Ledger` implements `Sync`, which implies concurrent calls to its functions should be executed atomically and not read partial/inconsistent data.
* Such invalid blocks are harder to catch on the snarkOS side, as they appear to have the correct height and inconsistencies in the state root will be detected only later when the block is executed.

While this PR will ensure calls to the `Ledger` are atomic (formally, the Ledger being _linearizable_), it does not ensure that multiple calls to these functions do not interleave in unintended ways (formally, _serializable_). The latter is implemented in snarkOS and out of the scope of snarkVM, while the former makes the implementation for in snarkOS a lot easier. 

P.S.: There is this [great blog post by Peter Bailis](http://www.bailis.org/blog/linearizability-versus-serializability/) describing the two formal guarantees mentioned in the previous paragraph, in case you want to learn more about the formalism behind it. 

### Other minor changes
The PR also reduces log verbosity for sequential operations, as they add a decent amount of noise otherwise.