### PR TITLE
[Feature] Fallback URL for parameter files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1082,7 +1082,7 @@ jobs:
           name:  Check for security vulnerabilities
           no_output_timeout: 10m
           command: |
-            cargo install cargo-audit@0.21.2 --locked
+            cargo install cargo-audit@0.22.0--locked
             cargo audit -D warnings
       - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-cargo-audit-cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,22 +153,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -227,7 +227,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -369,9 +369,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bzip2-sys"
@@ -391,9 +391,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -494,7 +494,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -560,7 +560,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "log",
  "serde",
  "serde_derive",
@@ -791,7 +791,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -942,7 +942,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "flate2"
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1249,7 +1249,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1339,12 +1339,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1379,9 +1378,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1433,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -1505,9 +1504,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1519,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -1571,12 +1570,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "rayon",
  "serde",
  "serde_core",
@@ -1590,9 +1589,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1624,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -1640,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1674,9 +1673,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libloading"
@@ -1685,7 +1684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1696,9 +1695,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -1777,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -1787,7 +1786,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1833,9 +1832,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -1859,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -1934,7 +1933,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2016,7 +2015,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2057,7 +2056,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2126,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "potential_utf"
@@ -2161,14 +2160,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2377,9 +2376,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -2485,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
@@ -2498,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
@@ -2513,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
@@ -2563,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -2666,21 +2665,21 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2701,7 +2700,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "ryu",
  "serde",
@@ -2730,7 +2729,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -2771,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_moving_average"
@@ -2846,7 +2845,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -2929,7 +2928,7 @@ name = "snarkvm-circuit-environment"
 version = "4.4.0"
 dependencies = [
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -3122,7 +3121,7 @@ version = "4.4.0"
 dependencies = [
  "aleo-std",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde",
  "snarkvm-console-algorithms",
@@ -3136,7 +3135,7 @@ version = "4.4.0"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "lazy_static",
  "paste",
  "serde",
@@ -3174,7 +3173,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "num-derive",
  "num-traits",
  "seq-macro",
@@ -3290,7 +3289,6 @@ dependencies = [
  "bincode",
  "criterion",
  "rand 0.8.5",
- "rayon",
  "rustc_version",
  "serde",
  "snarkvm-fields",
@@ -3325,7 +3323,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru",
  "parking_lot",
@@ -3372,7 +3370,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -3399,7 +3397,7 @@ version = "4.4.0"
 dependencies = [
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3432,7 +3430,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.4.0"
 dependencies = [
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3446,7 +3444,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.4.0"
 dependencies = [
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3472,7 +3470,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.4.0"
 dependencies = [
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -3514,7 +3512,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru",
  "parking_lot",
@@ -3534,7 +3532,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru",
  "parking_lot",
@@ -3573,7 +3571,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3661,7 +3659,7 @@ dependencies = [
  "bincode",
  "criterion",
  "hex",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "k256",
  "locktick",
@@ -3702,7 +3700,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "criterion",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3730,7 +3728,7 @@ dependencies = [
  "bincode",
  "criterion",
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "k256",
  "paste",
  "rand 0.8.5",
@@ -3799,7 +3797,7 @@ version = "4.4.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3859,7 +3857,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3870,7 +3868,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3903,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -3938,7 +3936,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -3964,14 +3962,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -3984,7 +3982,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4013,7 +4011,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4024,7 +4022,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4122,9 +4120,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -4156,9 +4154,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4193,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -4223,9 +4221,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4234,20 +4232,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4266,9 +4264,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4300,7 +4298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4373,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64",
  "http",
@@ -4385,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4476,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4489,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4502,9 +4500,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote 1.0.42",
  "wasm-bindgen-macro-support",
@@ -4512,34 +4510,42 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -4547,20 +4553,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4568,9 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4594,7 +4600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "winsafe",
 ]
 
@@ -4631,43 +4637,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4703,7 +4703,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4728,7 +4728,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4872,28 +4872,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4913,7 +4913,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
  "synstructure",
 ]
 
@@ -4928,13 +4928,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -4967,5 +4967,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.113",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb2c125bd7365735bebeb420ccb880265ed2d2bddcbcd49f597fdfe6bd5e577"

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -42,6 +42,9 @@ use std::{borrow::Cow, fmt};
 
 use anyhow::{Result, ensure};
 
+#[cfg(feature = "serial")]
+use itertools::Itertools;
+
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -69,17 +69,22 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                     .iter()
                     .zip(circuit_rand_assignments)
                     .enumerate()
-                    .map(|(_i, (instance, rand_assignments))| {
+                    .map(|(i, (instance, rand_assignments))| {
                         let constraint_time = start_timer!(|| format!(
-                            "Generating constraints and witnesses for {:?} and index {_i}",
+                            "Generating constraints and witnesses for {:?} and index {i}",
                             circuit.id
                         ));
+
+                        // i may not be used if the timer feature is disabled.
+                        #[allow(unused_variables)]
+                        let _ = i;
+
                         let mut pcs = prover::ConstraintSystem::new();
                         instance.generate_constraints(&mut pcs)?;
                         end_timer!(constraint_time);
 
                         let padding_time =
-                            start_timer!(|| format!("Padding matrices for {:?} and index {_i}", circuit.id));
+                            start_timer!(|| format!("Padding matrices for {:?} and index {i}", circuit.id));
 
                         SM::ZK.then(|| {
                             crate::snark::varuna::ahp::matrices::add_randomizing_variables::<_, _>(
@@ -120,7 +125,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 
                         Self::formatted_public_input_is_admissible(&padded_public_variables)?;
 
-                        let eval_z_a_time = start_timer!(|| format!("For {:?}, evaluating z_A_{_i}", circuit.id));
+                        let eval_z_a_time = start_timer!(|| format!("For {:?}, evaluating z_A_{i}", circuit.id));
                         let z_a = circuit
                             .a
                             .iter()
@@ -130,7 +135,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                             .collect();
                         end_timer!(eval_z_a_time);
 
-                        let eval_z_b_time = start_timer!(|| format!("For {:?}, evaluating z_B_{_i}", circuit.id));
+                        let eval_z_b_time = start_timer!(|| format!("For {:?}, evaluating z_B_{i}", circuit.id));
                         let z_b = circuit
                             .b
                             .iter()
@@ -140,7 +145,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                             .collect();
                         end_timer!(eval_z_b_time);
 
-                        let eval_z_c_time = start_timer!(|| format!("For {:?}, evaluating z_C_{_i}", circuit.id));
+                        let eval_z_c_time = start_timer!(|| format!("For {:?}, evaluating z_C_{i}", circuit.id));
                         let z_c = circuit
                             .c
                             .iter()

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -272,13 +272,18 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                     .iter()
                     .zip_eq(x_polys)
                     .enumerate()
-                    .map(|(_j, (w_poly, x_poly))| {
-                        let z_time = start_timer!(move || format!("Compute z poly for circuit {} {}", circuit.id, _j));
+                    .map(|(j, (w_poly, x_poly))| {
+                        let z_time = start_timer!(move || format!("Compute z poly for circuit {} {}", circuit.id, j));
+
                         let mut assignment =
                             w_poly.0.polynomial().as_dense().unwrap().mul_by_vanishing_poly(*input_domain);
                         // Zip safety: `x_poly` is smaller than `z_poly`.
                         assignment.coeffs.iter_mut().zip(&x_poly.coeffs).for_each(|(z, x)| *z += x);
                         end_timer!(z_time);
+                        // j may not be used if the timer feature is disabled.
+                        #[allow(unused_variables)]
+                        let _ = j;
+                        // return the assignment
                         assignment
                     })
                     .collect();

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -44,9 +44,6 @@ workspace = true
 [dependencies.rand]
 workspace = true
 
-[dependencies.rayon]
-workspace = true
-
 [dependencies.serde]
 workspace = true
 features = [ "derive" ]

--- a/parameters/src/canary/mod.rs
+++ b/parameters/src/canary/mod.rs
@@ -19,100 +19,100 @@ pub use genesis::*;
 /// The restrictions list as a JSON-compatible string.
 pub const RESTRICTIONS_LIST: &str = include_str!("./resources/restrictions.json");
 
-const REMOTE_URL: &str = "https://parameters.provable.com/canary";
+const REMOTE_URLS: [&str; 2] = ["https://parameters.provable.com/canary", "https://s3.us-west-1.amazonaws.com/canary.parameters"];
 
 // BondPublic
-impl_remote!(BondPublicProver, REMOTE_URL, "resources/", "bond_public", "prover", "credits");
+impl_remote!(BondPublicProver, REMOTE_URLS, "resources/", "bond_public", "prover", "credits");
 impl_local!(BondPublicVerifier, "resources/", "bond_public", "verifier", "credits");
 // BondValidator
-impl_remote!(BondValidatorProver, REMOTE_URL, "resources/", "bond_validator", "prover", "credits");
+impl_remote!(BondValidatorProver, REMOTE_URLS, "resources/", "bond_validator", "prover", "credits");
 impl_local!(BondValidatorVerifier, "resources/", "bond_validator", "verifier", "credits");
 // UnbondPublic
-impl_remote!(UnbondPublicProver, REMOTE_URL, "resources/", "unbond_public", "prover", "credits");
+impl_remote!(UnbondPublicProver, REMOTE_URLS, "resources/", "unbond_public", "prover", "credits");
 impl_local!(UnbondPublicVerifier, "resources/", "unbond_public", "verifier", "credits");
 // ClaimUnbondPublic
-impl_remote!(ClaimUnbondPublicProver, REMOTE_URL, "resources/", "claim_unbond_public", "prover", "credits");
+impl_remote!(ClaimUnbondPublicProver, REMOTE_URLS, "resources/", "claim_unbond_public", "prover", "credits");
 impl_local!(ClaimUnbondPublicVerifier, "resources/", "claim_unbond_public", "verifier", "credits");
 // SetValidatorState
-impl_remote!(SetValidatorStateProver, REMOTE_URL, "resources/", "set_validator_state", "prover", "credits");
+impl_remote!(SetValidatorStateProver, REMOTE_URLS, "resources/", "set_validator_state", "prover", "credits");
 impl_local!(SetValidatorStateVerifier, "resources/", "set_validator_state", "verifier", "credits");
 // TransferPrivate
-impl_remote!(TransferPrivateProver, REMOTE_URL, "resources/", "transfer_private", "prover", "credits");
+impl_remote!(TransferPrivateProver, REMOTE_URLS, "resources/", "transfer_private", "prover", "credits");
 impl_local!(TransferPrivateVerifier, "resources/", "transfer_private", "verifier", "credits");
 // TransferPublic
-impl_remote!(TransferPublicProver, REMOTE_URL, "resources/", "transfer_public", "prover", "credits");
+impl_remote!(TransferPublicProver, REMOTE_URLS, "resources/", "transfer_public", "prover", "credits");
 impl_local!(TransferPublicVerifier, "resources/", "transfer_public", "verifier", "credits");
 // TransferPublicAsSigner
-impl_remote!(TransferPublicAsSignerProver, REMOTE_URL, "resources/", "transfer_public_as_signer", "prover", "credits");
+impl_remote!(TransferPublicAsSignerProver, REMOTE_URLS, "resources/", "transfer_public_as_signer", "prover", "credits");
 impl_local!(TransferPublicAsSignerVerifier, "resources/", "transfer_public_as_signer", "verifier", "credits");
 // TransferPrivateToPublic
-impl_remote!(TransferPrivateToPublicProver, REMOTE_URL, "resources/", "transfer_private_to_public", "prover", "credits");
+impl_remote!(TransferPrivateToPublicProver, REMOTE_URLS, "resources/", "transfer_private_to_public", "prover", "credits");
 impl_local!(TransferPrivateToPublicVerifier, "resources/", "transfer_private_to_public", "verifier", "credits");
 // TransferPublicToPrivate
-impl_remote!(TransferPublicToPrivateProver, REMOTE_URL, "resources/", "transfer_public_to_private", "prover", "credits");
+impl_remote!(TransferPublicToPrivateProver, REMOTE_URLS, "resources/", "transfer_public_to_private", "prover", "credits");
 impl_local!(TransferPublicToPrivateVerifier, "resources/", "transfer_public_to_private", "verifier", "credits");
 // Join
-impl_remote!(JoinProver, REMOTE_URL, "resources/", "join", "prover", "credits");
+impl_remote!(JoinProver, REMOTE_URLS, "resources/", "join", "prover", "credits");
 impl_local!(JoinVerifier, "resources/", "join", "verifier", "credits");
 // Split
-impl_remote!(SplitProver, REMOTE_URL, "resources/", "split", "prover", "credits");
+impl_remote!(SplitProver, REMOTE_URLS, "resources/", "split", "prover", "credits");
 impl_local!(SplitVerifier, "resources/", "split", "verifier", "credits");
 // FeePrivate
-impl_remote!(FeePrivateProver, REMOTE_URL, "resources/", "fee_private", "prover", "credits");
+impl_remote!(FeePrivateProver, REMOTE_URLS, "resources/", "fee_private", "prover", "credits");
 impl_local!(FeePrivateVerifier, "resources/", "fee_private", "verifier", "credits");
 // FeePublic
-impl_remote!(FeePublicProver, REMOTE_URL, "resources/", "fee_public", "prover", "credits");
+impl_remote!(FeePublicProver, REMOTE_URLS, "resources/", "fee_public", "prover", "credits");
 impl_local!(FeePublicVerifier, "resources/", "fee_public", "verifier", "credits");
 // Upgrade
-impl_remote!(UpgradeProver, REMOTE_URL, "resources/", "upgrade", "prover", "credits");
+impl_remote!(UpgradeProver, REMOTE_URLS, "resources/", "upgrade", "prover", "credits");
 impl_local!(UpgradeVerifier, "resources/", "upgrade", "verifier", "credits");
 
 // V0 Credits Keys
 
 // BondPublic
-impl_remote!(BondPublicV0Prover, REMOTE_URL, "resources/", "bond_public", "prover", "credits_v0");
+impl_remote!(BondPublicV0Prover, REMOTE_URLS, "resources/", "bond_public", "prover", "credits_v0");
 impl_local!(BondPublicV0Verifier, "resources/", "bond_public", "verifier", "credits_v0");
 // BondValidator
-impl_remote!(BondValidatorV0Prover, REMOTE_URL, "resources/", "bond_validator", "prover", "credits_v0");
+impl_remote!(BondValidatorV0Prover, REMOTE_URLS, "resources/", "bond_validator", "prover", "credits_v0");
 impl_local!(BondValidatorV0Verifier, "resources/", "bond_validator", "verifier", "credits_v0");
 // UnbondPublic
-impl_remote!(UnbondPublicV0Prover, REMOTE_URL, "resources/", "unbond_public", "prover", "credits_v0");
+impl_remote!(UnbondPublicV0Prover, REMOTE_URLS, "resources/", "unbond_public", "prover", "credits_v0");
 impl_local!(UnbondPublicV0Verifier, "resources/", "unbond_public", "verifier", "credits_v0");
 // ClaimUnbondPublic
-impl_remote!(ClaimUnbondPublicV0Prover, REMOTE_URL, "resources/", "claim_unbond_public", "prover", "credits_v0");
+impl_remote!(ClaimUnbondPublicV0Prover, REMOTE_URLS, "resources/", "claim_unbond_public", "prover", "credits_v0");
 impl_local!(ClaimUnbondPublicV0Verifier, "resources/", "claim_unbond_public", "verifier", "credits_v0");
 // SetValidatorState
-impl_remote!(SetValidatorStateV0Prover, REMOTE_URL, "resources/", "set_validator_state", "prover", "credits_v0");
+impl_remote!(SetValidatorStateV0Prover, REMOTE_URLS, "resources/", "set_validator_state", "prover", "credits_v0");
 impl_local!(SetValidatorStateV0Verifier, "resources/", "set_validator_state", "verifier", "credits_v0");
 // TransferPrivate
-impl_remote!(TransferPrivateV0Prover, REMOTE_URL, "resources/", "transfer_private", "prover", "credits_v0");
+impl_remote!(TransferPrivateV0Prover, REMOTE_URLS, "resources/", "transfer_private", "prover", "credits_v0");
 impl_local!(TransferPrivateV0Verifier, "resources/", "transfer_private", "verifier", "credits_v0");
 // TransferPublic
-impl_remote!(TransferPublicV0Prover, REMOTE_URL, "resources/", "transfer_public", "prover", "credits_v0");
+impl_remote!(TransferPublicV0Prover, REMOTE_URLS, "resources/", "transfer_public", "prover", "credits_v0");
 impl_local!(TransferPublicV0Verifier, "resources/", "transfer_public", "verifier", "credits_v0");
 // TransferPublicAsSigner
-impl_remote!(TransferPublicAsSignerV0Prover, REMOTE_URL, "resources/", "transfer_public_as_signer", "prover", "credits_v0");
+impl_remote!(TransferPublicAsSignerV0Prover, REMOTE_URLS, "resources/", "transfer_public_as_signer", "prover", "credits_v0");
 impl_local!(TransferPublicAsSignerV0Verifier, "resources/", "transfer_public_as_signer", "verifier", "credits_v0");
 // TransferPrivateToPublic
-impl_remote!(TransferPrivateToPublicV0Prover, REMOTE_URL, "resources/", "transfer_private_to_public", "prover", "credits_v0");
+impl_remote!(TransferPrivateToPublicV0Prover, REMOTE_URLS, "resources/", "transfer_private_to_public", "prover", "credits_v0");
 impl_local!(TransferPrivateToPublicV0Verifier, "resources/", "transfer_private_to_public", "verifier", "credits_v0");
 // TransferPublicToPrivate
-impl_remote!(TransferPublicToPrivateV0Prover, REMOTE_URL, "resources/", "transfer_public_to_private", "prover", "credits_v0");
+impl_remote!(TransferPublicToPrivateV0Prover, REMOTE_URLS, "resources/", "transfer_public_to_private", "prover", "credits_v0");
 impl_local!(TransferPublicToPrivateV0Verifier, "resources/", "transfer_public_to_private", "verifier", "credits_v0");
 // Join
-impl_remote!(JoinV0Prover, REMOTE_URL, "resources/", "join", "prover", "credits_v0");
+impl_remote!(JoinV0Prover, REMOTE_URLS, "resources/", "join", "prover", "credits_v0");
 impl_local!(JoinV0Verifier, "resources/", "join", "verifier", "credits_v0");
 // Split
-impl_remote!(SplitV0Prover, REMOTE_URL, "resources/", "split", "prover", "credits_v0");
+impl_remote!(SplitV0Prover, REMOTE_URLS, "resources/", "split", "prover", "credits_v0");
 impl_local!(SplitV0Verifier, "resources/", "split", "verifier", "credits_v0");
 // FeePrivate
-impl_remote!(FeePrivateV0Prover, REMOTE_URL, "resources/", "fee_private", "prover", "credits_v0");
+impl_remote!(FeePrivateV0Prover, REMOTE_URLS, "resources/", "fee_private", "prover", "credits_v0");
 impl_local!(FeePrivateV0Verifier, "resources/", "fee_private", "verifier", "credits_v0");
 // FeePublic
-impl_remote!(FeePublicV0Prover, REMOTE_URL, "resources/", "fee_public", "prover", "credits_v0");
+impl_remote!(FeePublicV0Prover, REMOTE_URLS, "resources/", "fee_public", "prover", "credits_v0");
 impl_local!(FeePublicV0Verifier, "resources/", "fee_public", "verifier", "credits_v0");
 // Upgrade
-impl_remote!(UpgradeV0Prover, REMOTE_URL, "resources/", "upgrade", "prover", "credits_v0");
+impl_remote!(UpgradeV0Prover, REMOTE_URLS, "resources/", "upgrade", "prover", "credits_v0");
 impl_local!(UpgradeV0Verifier, "resources/", "upgrade", "verifier", "credits_v0");
 
 #[macro_export]
@@ -176,9 +176,9 @@ macro_rules! insert_canary_key {
 }
 
 // Inclusion
-impl_remote!(InclusionV0Prover, REMOTE_URL, "resources/", "inclusion", "prover", "credits_v0");
+impl_remote!(InclusionV0Prover, REMOTE_URLS, "resources/", "inclusion", "prover", "credits_v0");
 impl_local!(InclusionV0Verifier, "resources/", "inclusion", "verifier", "credits_v0");
-impl_remote!(InclusionProver, REMOTE_URL, "resources/", "inclusion", "prover", "credits");
+impl_remote!(InclusionProver, REMOTE_URLS, "resources/", "inclusion", "prover", "credits");
 impl_local!(InclusionVerifier, "resources/", "inclusion", "verifier", "credits");
 
 /// The function name for the inclusion circuit.

--- a/parameters/src/errors/parameter.rs
+++ b/parameters/src/errors/parameter.rs
@@ -42,7 +42,7 @@ pub enum ParameterError {
 #[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))]
 impl From<curl::Error> for ParameterError {
     fn from(error: curl::Error) -> Self {
-        ParameterError::Crate("curl::error", format!("{error:?}"))
+        ParameterError::Crate("curl::error", error.description().to_string())
     }
 }
 

--- a/parameters/src/macros.rs
+++ b/parameters/src/macros.rs
@@ -83,6 +83,10 @@ macro_rules! impl_store_and_remote_fetch {
 
                 easy.progress(true)?;
                 easy.progress_function(|total_download, current_download, _, _| {
+                    // avoid division by zero.
+                    if total_download == 0.0 {
+                        return true;
+                    }
                     let percent = (current_download / total_download) * 100.0;
                     let size_in_megabytes = total_download as u64 / 1_048_576;
                     let output =
@@ -165,7 +169,7 @@ macro_rules! impl_load_bytes_logic_local {
 }
 
 macro_rules! impl_load_bytes_logic_remote {
-    ($remote_url: expr, $local_dir: expr, $filename: expr, $metadata: expr, $expected_checksum: expr, $expected_size: expr) => {
+    ($remote_urls: expr, $local_dir: expr, $filename: expr, $metadata: expr, $expected_checksum: expr, $expected_size: expr) => {
         cfg_if::cfg_if! {
             if #[cfg(all(feature = "filesystem", not(feature="wasm")))] {
                 // Compose the correct file path for the parameter file.
@@ -191,14 +195,52 @@ macro_rules! impl_load_bytes_logic_remote {
                     // Load remote file
                     cfg_if::cfg_if!{
                         if #[cfg(all(not(feature = "wasm"), not(target_env = "sgx")))] {
-                            let url = format!("{}/{}", $remote_url, $filename);
+                            // Try each URL in order, falling back to the next if one fails.
+                            let remote_urls: &[&str] = &$remote_urls;
                             let mut buffer = vec![];
-                            Self::remote_fetch(&mut buffer, &url)?;
+                            let mut last_error: Option<($crate::errors::ParameterError, &str)> = None;
 
-                            // Ensure the checksum matches.
-                            let candidate_checksum = checksum!(&buffer);
-                            if $expected_checksum != candidate_checksum {
-                                return checksum_error!($expected_checksum, candidate_checksum)
+                            for base_url in remote_urls.iter() {
+                                // Remove the previous error (if any).
+                                cfg_if::cfg_if!{
+                                    if #[cfg(feature = "no_std_out")] {
+                                        last_error = None;
+                                    } else {
+                                        use colored::Colorize;
+                                        // If this is a retry, print the previous error as warning.
+                                        if let Some((err, url)) = last_error.take() {
+                                            eprintln!("{:>15} - {err}", "Warning".yellow());
+                                            eprintln!("{:>15} - Failed to fetch from \"{url}\". Trying next source...", "Warning".yellow());
+                                         }
+                                    }
+                                }
+
+                                let url = format!("{}/{}", base_url, $filename);
+                                buffer.clear();
+
+                                match Self::remote_fetch(&mut buffer, &url) {
+                                    Ok(()) => {
+                                        // Ensure the checksum matches.
+                                        let candidate_checksum = checksum!(&buffer);
+                                        if $expected_checksum == candidate_checksum {
+                                            // Success - break out of the loop
+                                            break;
+                                        } else {
+                                            last_error = Some(($crate::errors::ParameterError::ChecksumMismatch(
+                                                $expected_checksum.to_string(),
+                                                candidate_checksum,
+                                            ), base_url));
+                                        }
+                                    }
+                                    Err(err) => {
+                                        last_error = Some((err, base_url));
+                                    }
+                                }
+                            }
+
+                            // If all URLs failed, return the last error.
+                            if let Some((err, _)) = last_error {
+                                return Err(err);
                             }
 
                             match Self::store_bytes(&buffer, &file_path) {
@@ -232,19 +274,43 @@ macro_rules! impl_load_bytes_logic_remote {
             } else {
                 cfg_if::cfg_if! {
                     if #[cfg(feature = "wasm")] {
-                        let url = format!("{}/{}", $remote_url, $filename);
-                        let buffer = Self::remote_fetch(&url)?;
+                        // Try each URL in order, falling back to the next if one fails.
+                        let remote_urls: &[&str] = &$remote_urls;
+                        let mut buffer = vec![];
+                        let mut last_error: Option<$crate::errors::ParameterError> = None;
+
+                        for base_url in remote_urls.iter() {
+                            let url = format!("{}/{}", base_url, $filename);
+
+                            match Self::remote_fetch(&url) {
+                                Ok(fetched_buffer) => {
+                                    // Ensure the checksum matches.
+                                    let candidate_checksum = checksum!(&fetched_buffer);
+                                    if $expected_checksum == candidate_checksum {
+                                        buffer = fetched_buffer;
+                                        last_error = None;
+                                        break;
+                                    } else {
+                                        last_error = Some($crate::errors::ParameterError::ChecksumMismatch(
+                                            $expected_checksum.to_string(),
+                                            candidate_checksum,
+                                        ));
+                                    }
+                                }
+                                Err(e) => {
+                                    last_error = Some(e);
+                                }
+                            }
+                        }
+
+                        // If all URLs failed, return the last error.
+                        if let Some(e) = last_error {
+                            return Err(e);
+                        }
 
                         // Ensure the size matches.
                         if $expected_size != buffer.len() {
-                            remove_file!(file_path);
                             return Err($crate::errors::ParameterError::SizeMismatch($expected_size, buffer.len()));
-                        }
-
-                        // Ensure the checksum matches.
-                        let candidate_checksum = checksum!(&buffer);
-                        if $expected_checksum != candidate_checksum {
-                            return checksum_error!($expected_checksum, candidate_checksum)
                         }
 
                         return Ok(buffer)
@@ -282,7 +348,10 @@ macro_rules! impl_local {
             #[cfg(test)]
             #[test]
             fn [< test_ $fname _usrs >]() {
-                assert!($name::load_bytes().is_ok());
+                // Print error messages if loading fails. This can be simplified once assert_matches! is stable.
+                if let Err(err) = $name::load_bytes() {
+                    panic!("Failed to load bytes: {err}");
+                }
             }
         }
     };
@@ -311,7 +380,9 @@ macro_rules! impl_local {
             #[cfg(test)]
             #[test]
             fn [< test_ $credits_version _ $fname _ $ftype >]() {
-                assert!($name::load_bytes().is_ok());
+                if let Err(err) = $name::load_bytes() {
+                    panic!("Failed to load bytes: {err}");
+                }
             }
         }
     };
@@ -400,7 +471,9 @@ macro_rules! impl_remote {
             #[cfg(test)]
             #[test]
             fn [< test_ $credits_version _ $fname _ $ftype >]() {
-                assert!($name::load_bytes().is_ok());
+                if let Err(err) = $name::load_bytes() {
+                    panic!("Failed to load bytes: {err}");
+                }
             }
         }
     };

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -22,50 +22,51 @@ pub use powers::*;
 /// The restrictions list as a JSON-compatible string.
 pub const RESTRICTIONS_LIST: &str = include_str!("./resources/restrictions.json");
 
-const REMOTE_URL: &str = "https://parameters.provable.com/mainnet";
+const REMOTE_URLS: [&str; 2] =
+    ["https://parameters.provable.com/mainnet", "https://s3.us-west-1.amazonaws.com/mainnet.parameters"];
 
 // Degrees
 impl_local!(Degree15, "resources/", "powers-of-beta-15", "usrs");
-impl_remote!(Degree16, REMOTE_URL, "resources/", "powers-of-beta-16", "usrs");
-impl_remote!(Degree17, REMOTE_URL, "resources/", "powers-of-beta-17", "usrs");
-impl_remote!(Degree18, REMOTE_URL, "resources/", "powers-of-beta-18", "usrs");
-impl_remote!(Degree19, REMOTE_URL, "resources/", "powers-of-beta-19", "usrs");
-impl_remote!(Degree20, REMOTE_URL, "resources/", "powers-of-beta-20", "usrs");
-impl_remote!(Degree21, REMOTE_URL, "resources/", "powers-of-beta-21", "usrs");
-impl_remote!(Degree22, REMOTE_URL, "resources/", "powers-of-beta-22", "usrs");
-impl_remote!(Degree23, REMOTE_URL, "resources/", "powers-of-beta-23", "usrs");
-impl_remote!(Degree24, REMOTE_URL, "resources/", "powers-of-beta-24", "usrs");
-impl_remote!(Degree25, REMOTE_URL, "resources/", "powers-of-beta-25", "usrs");
+impl_remote!(Degree16, REMOTE_URLS, "resources/", "powers-of-beta-16", "usrs");
+impl_remote!(Degree17, REMOTE_URLS, "resources/", "powers-of-beta-17", "usrs");
+impl_remote!(Degree18, REMOTE_URLS, "resources/", "powers-of-beta-18", "usrs");
+impl_remote!(Degree19, REMOTE_URLS, "resources/", "powers-of-beta-19", "usrs");
+impl_remote!(Degree20, REMOTE_URLS, "resources/", "powers-of-beta-20", "usrs");
+impl_remote!(Degree21, REMOTE_URLS, "resources/", "powers-of-beta-21", "usrs");
+impl_remote!(Degree22, REMOTE_URLS, "resources/", "powers-of-beta-22", "usrs");
+impl_remote!(Degree23, REMOTE_URLS, "resources/", "powers-of-beta-23", "usrs");
+impl_remote!(Degree24, REMOTE_URLS, "resources/", "powers-of-beta-24", "usrs");
+impl_remote!(Degree25, REMOTE_URLS, "resources/", "powers-of-beta-25", "usrs");
 // TODO (nkls): restore on CI.
 // The SRS is only used for proving and we don't currently support provers of
 // this size. When a users wants to create a proof, they load the appropriate
 // powers for the circuit in `batch_circuit_setup` which calls `max_degree`
 // based on the domain size.
 #[cfg(feature = "large_params")]
-impl_remote!(Degree26, REMOTE_URL, "resources/", "powers-of-beta-26", "usrs");
+impl_remote!(Degree26, REMOTE_URLS, "resources/", "powers-of-beta-26", "usrs");
 #[cfg(feature = "large_params")]
-impl_remote!(Degree27, REMOTE_URL, "resources/", "powers-of-beta-27", "usrs");
+impl_remote!(Degree27, REMOTE_URLS, "resources/", "powers-of-beta-27", "usrs");
 #[cfg(feature = "large_params")]
-impl_remote!(Degree28, REMOTE_URL, "resources/", "powers-of-beta-28", "usrs");
+impl_remote!(Degree28, REMOTE_URLS, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
 impl_local!(ShiftedDegree15, "resources/", "shifted-powers-of-beta-15", "usrs");
 impl_local!(ShiftedDegree16, "resources/", "shifted-powers-of-beta-16", "usrs");
-impl_remote!(ShiftedDegree17, REMOTE_URL, "resources/", "shifted-powers-of-beta-17", "usrs");
-impl_remote!(ShiftedDegree18, REMOTE_URL, "resources/", "shifted-powers-of-beta-18", "usrs");
-impl_remote!(ShiftedDegree19, REMOTE_URL, "resources/", "shifted-powers-of-beta-19", "usrs");
-impl_remote!(ShiftedDegree20, REMOTE_URL, "resources/", "shifted-powers-of-beta-20", "usrs");
-impl_remote!(ShiftedDegree21, REMOTE_URL, "resources/", "shifted-powers-of-beta-21", "usrs");
-impl_remote!(ShiftedDegree22, REMOTE_URL, "resources/", "shifted-powers-of-beta-22", "usrs");
-impl_remote!(ShiftedDegree23, REMOTE_URL, "resources/", "shifted-powers-of-beta-23", "usrs");
-impl_remote!(ShiftedDegree24, REMOTE_URL, "resources/", "shifted-powers-of-beta-24", "usrs");
-impl_remote!(ShiftedDegree25, REMOTE_URL, "resources/", "shifted-powers-of-beta-25", "usrs");
+impl_remote!(ShiftedDegree17, REMOTE_URLS, "resources/", "shifted-powers-of-beta-17", "usrs");
+impl_remote!(ShiftedDegree18, REMOTE_URLS, "resources/", "shifted-powers-of-beta-18", "usrs");
+impl_remote!(ShiftedDegree19, REMOTE_URLS, "resources/", "shifted-powers-of-beta-19", "usrs");
+impl_remote!(ShiftedDegree20, REMOTE_URLS, "resources/", "shifted-powers-of-beta-20", "usrs");
+impl_remote!(ShiftedDegree21, REMOTE_URLS, "resources/", "shifted-powers-of-beta-21", "usrs");
+impl_remote!(ShiftedDegree22, REMOTE_URLS, "resources/", "shifted-powers-of-beta-22", "usrs");
+impl_remote!(ShiftedDegree23, REMOTE_URLS, "resources/", "shifted-powers-of-beta-23", "usrs");
+impl_remote!(ShiftedDegree24, REMOTE_URLS, "resources/", "shifted-powers-of-beta-24", "usrs");
+impl_remote!(ShiftedDegree25, REMOTE_URLS, "resources/", "shifted-powers-of-beta-25", "usrs");
 // TODO (nkls): restore on CI.
 // See `Degree28` above for context.
 #[cfg(feature = "large_params")]
-impl_remote!(ShiftedDegree26, REMOTE_URL, "resources/", "shifted-powers-of-beta-26", "usrs");
+impl_remote!(ShiftedDegree26, REMOTE_URLS, "resources/", "shifted-powers-of-beta-26", "usrs");
 #[cfg(feature = "large_params")]
-impl_remote!(ShiftedDegree27, REMOTE_URL, "resources/", "shifted-powers-of-beta-27", "usrs");
+impl_remote!(ShiftedDegree27, REMOTE_URLS, "resources/", "shifted-powers-of-beta-27", "usrs");
 
 // Powers of Beta Times Gamma * G
 impl_local!(Gamma, "resources/", "powers-of-beta-gamma", "usrs");
@@ -75,97 +76,97 @@ impl_local!(NegBeta, "resources/", "neg-powers-of-beta", "usrs");
 impl_local!(BetaH, "resources/", "beta-h", "usrs");
 
 // BondPublic
-impl_remote!(BondPublicProver, REMOTE_URL, "resources/", "bond_public", "prover", "credits");
+impl_remote!(BondPublicProver, REMOTE_URLS, "resources/", "bond_public", "prover", "credits");
 impl_local!(BondPublicVerifier, "resources/", "bond_public", "verifier", "credits");
 // BondValidator
-impl_remote!(BondValidatorProver, REMOTE_URL, "resources/", "bond_validator", "prover", "credits");
+impl_remote!(BondValidatorProver, REMOTE_URLS, "resources/", "bond_validator", "prover", "credits");
 impl_local!(BondValidatorVerifier, "resources/", "bond_validator", "verifier", "credits");
 // UnbondPublic
-impl_remote!(UnbondPublicProver, REMOTE_URL, "resources/", "unbond_public", "prover", "credits");
+impl_remote!(UnbondPublicProver, REMOTE_URLS, "resources/", "unbond_public", "prover", "credits");
 impl_local!(UnbondPublicVerifier, "resources/", "unbond_public", "verifier", "credits");
 // ClaimUnbondPublic
-impl_remote!(ClaimUnbondPublicProver, REMOTE_URL, "resources/", "claim_unbond_public", "prover", "credits");
+impl_remote!(ClaimUnbondPublicProver, REMOTE_URLS, "resources/", "claim_unbond_public", "prover", "credits");
 impl_local!(ClaimUnbondPublicVerifier, "resources/", "claim_unbond_public", "verifier", "credits");
 // SetValidatorState
-impl_remote!(SetValidatorStateProver, REMOTE_URL, "resources/", "set_validator_state", "prover", "credits");
+impl_remote!(SetValidatorStateProver, REMOTE_URLS, "resources/", "set_validator_state", "prover", "credits");
 impl_local!(SetValidatorStateVerifier, "resources/", "set_validator_state", "verifier", "credits");
 // TransferPrivate
-impl_remote!(TransferPrivateProver, REMOTE_URL, "resources/", "transfer_private", "prover", "credits");
+impl_remote!(TransferPrivateProver, REMOTE_URLS, "resources/", "transfer_private", "prover", "credits");
 impl_local!(TransferPrivateVerifier, "resources/", "transfer_private", "verifier", "credits");
 // TransferPublic
-impl_remote!(TransferPublicProver, REMOTE_URL, "resources/", "transfer_public", "prover", "credits");
+impl_remote!(TransferPublicProver, REMOTE_URLS, "resources/", "transfer_public", "prover", "credits");
 impl_local!(TransferPublicVerifier, "resources/", "transfer_public", "verifier", "credits");
 // TransferPublicAsSigner
-impl_remote!(TransferPublicAsSignerProver, REMOTE_URL, "resources/", "transfer_public_as_signer", "prover", "credits");
+impl_remote!(TransferPublicAsSignerProver, REMOTE_URLS, "resources/", "transfer_public_as_signer", "prover", "credits");
 impl_local!(TransferPublicAsSignerVerifier, "resources/", "transfer_public_as_signer", "verifier", "credits");
 // TransferPrivateToPublic
-impl_remote!(TransferPrivateToPublicProver, REMOTE_URL, "resources/", "transfer_private_to_public", "prover", "credits");
+impl_remote!(TransferPrivateToPublicProver, REMOTE_URLS, "resources/", "transfer_private_to_public", "prover", "credits");
 impl_local!(TransferPrivateToPublicVerifier, "resources/", "transfer_private_to_public", "verifier", "credits");
 // TransferPublicToPrivate
-impl_remote!(TransferPublicToPrivateProver, REMOTE_URL, "resources/", "transfer_public_to_private", "prover", "credits");
+impl_remote!(TransferPublicToPrivateProver, REMOTE_URLS, "resources/", "transfer_public_to_private", "prover", "credits");
 impl_local!(TransferPublicToPrivateVerifier, "resources/", "transfer_public_to_private", "verifier", "credits");
 // Join
-impl_remote!(JoinProver, REMOTE_URL, "resources/", "join", "prover", "credits");
+impl_remote!(JoinProver, REMOTE_URLS, "resources/", "join", "prover", "credits");
 impl_local!(JoinVerifier, "resources/", "join", "verifier", "credits");
 // Split
-impl_remote!(SplitProver, REMOTE_URL, "resources/", "split", "prover", "credits");
+impl_remote!(SplitProver, REMOTE_URLS, "resources/", "split", "prover", "credits");
 impl_local!(SplitVerifier, "resources/", "split", "verifier", "credits");
 // FeePrivate
-impl_remote!(FeePrivateProver, REMOTE_URL, "resources/", "fee_private", "prover", "credits");
+impl_remote!(FeePrivateProver, REMOTE_URLS, "resources/", "fee_private", "prover", "credits");
 impl_local!(FeePrivateVerifier, "resources/", "fee_private", "verifier", "credits");
 // FeePublic
-impl_remote!(FeePublicProver, REMOTE_URL, "resources/", "fee_public", "prover", "credits");
+impl_remote!(FeePublicProver, REMOTE_URLS, "resources/", "fee_public", "prover", "credits");
 impl_local!(FeePublicVerifier, "resources/", "fee_public", "verifier", "credits");
 // Upgrade
-impl_remote!(UpgradeProver, REMOTE_URL, "resources/", "upgrade", "prover", "credits");
+impl_remote!(UpgradeProver, REMOTE_URLS, "resources/", "upgrade", "prover", "credits");
 impl_local!(UpgradeVerifier, "resources/", "upgrade", "verifier", "credits");
 
 // V0 Credits Keys
 
 // BondPublic
-impl_remote!(BondPublicV0Prover, REMOTE_URL, "resources/", "bond_public", "prover", "credits_v0");
+impl_remote!(BondPublicV0Prover, REMOTE_URLS, "resources/", "bond_public", "prover", "credits_v0");
 impl_local!(BondPublicV0Verifier, "resources/", "bond_public", "verifier", "credits_v0");
 // BondValidator
-impl_remote!(BondValidatorV0Prover, REMOTE_URL, "resources/", "bond_validator", "prover", "credits_v0");
+impl_remote!(BondValidatorV0Prover, REMOTE_URLS, "resources/", "bond_validator", "prover", "credits_v0");
 impl_local!(BondValidatorV0Verifier, "resources/", "bond_validator", "verifier", "credits_v0");
 // UnbondPublic
-impl_remote!(UnbondPublicV0Prover, REMOTE_URL, "resources/", "unbond_public", "prover", "credits_v0");
+impl_remote!(UnbondPublicV0Prover, REMOTE_URLS, "resources/", "unbond_public", "prover", "credits_v0");
 impl_local!(UnbondPublicV0Verifier, "resources/", "unbond_public", "verifier", "credits_v0");
 // ClaimUnbondPublic
-impl_remote!(ClaimUnbondPublicV0Prover, REMOTE_URL, "resources/", "claim_unbond_public", "prover", "credits_v0");
+impl_remote!(ClaimUnbondPublicV0Prover, REMOTE_URLS, "resources/", "claim_unbond_public", "prover", "credits_v0");
 impl_local!(ClaimUnbondPublicV0Verifier, "resources/", "claim_unbond_public", "verifier", "credits_v0");
 // SetValidatorState
-impl_remote!(SetValidatorStateV0Prover, REMOTE_URL, "resources/", "set_validator_state", "prover", "credits_v0");
+impl_remote!(SetValidatorStateV0Prover, REMOTE_URLS, "resources/", "set_validator_state", "prover", "credits_v0");
 impl_local!(SetValidatorStateV0Verifier, "resources/", "set_validator_state", "verifier", "credits_v0");
 // TransferPrivate
-impl_remote!(TransferPrivateV0Prover, REMOTE_URL, "resources/", "transfer_private", "prover", "credits_v0");
+impl_remote!(TransferPrivateV0Prover, REMOTE_URLS, "resources/", "transfer_private", "prover", "credits_v0");
 impl_local!(TransferPrivateV0Verifier, "resources/", "transfer_private", "verifier", "credits_v0");
 // TransferPublic
-impl_remote!(TransferPublicV0Prover, REMOTE_URL, "resources/", "transfer_public", "prover", "credits_v0");
+impl_remote!(TransferPublicV0Prover, REMOTE_URLS, "resources/", "transfer_public", "prover", "credits_v0");
 impl_local!(TransferPublicV0Verifier, "resources/", "transfer_public", "verifier", "credits_v0");
 // TransferPublicAsSigner
-impl_remote!(TransferPublicAsSignerV0Prover, REMOTE_URL, "resources/", "transfer_public_as_signer", "prover", "credits_v0");
+impl_remote!(TransferPublicAsSignerV0Prover, REMOTE_URLS, "resources/", "transfer_public_as_signer", "prover", "credits_v0");
 impl_local!(TransferPublicAsSignerV0Verifier, "resources/", "transfer_public_as_signer", "verifier", "credits_v0");
 // TransferPrivateToPublic
-impl_remote!(TransferPrivateToPublicV0Prover, REMOTE_URL, "resources/", "transfer_private_to_public", "prover", "credits_v0");
+impl_remote!(TransferPrivateToPublicV0Prover, REMOTE_URLS, "resources/", "transfer_private_to_public", "prover", "credits_v0");
 impl_local!(TransferPrivateToPublicV0Verifier, "resources/", "transfer_private_to_public", "verifier", "credits_v0");
 // TransferPublicToPrivate
-impl_remote!(TransferPublicToPrivateV0Prover, REMOTE_URL, "resources/", "transfer_public_to_private", "prover", "credits_v0");
+impl_remote!(TransferPublicToPrivateV0Prover, REMOTE_URLS, "resources/", "transfer_public_to_private", "prover", "credits_v0");
 impl_local!(TransferPublicToPrivateV0Verifier, "resources/", "transfer_public_to_private", "verifier", "credits_v0");
 // Join
-impl_remote!(JoinV0Prover, REMOTE_URL, "resources/", "join", "prover", "credits_v0");
+impl_remote!(JoinV0Prover, REMOTE_URLS, "resources/", "join", "prover", "credits_v0");
 impl_local!(JoinV0Verifier, "resources/", "join", "verifier", "credits_v0");
 // Split
-impl_remote!(SplitV0Prover, REMOTE_URL, "resources/", "split", "prover", "credits_v0");
+impl_remote!(SplitV0Prover, REMOTE_URLS, "resources/", "split", "prover", "credits_v0");
 impl_local!(SplitV0Verifier, "resources/", "split", "verifier", "credits_v0");
 // FeePrivate
-impl_remote!(FeePrivateV0Prover, REMOTE_URL, "resources/", "fee_private", "prover", "credits_v0");
+impl_remote!(FeePrivateV0Prover, REMOTE_URLS, "resources/", "fee_private", "prover", "credits_v0");
 impl_local!(FeePrivateV0Verifier, "resources/", "fee_private", "verifier", "credits_v0");
 // FeePublic
-impl_remote!(FeePublicV0Prover, REMOTE_URL, "resources/", "fee_public", "prover", "credits_v0");
+impl_remote!(FeePublicV0Prover, REMOTE_URLS, "resources/", "fee_public", "prover", "credits_v0");
 impl_local!(FeePublicV0Verifier, "resources/", "fee_public", "verifier", "credits_v0");
 // Upgrade
-impl_remote!(UpgradeV0Prover, REMOTE_URL, "resources/", "upgrade", "prover", "credits_v0");
+impl_remote!(UpgradeV0Prover, REMOTE_URLS, "resources/", "upgrade", "prover", "credits_v0");
 impl_local!(UpgradeV0Verifier, "resources/", "upgrade", "verifier", "credits_v0");
 
 #[macro_export]
@@ -229,9 +230,9 @@ macro_rules! insert_key {
 }
 
 // Inclusion
-impl_remote!(InclusionV0Prover, REMOTE_URL, "resources/", "inclusion", "prover", "credits_v0");
+impl_remote!(InclusionV0Prover, REMOTE_URLS, "resources/", "inclusion", "prover", "credits_v0");
 impl_local!(InclusionV0Verifier, "resources/", "inclusion", "verifier", "credits_v0");
-impl_remote!(InclusionProver, REMOTE_URL, "resources/", "inclusion", "prover", "credits");
+impl_remote!(InclusionProver, REMOTE_URLS, "resources/", "inclusion", "prover", "credits");
 impl_local!(InclusionVerifier, "resources/", "inclusion", "verifier", "credits");
 
 /// The function name for the inclusion circuit.

--- a/parameters/src/testnet/mod.rs
+++ b/parameters/src/testnet/mod.rs
@@ -19,100 +19,101 @@ pub use genesis::*;
 /// The restrictions list as a JSON-compatible string.
 pub const RESTRICTIONS_LIST: &str = include_str!("./resources/restrictions.json");
 
-const REMOTE_URL: &str = "https://parameters.provable.com/testnet";
+const REMOTE_URLS: [&str; 2] =
+    ["https://parameters.provable.com/testnet", "https://s3.us-west-1.amazonaws.com/testnet.parameters"];
 
 // BondPublic
-impl_remote!(BondPublicProver, REMOTE_URL, "resources/", "bond_public", "prover", "credits");
+impl_remote!(BondPublicProver, REMOTE_URLS, "resources/", "bond_public", "prover", "credits");
 impl_local!(BondPublicVerifier, "resources/", "bond_public", "verifier", "credits");
 // BondValidator
-impl_remote!(BondValidatorProver, REMOTE_URL, "resources/", "bond_validator", "prover", "credits");
+impl_remote!(BondValidatorProver, REMOTE_URLS, "resources/", "bond_validator", "prover", "credits");
 impl_local!(BondValidatorVerifier, "resources/", "bond_validator", "verifier", "credits");
 // UnbondPublic
-impl_remote!(UnbondPublicProver, REMOTE_URL, "resources/", "unbond_public", "prover", "credits");
+impl_remote!(UnbondPublicProver, REMOTE_URLS, "resources/", "unbond_public", "prover", "credits");
 impl_local!(UnbondPublicVerifier, "resources/", "unbond_public", "verifier", "credits");
 // ClaimUnbondPublic
-impl_remote!(ClaimUnbondPublicProver, REMOTE_URL, "resources/", "claim_unbond_public", "prover", "credits");
+impl_remote!(ClaimUnbondPublicProver, REMOTE_URLS, "resources/", "claim_unbond_public", "prover", "credits");
 impl_local!(ClaimUnbondPublicVerifier, "resources/", "claim_unbond_public", "verifier", "credits");
 // SetValidatorState
-impl_remote!(SetValidatorStateProver, REMOTE_URL, "resources/", "set_validator_state", "prover", "credits");
+impl_remote!(SetValidatorStateProver, REMOTE_URLS, "resources/", "set_validator_state", "prover", "credits");
 impl_local!(SetValidatorStateVerifier, "resources/", "set_validator_state", "verifier", "credits");
 // TransferPrivate
-impl_remote!(TransferPrivateProver, REMOTE_URL, "resources/", "transfer_private", "prover", "credits");
+impl_remote!(TransferPrivateProver, REMOTE_URLS, "resources/", "transfer_private", "prover", "credits");
 impl_local!(TransferPrivateVerifier, "resources/", "transfer_private", "verifier", "credits");
 // TransferPublic
-impl_remote!(TransferPublicProver, REMOTE_URL, "resources/", "transfer_public", "prover", "credits");
+impl_remote!(TransferPublicProver, REMOTE_URLS, "resources/", "transfer_public", "prover", "credits");
 impl_local!(TransferPublicVerifier, "resources/", "transfer_public", "verifier", "credits");
 // TransferPublicAsSigner
-impl_remote!(TransferPublicAsSignerProver, REMOTE_URL, "resources/", "transfer_public_as_signer", "prover", "credits");
+impl_remote!(TransferPublicAsSignerProver, REMOTE_URLS, "resources/", "transfer_public_as_signer", "prover", "credits");
 impl_local!(TransferPublicAsSignerVerifier, "resources/", "transfer_public_as_signer", "verifier", "credits");
 // TransferPrivateToPublic
-impl_remote!(TransferPrivateToPublicProver, REMOTE_URL, "resources/", "transfer_private_to_public", "prover", "credits");
+impl_remote!(TransferPrivateToPublicProver, REMOTE_URLS, "resources/", "transfer_private_to_public", "prover", "credits");
 impl_local!(TransferPrivateToPublicVerifier, "resources/", "transfer_private_to_public", "verifier", "credits");
 // TransferPublicToPrivate
-impl_remote!(TransferPublicToPrivateProver, REMOTE_URL, "resources/", "transfer_public_to_private", "prover", "credits");
+impl_remote!(TransferPublicToPrivateProver, REMOTE_URLS, "resources/", "transfer_public_to_private", "prover", "credits");
 impl_local!(TransferPublicToPrivateVerifier, "resources/", "transfer_public_to_private", "verifier", "credits");
 // Join
-impl_remote!(JoinProver, REMOTE_URL, "resources/", "join", "prover", "credits");
+impl_remote!(JoinProver, REMOTE_URLS, "resources/", "join", "prover", "credits");
 impl_local!(JoinVerifier, "resources/", "join", "verifier", "credits");
 // Split
-impl_remote!(SplitProver, REMOTE_URL, "resources/", "split", "prover", "credits");
+impl_remote!(SplitProver, REMOTE_URLS, "resources/", "split", "prover", "credits");
 impl_local!(SplitVerifier, "resources/", "split", "verifier", "credits");
 // FeePrivate
-impl_remote!(FeePrivateProver, REMOTE_URL, "resources/", "fee_private", "prover", "credits");
+impl_remote!(FeePrivateProver, REMOTE_URLS, "resources/", "fee_private", "prover", "credits");
 impl_local!(FeePrivateVerifier, "resources/", "fee_private", "verifier", "credits");
 // FeePublic
-impl_remote!(FeePublicProver, REMOTE_URL, "resources/", "fee_public", "prover", "credits");
+impl_remote!(FeePublicProver, REMOTE_URLS, "resources/", "fee_public", "prover", "credits");
 impl_local!(FeePublicVerifier, "resources/", "fee_public", "verifier", "credits");
 // Upgrade
-impl_remote!(UpgradeProver, REMOTE_URL, "resources/", "upgrade", "prover", "credits");
+impl_remote!(UpgradeProver, REMOTE_URLS, "resources/", "upgrade", "prover", "credits");
 impl_local!(UpgradeVerifier, "resources/", "upgrade", "verifier", "credits");
 
 // V0 Credits Keys
 
 // BondPublic
-impl_remote!(BondPublicV0Prover, REMOTE_URL, "resources/", "bond_public", "prover", "credits_v0");
+impl_remote!(BondPublicV0Prover, REMOTE_URLS, "resources/", "bond_public", "prover", "credits_v0");
 impl_local!(BondPublicV0Verifier, "resources/", "bond_public", "verifier", "credits_v0");
 // BondValidator
-impl_remote!(BondValidatorV0Prover, REMOTE_URL, "resources/", "bond_validator", "prover", "credits_v0");
+impl_remote!(BondValidatorV0Prover, REMOTE_URLS, "resources/", "bond_validator", "prover", "credits_v0");
 impl_local!(BondValidatorV0Verifier, "resources/", "bond_validator", "verifier", "credits_v0");
 // UnbondPublic
-impl_remote!(UnbondPublicV0Prover, REMOTE_URL, "resources/", "unbond_public", "prover", "credits_v0");
+impl_remote!(UnbondPublicV0Prover, REMOTE_URLS, "resources/", "unbond_public", "prover", "credits_v0");
 impl_local!(UnbondPublicV0Verifier, "resources/", "unbond_public", "verifier", "credits_v0");
 // ClaimUnbondPublic
-impl_remote!(ClaimUnbondPublicV0Prover, REMOTE_URL, "resources/", "claim_unbond_public", "prover", "credits_v0");
+impl_remote!(ClaimUnbondPublicV0Prover, REMOTE_URLS, "resources/", "claim_unbond_public", "prover", "credits_v0");
 impl_local!(ClaimUnbondPublicV0Verifier, "resources/", "claim_unbond_public", "verifier", "credits_v0");
 // SetValidatorState
-impl_remote!(SetValidatorStateV0Prover, REMOTE_URL, "resources/", "set_validator_state", "prover", "credits_v0");
+impl_remote!(SetValidatorStateV0Prover, REMOTE_URLS, "resources/", "set_validator_state", "prover", "credits_v0");
 impl_local!(SetValidatorStateV0Verifier, "resources/", "set_validator_state", "verifier", "credits_v0");
 // TransferPrivate
-impl_remote!(TransferPrivateV0Prover, REMOTE_URL, "resources/", "transfer_private", "prover", "credits_v0");
+impl_remote!(TransferPrivateV0Prover, REMOTE_URLS, "resources/", "transfer_private", "prover", "credits_v0");
 impl_local!(TransferPrivateV0Verifier, "resources/", "transfer_private", "verifier", "credits_v0");
 // TransferPublic
-impl_remote!(TransferPublicV0Prover, REMOTE_URL, "resources/", "transfer_public", "prover", "credits_v0");
+impl_remote!(TransferPublicV0Prover, REMOTE_URLS, "resources/", "transfer_public", "prover", "credits_v0");
 impl_local!(TransferPublicV0Verifier, "resources/", "transfer_public", "verifier", "credits_v0");
 // TransferPublicAsSigner
-impl_remote!(TransferPublicAsSignerV0Prover, REMOTE_URL, "resources/", "transfer_public_as_signer", "prover", "credits_v0");
+impl_remote!(TransferPublicAsSignerV0Prover, REMOTE_URLS, "resources/", "transfer_public_as_signer", "prover", "credits_v0");
 impl_local!(TransferPublicAsSignerV0Verifier, "resources/", "transfer_public_as_signer", "verifier", "credits_v0");
 // TransferPrivateToPublic
-impl_remote!(TransferPrivateToPublicV0Prover, REMOTE_URL, "resources/", "transfer_private_to_public", "prover", "credits_v0");
+impl_remote!(TransferPrivateToPublicV0Prover, REMOTE_URLS, "resources/", "transfer_private_to_public", "prover", "credits_v0");
 impl_local!(TransferPrivateToPublicV0Verifier, "resources/", "transfer_private_to_public", "verifier", "credits_v0");
 // TransferPublicToPrivate
-impl_remote!(TransferPublicToPrivateV0Prover, REMOTE_URL, "resources/", "transfer_public_to_private", "prover", "credits_v0");
+impl_remote!(TransferPublicToPrivateV0Prover, REMOTE_URLS, "resources/", "transfer_public_to_private", "prover", "credits_v0");
 impl_local!(TransferPublicToPrivateV0Verifier, "resources/", "transfer_public_to_private", "verifier", "credits_v0");
 // Join
-impl_remote!(JoinV0Prover, REMOTE_URL, "resources/", "join", "prover", "credits_v0");
+impl_remote!(JoinV0Prover, REMOTE_URLS, "resources/", "join", "prover", "credits_v0");
 impl_local!(JoinV0Verifier, "resources/", "join", "verifier", "credits_v0");
 // Split
-impl_remote!(SplitV0Prover, REMOTE_URL, "resources/", "split", "prover", "credits_v0");
+impl_remote!(SplitV0Prover, REMOTE_URLS, "resources/", "split", "prover", "credits_v0");
 impl_local!(SplitV0Verifier, "resources/", "split", "verifier", "credits_v0");
 // FeePrivate
-impl_remote!(FeePrivateV0Prover, REMOTE_URL, "resources/", "fee_private", "prover", "credits_v0");
+impl_remote!(FeePrivateV0Prover, REMOTE_URLS, "resources/", "fee_private", "prover", "credits_v0");
 impl_local!(FeePrivateV0Verifier, "resources/", "fee_private", "verifier", "credits_v0");
 // FeePublic
-impl_remote!(FeePublicV0Prover, REMOTE_URL, "resources/", "fee_public", "prover", "credits_v0");
+impl_remote!(FeePublicV0Prover, REMOTE_URLS, "resources/", "fee_public", "prover", "credits_v0");
 impl_local!(FeePublicV0Verifier, "resources/", "fee_public", "verifier", "credits_v0");
 // Upgrade
-impl_remote!(UpgradeV0Prover, REMOTE_URL, "resources/", "upgrade", "prover", "credits_v0");
+impl_remote!(UpgradeV0Prover, REMOTE_URLS, "resources/", "upgrade", "prover", "credits_v0");
 impl_local!(UpgradeV0Verifier, "resources/", "upgrade", "verifier", "credits_v0");
 
 #[macro_export]
@@ -176,9 +177,9 @@ macro_rules! insert_testnet_key {
 }
 
 // Inclusion
-impl_remote!(InclusionV0Prover, REMOTE_URL, "resources/", "inclusion", "prover", "credits_v0");
+impl_remote!(InclusionV0Prover, REMOTE_URLS, "resources/", "inclusion", "prover", "credits_v0");
 impl_local!(InclusionV0Verifier, "resources/", "inclusion", "verifier", "credits_v0");
-impl_remote!(InclusionProver, REMOTE_URL, "resources/", "inclusion", "prover", "credits");
+impl_remote!(InclusionProver, REMOTE_URLS, "resources/", "inclusion", "prover", "credits");
 impl_local!(InclusionVerifier, "resources/", "inclusion", "verifier", "credits");
 
 /// The function name for the inclusion circuit.


### PR DESCRIPTION
The PR adds another URL to fetch parameters from. It also includes a few small commits to fix CI. 

### Testing

1. Rename the first entry of `REMOTE_URLS` in `parameters/src/canary.rs` to something like `broken.provable.com`.
2. Remove any cached parameter files `rm -rf ~/.aleo/resources/*` (double check that this is the correct location for your setup)
3. Run the test without output capture: `cargo test --package=snarkvm-parameters canary::test_credits_bond_public_prover -- --nocapture`

You will get the following output:
```
running 1 test

⚠️  "bond_public.prover.e2c9caa" does not exist. Downloading and storing it (in "/Users/kaimast/.aleo/resources/bond_public.prover.e2c9caa").

   Installation - Downloading "https://broken.provable.com/canary/bond_public.prover.e2c9caa"
        Warning - curl::error: Couldn't resolve host name
        Warning - Failed to fetch from "https://broken.provable.com/canary". Trying next source...
   Installation - Downloading "https://s3.us-west-1.amazonaws.com/canary.parameters/bond_public.prover.e2c9caa"
   Installation - 100.00% complete (27 MB total)   Installation - Storing file in "/Users/kaimast/.aleo/resources/bond_public.prover.e2c9caa"
test canary::test_credits_bond_public_prover ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 220 filtered out; finished in 1.46s
```