### PR TITLE
Reduce circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1205,16 +1205,15 @@ workflows:
       - synthesizer-process 
       - synthesizer-integration
       - synthesizer-program
-      - synthesizer-program-integration
       - synthesizer-snark
 
   snarkvm-workflow:
     jobs:
-      - snarkvm
       - algorithms
       - curves
       - fields
       - parameters
+      - snarkvm
       - utilities
       - utilities-derives
       - wasm
@@ -1229,18 +1228,26 @@ workflows:
       - ledger-with-rocksdb-partition1 # Often similar results as `ledger`
       - ledger-with-rocksdb-partition2 # Often similar results as `ledger`
       - synthesizer-process-with-rocksdb # Often similar results as `synthesizer-process`
-      - parameters-large # Infrastructure which often runs fine
-      - parameters-uncached # Infrastructure which often runs fine
-      - algorithms-profiler # Often similar results as `algorithms`
       - check-unused-dependencies # This can be cleaned up before releases
       - check-cargo-semver-checks # This can be cleaned up before releases
-      - synthesizer-program-integration-keccak # Expensive and rarely used
-      - synthesizer-program-integration-psd # Expensive and rarely used
-      - synthesizer-program-integration-sha # Expensive and rarely used
-      - synthesizer-program-integration-instruction-is # Expensive and rarely used
-      - synthesizer-program-integration-instruction-equal # Expensive and rarely used
-      - synthesizer-program-integration-instruction-commit # Expensive and rarely used
-      - verify-windows:
+      - synthesizer-program-integration # Expensive and rarely impacted
+      - synthesizer-program-integration-keccak # Expensive and rarely impacted
+      - synthesizer-program-integration-psd # Expensive and rarely impacted
+      - synthesizer-program-integration-sha # Expensive and rarely impacted
+      - synthesizer-program-integration-instruction-is # Expensive and rarely impacted
+      - synthesizer-program-integration-instruction-equal # Expensive and rarely impacted
+      - synthesizer-program-integration-instruction-commit # Expensive and rarely impacted
+
+  # Run additional but unlikely to fail checks on releases only
+  release-workflow:
+    when: pipeline.git.branch == "canary"
+      or pipeline.git.branch == "testnet"
+      or pipeline.git.branch == "mainnet"
+    jobs:
+      - algorithms-profiler # Just checks some non-critical profiling code
+      - parameters-large # Infrastructure which often runs fine
+      - parameters-uncached # Infrastructure which often runs fine
+      - verify-windows: # Windows has never failed us when linux passed
           matrix:
             parameters:
               workspace_member: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1138,6 +1138,7 @@ workflows:
     jobs:
       - check-fmt
       - check-clippy
+      - check-cargo-audit
       - check-all-targets
 
   circuit-workflow:
@@ -1179,8 +1180,6 @@ workflows:
   ledger-workflow:
     jobs:
       - ledger
-      - ledger-with-rocksdb-partition1
-      - ledger-with-rocksdb-partition2
       - ledger-with-valid-solutions
       - ledger-authority
       - ledger-block
@@ -1203,8 +1202,8 @@ workflows:
       - synthesizer
       - synthesizer-test-partition1
       - synthesizer-test-partition2
+      - synthesizer-process 
       - synthesizer-integration
-      - synthesizer-process-with-rocksdb
       - synthesizer-program
       - synthesizer-program-integration
       - synthesizer-snark
@@ -1220,25 +1219,27 @@ workflows:
       - utilities-derives
       - wasm
   
-  # Enable to run additional checks before releases
-  # prerelease-workflow:
-  #   jobs:
-  #     - synthesizer-process
-  #     - parameters-large
-  #     - parameters-uncached
-  #     - algorithms-profiler
-  #     - check-unused-dependencies
-  #     - check-cargo-audit
-  #     - check-cargo-semver-checks
-  #     - synthesizer-program-integration-keccak
-  #     - synthesizer-program-integration-psd
-  #     - synthesizer-program-integration-sha
-  #     - synthesizer-program-integration-instruction-is
-  #     - synthesizer-program-integration-instruction-equal
-  #     - synthesizer-program-integration-instruction-commit
-
-  windows-workflow:
+  # Run additional but unlikely to fail checks on merges only
+  merge-workflow:
+    when: pipeline.git.branch == "staging"
+      or pipeline.git.branch == "canary"
+      or pipeline.git.branch == "testnet"
+      or pipeline.git.branch == "mainnet"
     jobs:
+      - ledger-with-rocksdb-partition1 # Often similar results as `ledger`
+      - ledger-with-rocksdb-partition2 # Often similar results as `ledger`
+      - synthesizer-process-with-rocksdb # Often similar results as `synthesizer-process`
+      - parameters-large # Infrastructure which often runs fine
+      - parameters-uncached # Infrastructure which often runs fine
+      - algorithms-profiler # Often similar results as `algorithms`
+      - check-unused-dependencies # This can be cleaned up before releases
+      - check-cargo-semver-checks # This can be cleaned up before releases
+      - synthesizer-program-integration-keccak # Expensive and rarely used
+      - synthesizer-program-integration-psd # Expensive and rarely used
+      - synthesizer-program-integration-sha # Expensive and rarely used
+      - synthesizer-program-integration-instruction-is # Expensive and rarely used
+      - synthesizer-program-integration-instruction-equal # Expensive and rarely used
+      - synthesizer-program-integration-instruction-commit # Expensive and rarely used
       - verify-windows:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,16 +444,6 @@ jobs:
       - run_test:
           workspace_member: snarkvm-circuit-account
 
-  # This checks that no `console` structs are used in core circuit logic.
-  circuit-account-noconsole:
-    executor: rust-docker
-    resource_class: << pipeline.parameters.small >>
-    steps:
-      - run_test:
-          workspace_member: snarkvm-circuit-account
-          cache_key_suffix: -noconsole
-          flags: --no-default-features
-
   circuit-algorithms:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
@@ -467,16 +457,6 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-circuit-collections
-
-  # This checks that no `console` structs are used in core circuit logic.
-  circuit-collections-noconsole:
-    executor: rust-docker
-    resource_class: << pipeline.parameters.xlarge >>
-    steps:
-      - run_test:
-          workspace_member: snarkvm-circuit-collections
-          cache_key_suffix: -noconsole
-          flags: --no-default-features
 
   circuit-environment:
     executor: rust-docker
@@ -1167,10 +1147,8 @@ workflows:
     jobs:
       - circuit
       - circuit-account
-      - circuit-account-noconsole
       - circuit-algorithms
       - circuit-collections
-      - circuit-collections-noconsole
       - circuit-environment
       - circuit-network
       - circuit-program

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1138,9 +1138,6 @@ workflows:
     jobs:
       - check-fmt
       - check-clippy
-      - check-unused-dependencies
-      - check-cargo-audit
-      - check-cargo-semver-checks
       - check-all-targets
 
   circuit-workflow:
@@ -1207,31 +1204,38 @@ workflows:
       - synthesizer-test-partition1
       - synthesizer-test-partition2
       - synthesizer-integration
-      - synthesizer-process
       - synthesizer-process-with-rocksdb
       - synthesizer-program
       - synthesizer-program-integration
-      - synthesizer-program-integration-keccak
-      - synthesizer-program-integration-psd
-      - synthesizer-program-integration-sha
-      - synthesizer-program-integration-instruction-is
-      - synthesizer-program-integration-instruction-equal
-      - synthesizer-program-integration-instruction-commit
       - synthesizer-snark
 
   snarkvm-workflow:
     jobs:
       - snarkvm
       - algorithms
-      - algorithms-profiler
       - curves
       - fields
       - parameters
-      - parameters-large
-      - parameters-uncached
       - utilities
       - utilities-derives
       - wasm
+  
+  # Enable to run additional checks before releases
+  # prerelease-workflow:
+  #   jobs:
+  #     - synthesizer-process
+  #     - parameters-large
+  #     - parameters-uncached
+  #     - algorithms-profiler
+  #     - check-unused-dependencies
+  #     - check-cargo-audit
+  #     - check-cargo-semver-checks
+  #     - synthesizer-program-integration-keccak
+  #     - synthesizer-program-integration-psd
+  #     - synthesizer-program-integration-sha
+  #     - synthesizer-program-integration-instruction-is
+  #     - synthesizer-program-integration-instruction-equal
+  #     - synthesizer-program-integration-instruction-commit
 
   windows-workflow:
     jobs:


### PR DESCRIPTION
## Motivation

To reduce costs, which are starting to get out of hand. 

Please review whether removing the noconsole jobs are fine, they seem:
(1) inaccurate, because we dó use Console stuff in Circuit crates
(2) not even unique because the two crates in question don't have custom features?

Two concurrent efforts are:
- migration to free but less performant github actions, this will take a lot longer to verify: https://github.com/ProvableHQ/snarkVM/pull/3074
- making tests more efficient: https://github.com/ProvableHQ/snarkVM/pull/3058