### PR TITLE
[Perf] Optimize rayon use in apply_butterfly

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -684,7 +684,7 @@ impl<F: FftField> EvaluationDomain<F> {
             // we parallelize the butterfly operation within the chunk.
 
             if gap > MIN_GAP_SIZE_FOR_PARALLELISATION && num_chunks < max_threads {
-                cfg_iter_mut!(lo).zip(hi).zip(cfg_iter!(roots).step_by(step)).for_each(g);
+                cfg_iter_mut!(lo, 1000).zip(hi).zip(cfg_iter!(roots, 1000).step_by(step)).for_each(g);
             } else {
                 lo.iter_mut().zip(hi).zip(roots.iter().step_by(step)).for_each(g);
             }


### PR DESCRIPTION
A tiny follow-up to https://github.com/ProvableHQ/snarkVM/pull/3069.

It results in the following further boost across benchmarks (the ones not listed were unaffected):
```
snark_prove_v1          time:   [99.795 ms 100.06 ms 100.33 ms]
                        change: [−2.8872% −2.5405% −2.1681%] (p = 0.00 < 0.05)
                        Performance has improved.

snark_prove_v2          time:   [102.16 ms 102.41 ms 102.65 ms]
                        change: [−2.5415% −2.2223% −1.9024%] (p = 0.00 < 0.05)
                        Performance has improved.

Transaction::Deploy     time:   [2.8851 s 2.8984 s 2.9110 s]
                        change: [−3.5419% −2.8683% −2.1577%] (p = 0.00 < 0.05)
                        Performance has improved.

Transaction::Execute(transfer_public)
                        time:   [568.33 ms 570.67 ms 573.05 ms]
                        change: [−3.6799% −2.8802% −2.0589%] (p = 0.00 < 0.05)
                        Performance has improved.

Transaction::Execute(transfer_private)
                        time:   [2.7670 s 2.7800 s 2.7937 s]
                        change: [−2.6375% −2.0892% −1.5061%] (p = 0.00 < 0.05)
                        Performance has improved.

LimitedWriter::new - too_big.aleo
                        time:   [811.25 µs 813.09 µs 815.82 µs]
                        change: [−2.6791% −2.3878% −2.0930%] (p = 0.00 < 0.05)
                        Performance has improved.

Transaction::Execute(too_big.aleo) - verify
                        time:   [799.39 µs 802.03 µs 806.05 µs]
                        change: [−3.1293% −2.8469% −2.4781%] (p = 0.00 < 0.05)
                        Performance has improved.
```