### PR TITLE
feat: On instruction failure, return an error with the failing aleo instruction index (re-opened)

### DIFF
--- a/.circleci/semver-checks.sh
+++ b/.circleci/semver-checks.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-BASELINE_REV=acd55ad100550 # UPDATE ME ON NECESSARY BREAKING CHANGES
+BASELINE_REV=1d47c130fa9c2 # UPDATE ME ON NECESSARY BREAKING CHANGES
 
 # Ensure that the command is installed.
 cargo install cargo-semver-checks@0.43.0 --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,6 +3687,7 @@ dependencies = [
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
  "tempfile",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "walkdir",
@@ -3697,6 +3698,7 @@ name = "snarkvm-synthesizer-process"
 version = "4.4.0"
 dependencies = [
  "aleo-std",
+ "anyhow",
  "bincode",
  "colored 3.0.0",
  "criterion",
@@ -3719,6 +3721,7 @@ dependencies = [
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
  "tempfile",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -168,15 +168,14 @@ workspace = true
 [dependencies.rayon]
 workspace = true
 
+[dependencies.thiserror]
+workspace = true
+
 [dependencies.time]
 workspace = true
 
 [dependencies.tracing]
 workspace = true
-
-[dependencies.thiserror]
-workspace = true
-features = [ "std" ]
 
 [dev-dependencies.bincode]
 workspace = true

--- a/ledger/src/error.rs
+++ b/ledger/src/error.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm_synthesizer::{VmDeployError, VmExecError};
+use thiserror::Error;
+
+// NOTE: Many errors in this module temporarily contain `Anyhow` variants.
+// Remove these variants as we migrate errors to thiserror.
+
+/// Errors that may occur when creating a transfer transaction.
+#[derive(Debug, Error)]
+pub enum CreateTransferError {
+    /// VM execution failed.
+    #[error("VM execution failed: {0}")]
+    VmExec(#[from] VmExecError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur when creating a deploy transaction.
+#[derive(Debug, Error)]
+pub enum CreateDeployError {
+    /// VM deployment failed.
+    #[error("VM deployment failed: {0}")]
+    VmDeploy(#[from] VmDeployError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -32,6 +32,9 @@ pub use snarkvm_ledger_store as store;
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers;
 
+mod error;
+pub use error::*;
+
 mod helpers;
 pub use helpers::*;
 
@@ -477,17 +480,19 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         priority_fee_in_microcredits: u64,
         query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
-    ) -> Result<Transaction<N>> {
+    ) -> Result<Transaction<N>, CreateDeployError> {
         // Fetch the unspent records.
         let records = self.find_unspent_credits_records(&ViewKey::try_from(private_key)?)?;
-        ensure!(!records.len().is_zero(), "The Aleo account has no records to spend.");
+        if records.len().is_zero() {
+            return Err(anyhow!("The Aleo account has no records to spend.").into());
+        }
         let mut records = records.values();
 
         // Prepare the fee record.
         let fee_record = Some(records.next().unwrap().clone());
 
         // Create a new deploy transaction.
-        self.vm.deploy(private_key, program, fee_record, priority_fee_in_microcredits, query, rng)
+        Ok(self.vm.deploy(private_key, program, fee_record, priority_fee_in_microcredits, query, rng)?)
     }
 
     /// Creates a transfer transaction.
@@ -501,10 +506,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         priority_fee_in_microcredits: u64,
         query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
-    ) -> Result<Transaction<N>> {
+    ) -> Result<Transaction<N>, CreateTransferError> {
         // Fetch the unspent records.
         let records = self.find_unspent_credits_records(&ViewKey::try_from(private_key)?)?;
-        ensure!(records.len() >= 2, "The Aleo account does not have enough records to spend.");
+        if records.len() < 2 {
+            return Err(anyhow!("The Aleo account does not have enough records to spend.").into());
+        }
         let mut records = records.values();
 
         // Prepare the inputs.
@@ -518,7 +525,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let fee_record = Some(records.next().unwrap().clone());
 
         // Create a new execute transaction.
-        self.vm.execute(
+        Ok(self.vm.execute(
             private_key,
             ("credits.aleo", "transfer_private"),
             inputs.iter(),
@@ -526,7 +533,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             priority_fee_in_microcredits,
             query,
             rng,
-        )
+        )?)
     }
 }
 

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -149,6 +149,9 @@ optional = true
 workspace = true
 features = [ "preserve_order" ]
 
+[dependencies.thiserror]
+workspace = true
+
 [dependencies.tokio]
 version = "1"
 features = [ "sync" ]

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -91,6 +91,9 @@ workspace = true
 [dependencies.aleo-std]
 workspace = true
 
+[dependencies.anyhow]
+workspace = true
+
 [dependencies.colored]
 workspace = true
 
@@ -119,6 +122,9 @@ optional = true
 [dependencies.serde_json]
 workspace = true
 features = [ "preserve_order" ]
+
+[dependencies.thiserror]
+workspace = true
 
 [dev-dependencies.bincode]
 workspace = true

--- a/synthesizer/process/src/authorize.rs
+++ b/synthesizer/process/src/authorize.rs
@@ -25,9 +25,11 @@ impl<N: Network> Process<N> {
         function_name: impl TryInto<Identifier<N>>,
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, ProcessAuthError> {
         // Authorize the call.
-        self.get_stack(program_id)?.authorize::<A, R>(private_key, function_name, inputs, rng)
+        self.get_stack(program_id)?
+            .authorize::<A, R>(private_key, function_name, inputs, rng)
+            .map_err(ProcessAuthError::from)
     }
 
     /// Authorizes a call to the program function for the given inputs.
@@ -40,9 +42,11 @@ impl<N: Network> Process<N> {
         function_name: impl TryInto<Identifier<N>>,
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, ProcessAuthError> {
         // Authorize the call.
-        self.get_stack(program_id)?.authorize_unchecked::<A, R>(private_key, function_name, inputs, rng)
+        self.get_stack(program_id)?
+            .authorize_unchecked::<A, R>(private_key, function_name, inputs, rng)
+            .map_err(ProcessAuthError::from)
     }
 
     /// Authorizes a call to the program function for the given inputs.
@@ -52,11 +56,11 @@ impl<N: Network> Process<N> {
         &self,
         request: Request<N>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, ProcessAuthError> {
         // Initialize the program id.
         let program_id = request.program_id();
         // Authorize the call.
-        self.get_stack(program_id)?.authorize_request::<A, R>(request, rng)
+        self.get_stack(program_id)?.authorize_request::<A, R>(request, rng).map_err(ProcessAuthError::from)
     }
 
     /// Authorizes the fee given the credits record, the fee amount (in microcredits),
@@ -70,7 +74,7 @@ impl<N: Network> Process<N> {
         priority_fee_in_microcredits: u64,
         deployment_or_execution_id: Field<N>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, ProcessAuthError> {
         let timer = timer!("Process::authorize_fee_private");
 
         // Ensure the fee has the correct program ID.
@@ -111,7 +115,7 @@ impl<N: Network> Process<N> {
         priority_fee_in_microcredits: u64,
         deployment_or_execution_id: Field<N>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, ProcessAuthError> {
         let timer = timer!("Process::authorize_fee_public");
 
         // Ensure the fee has the correct program ID.

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::error::ProcessDeployError;
 
 impl<N: Network> Process<N> {
     /// Deploys the given program ID, if it does not exist.
@@ -22,7 +23,7 @@ impl<N: Network> Process<N> {
         &self,
         program: &Program<N>,
         rng: &mut R,
-    ) -> Result<Deployment<N>> {
+    ) -> Result<Deployment<N>, ProcessDeployError> {
         let timer = timer!("Process::deploy");
 
         // Compute the stack.
@@ -30,12 +31,12 @@ impl<N: Network> Process<N> {
         lap!(timer, "Compute the stack");
 
         // Return the deployment.
-        let deployment = stack.deploy::<A, R>(rng);
+        let deployment = stack.deploy::<A, R>(rng)?;
         lap!(timer, "Construct the deployment");
 
         finish!(timer);
 
-        deployment
+        Ok(deployment)
     }
 
     /// Adds the newly-deployed program.

--- a/synthesizer/process/src/error.rs
+++ b/synthesizer/process/src/error.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use thiserror::Error;
+
+// NOTE: Many errors in this module temporarily contain `Anyhow` variants.
+// Remove these variants as we migrate errors to thiserror.
+
+/// Errors that may occur during process authorization.
+#[derive(Debug, Error)]
+pub enum ProcessAuthError {
+    /// Stack authorization failed.
+    #[error("Stack authorization failed: {0}")]
+    StackAuth(#[from] StackAuthError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during process evaluation.
+#[derive(Debug, Error)]
+pub enum ProcessEvalError {
+    /// Stack evaluation failed.
+    #[error("Stack evaluation failed: {0}")]
+    StackEval(#[from] StackEvalError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during process execution.
+#[derive(Debug, Error)]
+pub enum ProcessExecError {
+    /// Stack execution failed.
+    #[error("Stack execution failed: {0}")]
+    StackExec(#[from] StackExecError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during process deployment.
+#[derive(Debug, Error)]
+pub enum ProcessDeployError {
+    /// Stack execution failed during synthesis.
+    #[error("Stack synthesis failed: {0}")]
+    StackExec(#[from] StackExecError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during call evaluation.
+#[derive(Debug, Error)]
+pub enum CallEvalError {
+    /// An error occurred during substack evaluation.
+    #[error("Substack evaluation failed: {0}")]
+    StackEval(#[from] StackEvalError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during call execution.
+#[derive(Debug, Error)]
+pub enum CallExecError {
+    /// An error occurred during substack execution.
+    #[error("Substack execution failed: {0}")]
+    StackExec(#[from] StackExecError),
+    /// An error occurred during substack evaluation.
+    #[error("Substack evaluation failed: {0}")]
+    StackEval(#[from] StackEvalError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during stack authorization.
+#[derive(Debug, Error)]
+pub enum StackAuthError {
+    /// Stack execution failed.
+    #[error("Stack execution failed: {0}")]
+    Exec(#[from] StackExecError),
+    /// Stack evaluation failed.
+    #[error("Stack evaluation failed: {0}")]
+    Eval(#[from] StackEvalError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during stack execution.
+#[derive(Debug, Error)]
+pub enum StackExecError {
+    /// Instruction at the given index failed.
+    #[error(transparent)]
+    Instruction(#[from] IndexedInstructionError<InstructionError>),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during stack evaluation.
+#[derive(Debug, Error)]
+pub enum StackEvalError {
+    /// Instruction at the given index failed.
+    #[error(transparent)]
+    Instruction(#[from] IndexedInstructionError<InstructionEvalError>),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// An instruction error occurred at a particular index.
+#[derive(Debug, Error)]
+#[error("Instruction ({instruction}) at index {index} failed: {error}")]
+pub struct IndexedInstructionError<E> {
+    /// The index of the failing instruction.
+    pub index: usize,
+    /// The failing instruction formatted.
+    pub instruction: String,
+    /// The instruction error.
+    pub error: E,
+}
+
+/// An error occurred during the execution/evaluation/synthesis of an
+/// instruction.
+#[derive(Debug, Error)]
+pub enum InstructionError {
+    /// Failed to evaluate an instruction.
+    #[error("Failed to evaluate: {0}")]
+    Eval(#[from] InstructionEvalError),
+    /// Failed to execute an instruction.
+    #[error("Failed to execute: {0}")]
+    Exec(#[from] InstructionExecError),
+}
+
+/// An error occurred during the evaluation of an instruction.
+#[derive(Debug, Error)]
+pub enum InstructionEvalError {
+    /// An error occurred during a `Call` instruction.
+    #[error("Call failed: {0}")]
+    Call(#[from] Box<CallEvalError>),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// An error occurred during the execution of an instruction.
+#[derive(Debug, Error)]
+pub enum InstructionExecError {
+    /// An error occurred during a `Call` instruction.
+    #[error("Call failed: {0}")]
+    Call(#[from] Box<CallExecError>),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+impl<E> IndexedInstructionError<E> {
+    /// Short-hand constructor for the `IndexedInstructionError` type.
+    pub(crate) fn new(index: usize, instruction: String, error: E) -> Self {
+        Self { index, instruction, error }
+    }
+}

--- a/synthesizer/process/src/evaluate.rs
+++ b/synthesizer/process/src/evaluate.rs
@@ -14,11 +14,15 @@
 // limitations under the License.
 
 use super::*;
+use crate::error::ProcessEvalError;
 
 impl<N: Network> Process<N> {
     /// Evaluates a program function on the given request.
     #[inline]
-    pub fn evaluate<A: circuit::Aleo<Network = N>>(&self, authorization: Authorization<N>) -> Result<Response<N>> {
+    pub fn evaluate<A: circuit::Aleo<Network = N>>(
+        &self,
+        authorization: Authorization<N>,
+    ) -> Result<Response<N>, ProcessEvalError> {
         let timer = timer!("Process::evaluate");
 
         // Retrieve the top-level request (without popping it).
@@ -31,11 +35,11 @@ impl<N: Network> Process<N> {
         // Initialize an RNG.
         let rng = &mut rand::thread_rng();
         // Evaluate the function.
-        let response = stack.evaluate_function::<A, _>(CallStack::evaluate(authorization)?, None, None, rng);
+        let response = stack.evaluate_function::<A, _>(CallStack::evaluate(authorization)?, None, None, rng)?;
         lap!(timer, "Evaluate the function");
 
         finish!(timer);
 
-        response
+        Ok(response)
     }
 }

--- a/synthesizer/process/src/execute.rs
+++ b/synthesizer/process/src/execute.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::error::ProcessExecError;
 
 impl<N: Network> Process<N> {
     /// Executes the given authorization.
@@ -22,7 +23,7 @@ impl<N: Network> Process<N> {
         &self,
         authorization: Authorization<N>,
         rng: &mut R,
-    ) -> Result<(Response<N>, Trace<N>)> {
+    ) -> Result<(Response<N>, Trace<N>), ProcessExecError> {
         let timer = timer!("Process::execute");
 
         // Retrieve the main request (without popping it).
@@ -51,7 +52,9 @@ impl<N: Network> Process<N> {
         // Extract the trace.
         let trace = Arc::try_unwrap(trace).unwrap().into_inner();
         // Ensure the trace is not empty.
-        ensure!(!trace.transitions().is_empty(), "Execution of '{locator}' is empty");
+        if trace.transitions().is_empty() {
+            return Err(anyhow!("Execution of '{locator}' is empty").into());
+        }
 
         finish!(timer);
         Ok((response, trace))

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -25,6 +25,9 @@ extern crate snarkvm_console as console;
 mod cost;
 pub use cost::*;
 
+mod error;
+pub use error::*;
+
 mod stack;
 pub use stack::*;
 

--- a/synthesizer/process/src/stack/authorize.rs
+++ b/synthesizer/process/src/stack/authorize.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::error::*;
 
 impl<N: Network> Stack<N> {
     /// Authorizes a call to the program function for the given inputs.
@@ -24,7 +25,7 @@ impl<N: Network> Stack<N> {
         function_name: impl TryInto<Identifier<N>>,
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, StackAuthError> {
         let timer = timer!("Stack::authorize");
 
         // Get the program ID.
@@ -80,7 +81,7 @@ impl<N: Network> Stack<N> {
         function_name: impl TryInto<Identifier<N>>,
         inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, StackAuthError> {
         let timer = timer!("Stack::authorize_unchecked");
 
         // Get the program ID.
@@ -134,13 +135,15 @@ impl<N: Network> Stack<N> {
         &self,
         request: Request<N>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, StackAuthError> {
         let timer = timer!("Stack::authorize_request");
 
         // Get the program ID.
         let program_id = *self.program.id();
         // Ensure the program ID is credits.aleo.
-        ensure!(program_id.to_string() == "credits.aleo", "Program ID must be credits.aleo");
+        if program_id.to_string() != "credits.aleo" {
+            return Err(anyhow!("Program ID must be credits.aleo").into());
+        }
         // Initialize the authorization.
         let authorization = Authorization::new(request.clone());
         // Construct the call stack.

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{CallStack, Registers, Stack, stack::Address};
+use crate::{CallStack, Registers, Stack, error::*, stack::Address};
 use aleo_std::prelude::{finish, lap, timer};
 use console::{
     account::Field,
@@ -38,7 +38,7 @@ pub trait CallTrait<N: Network> {
         stack: &Stack<N>,
         registers: &mut Registers<N, A>,
         rng: &mut R,
-    ) -> Result<()>;
+    ) -> Result<(), CallEvalError>;
 
     /// Executes the instruction.
     fn execute<A: circuit::Aleo<Network = N>, R: CryptoRng + Rng>(
@@ -46,7 +46,7 @@ pub trait CallTrait<N: Network> {
         stack: &Stack<N>,
         registers: &mut Registers<N, A>,
         rng: &mut R,
-    ) -> Result<()>;
+    ) -> Result<(), CallExecError>;
 }
 
 impl<N: Network> CallTrait<N> for Call<N> {
@@ -57,7 +57,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         stack: &Stack<N>,
         registers: &mut Registers<N, A>,
         rng: &mut R,
-    ) -> Result<()> {
+    ) -> Result<(), CallEvalError> {
         let timer = timer!("Call::evaluate");
 
         // Load the operands values.
@@ -74,7 +74,9 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 //  But there are legitimate uses for passing a record through to an internal function.
                 //  We could invoke the internal function without a state transition, but need to match visibility.
                 if stack.program().contains_function(resource) {
-                    bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
+                    return Err(
+                        anyhow!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.").into()
+                    );
                 }
                 (None, resource)
             }
@@ -90,7 +92,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         let outputs = if let Ok(closure) = substack.program().get_closure(resource) {
             // Ensure the number of inputs matches the number of input statements.
             if closure.inputs().len() != inputs.len() {
-                bail!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len())
+                return Err(anyhow!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len()).into());
             }
             // Evaluate the closure, and load the outputs.
             substack.evaluate_closure::<A>(
@@ -106,7 +108,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         else if let Ok(function) = substack.program().get_function(resource) {
             // Ensure the number of inputs matches the number of input statements.
             if function.inputs().len() != inputs.len() {
-                bail!("Expected {} inputs, found {}", function.inputs().len(), inputs.len())
+                return Err(anyhow!("Expected {} inputs, found {}", function.inputs().len(), inputs.len()).into());
             }
 
             // Get the 'root_tvk'.
@@ -121,7 +123,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 let is_root = false;
                 // Ensure that we have a private key to sign the new request.
                 let Some(private_key) = private_key else {
-                    bail!("Cannot authorize a new function call without a private key.")
+                    return Err(anyhow!("Cannot authorize a new function call without a private key.").into());
                 };
                 // Retrieve the program checksum, if the program has a constructor.
                 let program_checksum = match substack.program().contains_constructor() {
@@ -155,7 +157,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         }
         // Else, throw an error.
         else {
-            bail!("Call operator '{}' is invalid or unsupported.", self.operator())
+            return Err(anyhow!("Call operator '{}' is invalid or unsupported.", self.operator()).into());
         };
         lap!(timer, "Computed outputs");
 
@@ -176,7 +178,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         stack: &Stack<N>,
         registers: &mut Registers<N, A>,
         rng: &mut R,
-    ) -> Result<()> {
+    ) -> Result<(), CallExecError> {
         let timer = timer!("Call::execute");
 
         // Load the operands values.
@@ -195,7 +197,10 @@ impl<N: Network> CallTrait<N> for Call<N> {
 
                 // Ensure the external call is not to 'credits.aleo/fee_private' or 'credits.aleo/fee_public'.
                 if is_credits_program && (is_fee_private || is_fee_public) {
-                    bail!("Cannot perform an external call to 'credits.aleo/fee_private' or 'credits.aleo/fee_public'.")
+                    return Err(anyhow!(
+                        "Cannot perform an external call to 'credits.aleo/fee_private' or 'credits.aleo/fee_public'."
+                    )
+                    .into());
                 } else {
                     (Some(stack.get_external_stack(locator.program_id())?), locator.resource())
                 }
@@ -205,7 +210,9 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 //  But there are legitimate uses for passing a record through to an internal function.
                 //  We could invoke the internal function without a state transition, but need to match visibility.
                 if stack.program().contains_function(resource) {
-                    bail!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.")
+                    return Err(
+                        anyhow!("Cannot call '{resource}'. Use a closure ('closure {resource}:') instead.").into()
+                    );
                 }
                 (None, resource)
             }
@@ -246,7 +253,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             let num_inputs = function.inputs().len();
             // Ensure the number of inputs matches the number of input statements.
             if num_inputs != inputs.len() {
-                bail!("Expected {} inputs, found {}", num_inputs, inputs.len())
+                return Err(anyhow!("Expected {} inputs, found {}", num_inputs, inputs.len()).into());
             }
 
             // Retrieve the number of public variables in the circuit.
@@ -272,7 +279,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     CallStack::Authorize(_, private_key, authorization) => {
                         // Ensure that we have a private key to sign the new request.
                         let Some(private_key) = private_key else {
-                            bail!("Cannot authorize a new function call without a private key.")
+                            return Err(anyhow!("Cannot authorize a new function call without a private key.").into());
                         };
                         // Compute the request.
                         let request = Request::sign(
@@ -425,7 +432,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                     }
                     // If the circuit is in evaluate mode, then throw an error.
                     CallStack::Evaluate(..) => {
-                        bail!("Cannot 'execute' a function in 'evaluate' mode.")
+                        return Err(anyhow!("Cannot 'execute' a function in 'evaluate' mode.").into());
                     }
                     // If the circuit is in execute mode, then evaluate and execute the instructions.
                     CallStack::Execute(authorization, ..) => {
@@ -450,7 +457,11 @@ impl<N: Network> CallTrait<N> for Call<N> {
                         // Ensure the values are equal.
                         if console_response.outputs() != response.outputs() {
                             dev_eprintln!("\n{:#?} != {:#?}\n", console_response.outputs(), response.outputs());
-                            bail!("Function '{}' outputs do not match in a 'call' instruction.", function.name())
+                            return Err(anyhow!(
+                                "Function '{}' outputs do not match in a 'call' instruction.",
+                                function.name()
+                            )
+                            .into());
                         }
                         // Return the request and response.
                         (request, response)
@@ -472,7 +483,9 @@ impl<N: Network> CallTrait<N> for Call<N> {
             let function_name = circuit::Identifier::constant(*function.name());
 
             // Ensure the number of public variables remains the same.
-            ensure!(A::num_public() == num_public, "Forbidden: 'call' injected excess public variables");
+            if A::num_public() != num_public {
+                return Err(anyhow!("Forbidden: 'call' injected excess public variables").into());
+            }
 
             // Inject the `signer` (from the request) as `Mode::Private`.
             let signer = circuit::Address::new(circuit::Mode::Private, *request.signer());
@@ -538,7 +551,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
         }
         // Else, throw an error.
         else {
-            bail!("Call operator '{}' is invalid or unsupported.", self.operator())
+            return Err(anyhow!("Call operator '{}' is invalid or unsupported.", self.operator()).into());
         };
 
         // Assign the outputs to the destination registers.

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::error::*;
 
 impl<N: Network> Stack<N> {
     /// Evaluates a program closure on the given inputs.
@@ -28,12 +29,12 @@ impl<N: Network> Stack<N> {
         signer: Address<N>,
         caller: Address<N>,
         tvk: Field<N>,
-    ) -> Result<Vec<Value<N>>> {
+    ) -> Result<Vec<Value<N>>, StackEvalError> {
         let timer = timer!("Stack::evaluate_closure");
 
         // Ensure the number of inputs matches the number of input statements.
         if closure.inputs().len() != inputs.len() {
-            bail!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len())
+            return Err(anyhow!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len()).into());
         }
 
         // Initialize the registers.
@@ -55,10 +56,10 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Store the inputs");
 
         // Evaluate the instructions.
-        for instruction in closure.instructions() {
+        for (ix, instruction) in closure.instructions().iter().enumerate() {
             // If the evaluation fails, bail and return the error.
             if let Err(error) = instruction.evaluate(self, &mut registers) {
-                bail!("Failed to evaluate instruction ({instruction}): {error}");
+                return Err(IndexedInstructionError::new(ix, format!("{instruction}"), error.into()).into());
             }
         }
         lap!(timer, "Evaluate the instructions");
@@ -67,7 +68,7 @@ impl<N: Network> Stack<N> {
         let outputs = closure
             .outputs()
             .iter()
-            .map(|output| {
+            .map(|output| -> Result<_> {
                 match output.operand() {
                     // If the operand is a literal, use the literal directly.
                     Operand::Literal(literal) => Ok(Value::Plaintext(Plaintext::from(literal))),
@@ -95,6 +96,7 @@ impl<N: Network> Stack<N> {
                     Operand::ProgramOwner(_) => bail!("Cannot retrieve the program owner from a closure scope."),
                 }
             })
+            .map(|res| res.map_err(StackEvalError::from))
             .collect();
         lap!(timer, "Load the outputs");
 
@@ -112,36 +114,35 @@ impl<N: Network> Stack<N> {
         caller: Option<ProgramID<N>>,
         root_tvk: Option<Field<N>>,
         rng: &mut R,
-    ) -> Result<Response<N>> {
+    ) -> Result<Response<N>, StackEvalError> {
         let timer = timer!("Stack::evaluate_function");
 
         // Retrieve the next request, based on the call stack mode.
-        let (request, call_stack) = match &mut call_stack {
-            CallStack::Authorize(..) => (call_stack.pop()?, call_stack),
-            CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
-            // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
-            // This is done to ensure that evaluation during execution is performed consistently.
-            CallStack::Execute(authorization, _) => {
-                // Note: We need to replicate the authorization, so that 'execute' can call 'authorization.next()?'.
-                // This way, the authorization remains unmodified in this 'evaluate' scope.
-                let authorization = authorization.replicate();
-                let request = authorization.next()?;
-                let call_stack = CallStack::Evaluate(authorization);
-                (request, call_stack)
-            }
-            _ => bail!(
-                "Illegal operation: call stack must be `Authorize`, `Evaluate` or `Execute` in `evaluate_function`."
-            ),
-        };
+        let (request, call_stack) =
+            match &mut call_stack {
+                CallStack::Authorize(..) => (call_stack.pop()?, call_stack),
+                CallStack::Evaluate(authorization) => (authorization.next()?, call_stack),
+                // If the evaluation is performed in the `Execute` mode, create a new `Evaluate` mode.
+                // This is done to ensure that evaluation during execution is performed consistently.
+                CallStack::Execute(authorization, _) => {
+                    // Note: We need to replicate the authorization, so that 'execute' can call 'authorization.next()?'.
+                    // This way, the authorization remains unmodified in this 'evaluate' scope.
+                    let authorization = authorization.replicate();
+                    let request = authorization.next()?;
+                    let call_stack = CallStack::Evaluate(authorization);
+                    (request, call_stack)
+                }
+                _ => return Err(anyhow!(
+                    "Illegal operation: call stack must be `Authorize`, `Evaluate` or `Execute` in `evaluate_function`."
+                )
+                .into()),
+            };
         lap!(timer, "Retrieve the next request");
 
         // Ensure the network ID matches.
-        ensure!(
-            **request.network_id() == N::ID,
-            "Network ID mismatch. Expected {}, but found {}",
-            N::ID,
-            request.network_id()
-        );
+        if **request.network_id() != N::ID {
+            return Err(anyhow!("Network ID mismatch. Expected {}, but found {}", N::ID, request.network_id()).into());
+        }
 
         // Retrieve the function, inputs, and transition view key.
         let function = self.get_function(request.function_name())?;
@@ -162,13 +163,14 @@ impl<N: Network> Stack<N> {
 
         // Ensure the number of inputs matches.
         if function.inputs().len() != inputs.len() {
-            bail!(
+            return Err(anyhow!(
                 "Function '{}' in the program '{}' expects {} inputs, but {} were provided.",
                 function.name(),
                 self.program.id(),
                 function.inputs().len(),
                 inputs.len()
             )
+            .into());
         }
         lap!(timer, "Perform input checks");
 
@@ -189,7 +191,9 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Initialize the registers");
 
         // Ensure the request is well-formed.
-        ensure!(request.verify(&function.input_types(), is_root, program_checksum), "[Evaluate] Request is invalid");
+        if !request.verify(&function.input_types(), is_root, program_checksum) {
+            return Err(anyhow!("[Evaluate] Request is invalid").into());
+        }
         lap!(timer, "Verify the request");
 
         // Store the inputs.
@@ -201,17 +205,18 @@ impl<N: Network> Stack<N> {
 
         // Evaluate the instructions.
         // Note: We handle the `call` instruction separately, as it requires special handling.
-        for instruction in function.instructions() {
+        for (ix, instruction) in function.instructions().iter().enumerate() {
             // Evaluate the instruction.
             let result = match instruction {
                 // If the instruction is a `call` instruction, we need to handle it separately.
-                Instruction::Call(call) => CallTrait::evaluate(call, self, &mut registers, rng),
+                Instruction::Call(call) => CallTrait::evaluate(call, self, &mut registers, rng)
+                    .map_err(|e| InstructionEvalError::Call(Box::new(e))),
                 // Otherwise, evaluate the instruction normally.
-                _ => instruction.evaluate(self, &mut registers),
+                _ => instruction.evaluate(self, &mut registers).map_err(InstructionEvalError::Anyhow),
             };
             // If the evaluation fails, bail and return the error.
             if let Err(error) = result {
-                bail!("Failed to evaluate instruction ({instruction}): {error}");
+                return Err(IndexedInstructionError::new(ix, format!("{instruction}"), error).into());
             }
         }
         lap!(timer, "Evaluate the instructions");

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::error::*;
 
 impl<N: Network> Stack<N> {
     /// Executes a program closure on the given inputs.
@@ -28,15 +29,17 @@ impl<N: Network> Stack<N> {
         signer: circuit::Address<A>,
         caller: circuit::Address<A>,
         tvk: circuit::Field<A>,
-    ) -> Result<Vec<circuit::Value<A>>> {
+    ) -> Result<Vec<circuit::Value<A>>, StackExecError> {
         let timer = timer!("Stack::execute_closure");
 
         // Ensure the call stack is not `Evaluate`.
-        ensure!(!matches!(call_stack, CallStack::Evaluate(..)), "Illegal operation: cannot evaluate in execute mode");
+        if matches!(call_stack, CallStack::Evaluate(..)) {
+            return Err(anyhow!("Illegal operation: cannot evaluate in execute mode").into());
+        }
 
         // Ensure the number of inputs matches the number of input statements.
         if closure.inputs().len() != inputs.len() {
-            bail!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len())
+            return Err(anyhow!("Expected {} inputs, found {}", closure.inputs().len(), inputs.len()).into());
         }
         lap!(timer, "Check the number of inputs");
 
@@ -67,21 +70,27 @@ impl<N: Network> Stack<N> {
         lap!(timer, "Store the inputs");
 
         // Execute the instructions.
-        for instruction in closure.instructions() {
+        for (ix, instruction) in closure.instructions().iter().enumerate() {
             // If the circuit is in execute mode, then evaluate the instructions.
             if let CallStack::Execute(..) = registers.call_stack_ref() {
                 // If the evaluation fails, bail and return the error.
                 if let Err(error) = instruction.evaluate(self, &mut registers) {
-                    bail!("Failed to evaluate instruction ({instruction}): {error}");
+                    let err = InstructionError::Eval(error.into());
+                    return Err(IndexedInstructionError::new(ix, format!("{instruction}"), err).into());
                 }
             }
             // Execute the instruction.
-            instruction.execute(self, &mut registers)?;
+            if let Err(error) = instruction.execute(self, &mut registers) {
+                let err = InstructionError::Exec(error.into());
+                return Err(IndexedInstructionError::new(ix, format!("{instruction}"), err).into());
+            }
         }
         lap!(timer, "Execute the instructions");
 
         // Ensure the number of public variables remains the same.
-        ensure!(A::num_public() == num_public, "Illegal closure operation: instructions injected public variables");
+        if A::num_public() != num_public {
+            return Err(anyhow!("Illegal closure operation: instructions injected public variables").into());
+        }
 
         use circuit::Inject;
 
@@ -89,7 +98,7 @@ impl<N: Network> Stack<N> {
         let outputs = closure
             .outputs()
             .iter()
-            .map(|output| {
+            .map(|output| -> Result<_> {
                 match output.operand() {
                     // If the operand is a literal, use the literal directly.
                     Operand::Literal(literal) => Ok(circuit::Value::Plaintext(circuit::Plaintext::from(
@@ -133,6 +142,7 @@ impl<N: Network> Stack<N> {
                     }
                 }
             })
+            .map(|res| res.map_err(StackExecError::Anyhow))
             .collect();
         lap!(timer, "Load the outputs");
 
@@ -152,7 +162,7 @@ impl<N: Network> Stack<N> {
         console_caller: Option<ProgramID<N>>,
         console_root_tvk: Option<Field<N>>,
         rng: &mut R,
-    ) -> Result<Response<N>> {
+    ) -> Result<Response<N>, StackExecError> {
         let timer = timer!("Stack::execute_function");
 
         // Ensure the global constants for the Aleo environment are initialized.
@@ -171,15 +181,17 @@ impl<N: Network> Stack<N> {
         let console_request = call_stack.pop()?;
 
         // Ensure the network ID matches.
-        ensure!(
-            **console_request.network_id() == N::ID,
-            "Network ID mismatch. Expected {}, but found {}",
-            N::ID,
-            console_request.network_id()
-        );
+        if **console_request.network_id() != N::ID {
+            return Err(
+                anyhow!("Network ID mismatch. Expected {}, but found {}", N::ID, console_request.network_id()).into()
+            );
+        }
 
         // We can only have a root_tvk if this request was called by another request
-        ensure!(console_caller.is_some() == console_root_tvk.is_some());
+        if console_caller.is_some() != console_root_tvk.is_some() {
+            return Err(anyhow!("root_tvk requires a caller").into());
+        }
+
         // Determine if this is the top-level caller.
         let console_is_root = console_caller.is_none();
 
@@ -199,7 +211,7 @@ impl<N: Network> Stack<N> {
         let num_inputs = function.inputs().len();
         // Ensure the number of inputs matches the number of input statements.
         if num_inputs != console_request.inputs().len() {
-            bail!("Expected {num_inputs} inputs, found {}", console_request.inputs().len())
+            return Err(anyhow!("Expected {num_inputs} inputs, found {}", console_request.inputs().len()).into());
         }
         // Retrieve the input types.
         let input_types = function.input_types();
@@ -221,10 +233,9 @@ impl<N: Network> Stack<N> {
         };
 
         // Ensure the request is well-formed.
-        ensure!(
-            console_request.verify(&input_types, console_is_root, program_checksum),
-            "[Execute] Request is invalid"
-        );
+        if !console_request.verify(&input_types, console_is_root, program_checksum) {
+            return Err(anyhow!("[Execute] Request is invalid").into());
+        }
         lap!(timer, "Verify the console request");
 
         // Initialize the registers.
@@ -301,32 +312,36 @@ impl<N: Network> Stack<N> {
         let mut contains_function_call = false;
 
         // Execute the instructions.
-        for instruction in function.instructions() {
+        for (ix, instruction) in function.instructions().iter().enumerate() {
             // If the circuit is in execute mode, then evaluate the instructions.
             if let CallStack::Execute(..) = registers.call_stack_ref() {
                 // Evaluate the instruction.
                 let result = match instruction {
                     // If the instruction is a `call` instruction, we need to handle it separately.
-                    Instruction::Call(call) => CallTrait::evaluate(call, self, &mut registers, rng),
+                    Instruction::Call(call) => CallTrait::evaluate(call, self, &mut registers, rng)
+                        .map_err(|e| InstructionEvalError::Call(Box::new(e))),
                     // Otherwise, evaluate the instruction normally.
-                    _ => instruction.evaluate(self, &mut registers),
+                    _ => instruction.evaluate(self, &mut registers).map_err(InstructionEvalError::Anyhow),
                 };
                 // If the evaluation fails, bail and return the error.
                 if let Err(error) = result {
-                    bail!("Failed to evaluate instruction ({instruction}): {error}");
+                    let err = InstructionError::Eval(error);
+                    return Err(IndexedInstructionError::new(ix, format!("{instruction}"), err).into());
                 }
             }
 
             // Execute the instruction.
             let result = match instruction {
                 // If the instruction is a `call` instruction, we need to handle it separately.
-                Instruction::Call(call) => CallTrait::execute(call, self, &mut registers, rng),
+                Instruction::Call(call) => CallTrait::execute(call, self, &mut registers, rng)
+                    .map_err(|e| InstructionExecError::Call(Box::new(e))),
                 // Otherwise, execute the instruction normally.
-                _ => instruction.execute(self, &mut registers),
+                _ => instruction.execute(self, &mut registers).map_err(InstructionExecError::Anyhow),
             };
             // If the execution fails, bail and return the error.
             if let Err(error) = result {
-                bail!("Failed to execute instruction ({instruction}): {error}");
+                let err = InstructionError::Exec(error);
+                return Err(IndexedInstructionError::new(ix, format!("{instruction}"), err).into());
             }
 
             // If the instruction was a function call, then set the tracker to `true`.
@@ -409,9 +424,9 @@ impl<N: Network> Stack<N> {
         let num_function_constraints = A::num_constraints().saturating_sub(num_request_constraints);
 
         // If the function does not contain function calls, ensure no new public variables were injected.
-        if !contains_function_call {
+        if !contains_function_call && A::num_public() != num_public {
             // Ensure the number of public variables remains the same.
-            ensure!(A::num_public() == num_public, "Instructions in function injected public variables");
+            return Err(anyhow!("Instructions in function injected public variables").into());
         }
 
         // Construct the response.
@@ -449,13 +464,15 @@ impl<N: Network> Stack<N> {
         // If the circuit is in `Execute` or `PackageRun` mode, then ensure the circuit is satisfied.
         if matches!(registers.call_stack_ref(), CallStack::Execute(..) | CallStack::PackageRun(..)) {
             // If the circuit is empty or not satisfied, then throw an error.
-            ensure!(
-                A::num_constraints() > 0 && A::is_satisfied(),
-                "'{}/{}' is not satisfied on the given inputs ({} constraints).",
-                self.program.id(),
-                function.name(),
-                A::num_constraints()
-            );
+            if A::num_constraints() == 0 || !A::is_satisfied() {
+                return Err(anyhow!(
+                    "'{}/{}' is not satisfied on the given inputs ({} constraints).",
+                    self.program.id(),
+                    function.name(),
+                    A::num_constraints()
+                )
+                .into());
+            }
         }
 
         // Eject the circuit assignment and reset the circuit.

--- a/synthesizer/src/vm/authorize.rs
+++ b/synthesizer/src/vm/authorize.rs
@@ -25,7 +25,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         function_name: impl TryInto<Identifier<N>>,
         inputs: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = impl TryInto<Value<N>>>>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, VmAuthError> {
         let timer = timer!("VM::authorize");
 
         // Prepare the program ID.
@@ -128,7 +128,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         function_name: Identifier<N>,
         inputs: Vec<Value<N>>,
         rng: &mut R,
-    ) -> Result<Authorization<N>> {
+    ) -> Result<Authorization<N>, VmAuthError> {
         macro_rules! logic {
             ($process:expr, $network:path, $aleo:path) => {{
                 // Compute the authorization.

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -30,11 +30,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         priority_fee_in_microcredits: u64,
         query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
-    ) -> Result<Transaction<N>> {
+    ) -> Result<Transaction<N>, VmDeployError> {
         // Compute the deployment.
         let mut deployment = self.deploy_raw(program, rng)?;
         // Ensure the transaction is not empty.
-        ensure!(!deployment.program().functions().is_empty(), "Attempted to create an empty transaction deployment");
+        if deployment.program().functions().is_empty() {
+            return Err(anyhow!("Attempted to create an empty transaction deployment").into());
+        }
         // Get a default query if one is not provided.
         let query = match query {
             Some(q) => q,
@@ -78,14 +80,18 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let fee = self.execute_fee_authorization(fee_authorization, Some(query), rng)?;
 
         // Return the deploy transaction.
-        Transaction::from_deployment(owner, deployment, fee)
+        Ok(Transaction::from_deployment(owner, deployment, fee)?)
     }
 }
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Returns a deployment for the given program.
     #[inline]
-    pub(super) fn deploy_raw<R: Rng + CryptoRng>(&self, program: &Program<N>, rng: &mut R) -> Result<Deployment<N>> {
+    pub(super) fn deploy_raw<R: Rng + CryptoRng>(
+        &self,
+        program: &Program<N>,
+        rng: &mut R,
+    ) -> Result<Deployment<N>, VmDeployError> {
         macro_rules! logic {
             ($process:expr, $network:path, $aleo:path) => {{
                 // Prepare the program.

--- a/synthesizer/src/vm/error.rs
+++ b/synthesizer/src/vm/error.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm_synthesizer_process::{ProcessAuthError, ProcessDeployError, ProcessExecError};
+use thiserror::Error;
+
+// NOTE: Many errors in this module temporarily contain `Anyhow` variants.
+// Remove these variants as we migrate errors to thiserror.
+
+/// Errors that may occur during VM execution.
+#[derive(Debug, Error)]
+pub enum VmExecError {
+    /// Authorization failed.
+    #[error("Authorization failed: {0}")]
+    Auth(#[from] VmAuthError),
+    /// Process execution failed (contains instruction index).
+    #[error("Process execution failed: {0}")]
+    Process(#[from] ProcessExecError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during VM authorization.
+#[derive(Debug, Error)]
+pub enum VmAuthError {
+    /// Process authorization failed.
+    #[error("Process authorization failed: {0}")]
+    Process(#[from] ProcessAuthError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+/// Errors that may occur during VM deployment.
+#[derive(Debug, Error)]
+pub enum VmDeployError {
+    /// Process deployment failed.
+    #[error("Process deployment failed: {0}")]
+    Process(#[from] ProcessDeployError),
+    /// Fee execution failed.
+    #[error("Fee execution failed: {0}")]
+    FeeExec(#[from] VmExecError),
+    /// A temporary variant for type-erased anyhow errors.
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -33,7 +33,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         priority_fee_in_microcredits: u64,
         query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
-    ) -> Result<Transaction<N>> {
+    ) -> Result<Transaction<N>, VmExecError> {
         let (execution, _) = self.execute_with_response(
             private_key,
             (program_id, function_name),
@@ -61,7 +61,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         priority_fee_in_microcredits: u64,
         query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
-    ) -> Result<(Transaction<N>, Response<N>)> {
+    ) -> Result<(Transaction<N>, Response<N>), VmExecError> {
         // Get a default query if one is not provided.
         let query = match query {
             Some(q) => q,
@@ -157,7 +157,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         authorization: Authorization<N>,
         query: Option<&dyn QueryTrait<N>>,
         rng: &mut R,
-    ) -> Result<Fee<N>> {
+    ) -> Result<Fee<N>, VmExecError> {
         debug_assert!(authorization.is_fee_private() || authorization.is_fee_public(), "Expected a fee authorization");
         // Get a default query if one is not provided.
         let query = match query {
@@ -177,7 +177,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         authorization: Authorization<N>,
         query: &dyn QueryTrait<N>,
         rng: &mut R,
-    ) -> Result<(Execution<N>, Response<N>)> {
+    ) -> Result<(Execution<N>, Response<N>), VmExecError> {
         let timer = timer!("VM::execute_authorization_raw");
 
         // Construct the locator of the main function.
@@ -232,7 +232,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         authorization: Authorization<N>,
         query: &dyn QueryTrait<N>,
         rng: &mut R,
-    ) -> Result<Fee<N>> {
+    ) -> Result<Fee<N>, VmExecError> {
         let timer = timer!("VM::execute_fee_authorization_raw");
 
         // Determine the consensus version.

--- a/synthesizer/src/vm/helpers/macros.rs
+++ b/synthesizer/src/vm/helpers/macros.rs
@@ -71,7 +71,7 @@ macro_rules! convert {
                 // Process the logic.
                 $logic!(console::network::CanaryV0, circuit::AleoCanaryV0)
             }
-            _ => bail!("Unsupported VM configuration for network: {}", N::ID),
+            _ => return Err(anyhow!("Unsupported VM configuration for network: {}", N::ID).into()),
         }
     }};
 }
@@ -106,7 +106,7 @@ macro_rules! process {
                 // Process the logic.
                 $logic!(process.read(), console::network::CanaryV0, circuit::AleoCanaryV0)
             }
-            _ => bail!("Unsupported VM configuration for network: {}", N::ID),
+            _ => return Err(anyhow!("Unsupported VM configuration for network: {}", N::ID).into()),
         }
     }};
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -16,6 +16,9 @@
 mod helpers;
 pub use helpers::*;
 
+mod error;
+pub use error::*;
+
 mod authorize;
 mod deploy;
 mod execute;
@@ -1451,7 +1454,7 @@ function call_fee_public:
 finalize call_fee_public:
     input r0 as credits.aleo/fee_public.future;
     await r0;
-    
+
 function call_fee_private:
     input r0 as credits.aleo/credits.record;
     input r1 as u64.private;

--- a/synthesizer/src/vm/tests/test_v11.rs
+++ b/synthesizer/src/vm/tests/test_v11.rs
@@ -379,7 +379,7 @@ constructor:
                 // Create a block and fail if the number of accepted transactions is zero.
                 let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
                 if block.transactions().num_accepted() == 0 {
-                    Err(anyhow::anyhow!("The transaction was not accepted"))
+                    Err(anyhow::anyhow!("The transaction was not accepted").into())
                 } else {
                     Ok(())
                 }

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/async_without_finalize_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/async_without_finalize_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program child.aleo: ''child.aleo/foo'' does not have a finalize block'
+- 'Failed to run `VM::deploy for program child.aleo: Process deployment failed: ''child.aleo/foo'' does not have a finalize block'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/bad_constructor_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/bad_constructor_fail.out
@@ -1,5 +1,5 @@
 errors: []
 outputs:
-- execute: Program 'bad_constructor.aleo' does not exist
+- execute: 'Authorization failed: Process authorization failed: Program ''bad_constructor.aleo'' does not exist'
 additional:
 - {}

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/call_after_async_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/call_after_async_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program parent.aleo: The ''call'' can only be invoked before an ''async'' instruction'
+- 'Failed to run `VM::deploy for program parent.aleo: Process deployment failed: The ''call'' can only be invoked before an ''async'' instruction'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/external_read_with_local_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/external_read_with_local_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program relay.aleo: Locator ''relay.aleo/users'' does not reference an external mapping.'
+- 'Failed to run `VM::deploy for program relay.aleo: Process deployment failed: Locator ''relay.aleo/users'' does not reference an external mapping.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/future_not_all_awaited_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/future_not_all_awaited_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program parent.aleo: Futures in finalize ''foo'' are not all awaited.'
+- 'Failed to run `VM::deploy for program parent.aleo: Process deployment failed: Futures in finalize ''foo'' are not all awaited.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/future_not_all_passed_to_async_call_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/future_not_all_passed_to_async_call_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program parent.aleo: Function ''foo'' contains futures, but the ''async'' instruction does not consume all of the ones produced.'
+- 'Failed to run `VM::deploy for program parent.aleo: Process deployment failed: Function ''foo'' contains futures, but the ''async'' instruction does not consume all of the ones produced.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/ignore_finalize_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/ignore_finalize_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program parent.aleo: Function ''parent.aleo/foo'' must contain a finalize block, since it calls ''child.aleo/foo''.'
+- 'Failed to run `VM::deploy for program parent.aleo: Process deployment failed: Function ''parent.aleo/foo'' must contain a finalize block, since it calls ''child.aleo/foo''.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/last_reg_is_not_future_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/last_reg_is_not_future_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program child.aleo: The last output of function ''foo'' must be a future associated with itself'
+- 'Failed to run `VM::deploy for program child.aleo: Process deployment failed: The last output of function ''foo'' must be a future associated with itself'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/mint_and_split.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/mint_and_split.out
@@ -8,7 +8,7 @@ outputs:
   speculate: the execution was accepted
   add_next_block: succeeded.
 - execute: Commitment '1266307482263846358970326041806201638141701138269282465033372005968041137990field' does not exist
-- execute: Input record for 'mint_and_split.aleo' must belong to the signer
+- execute: 'Authorization failed: Process authorization failed: Stack authorization failed: Input record for ''mint_and_split.aleo'' must belong to the signer'
 - execute: Commitment '5664701406562067552828344114098303767897965604026128467062564698122653063423field' does not exist
 additional:
 - child_outputs:

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/multiple_async_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/multiple_async_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program parent.aleo: Function ''foo'' can contain at most one ''async'' instruction'
+- 'Failed to run `VM::deploy for program parent.aleo: Process deployment failed: Function ''foo'' can contain at most one ''async'' instruction'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/no_import_external_read_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/no_import_external_read_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program relay.aleo: External program ''registry.aleo'' is not imported by ''relay.aleo''.'
+- 'Failed to run `VM::deploy for program relay.aleo: Process deployment failed: External program ''registry.aleo'' is not imported by ''relay.aleo''.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/output_child_without_async_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/output_child_without_async_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program parent.aleo: Function ''parent.aleo/foo'' must contain a finalize block, since it calls ''child.aleo/foo''.'
+- 'Failed to run `VM::deploy for program parent.aleo: Process deployment failed: Function ''parent.aleo/foo'' must contain a finalize block, since it calls ''child.aleo/foo''.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/program_callable.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/program_callable.out
@@ -1,6 +1,6 @@
 errors: []
 outputs:
-- execute: 'Failed to evaluate instruction (assert.neq self.caller self.signer;): ''assert.neq'' failed: ''aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx'' is equal to ''aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx'' (should not be equal)'
+- execute: 'Process execution failed: Stack execution failed: Instruction (assert.neq self.caller self.signer;) at index 0 failed: Failed to evaluate: ''assert.neq'' failed: ''aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx'' is equal to ''aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx'' (should not be equal)'
 - verified: true
   execute:
     parent.aleo/foo:

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/unknown_external_mapping_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/unknown_external_mapping_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program relay.aleo: Mapping ''foo'' in ''registry.aleo'' is not defined.'
+- 'Failed to run `VM::deploy for program relay.aleo: Process deployment failed: Mapping ''foo'' in ''registry.aleo'' is not defined.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/unknown_mapping_fail.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/unknown_mapping_fail.out
@@ -1,3 +1,3 @@
 errors:
-- 'Failed to run `VM::deploy for program registry.aleo: Mapping ''foo'' in ''registry.aleo'' is not defined.'
+- 'Failed to run `VM::deploy for program registry.aleo: Process deployment failed: Mapping ''foo'' in ''registry.aleo'' is not defined.'
 outputs: []

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/user_callable.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/user_callable.out
@@ -8,7 +8,7 @@ outputs:
       - '{"type":"public","id":"7571316186508319878827016469809649549608056961397657756993177747855651462866field","value":"aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx"}'
   speculate: the execution was accepted
   add_next_block: succeeded.
-- execute: 'Failed to evaluate instruction (call child.aleo/foo into r0 r1;): Failed to evaluate instruction (assert.eq self.caller self.signer;): ''assert.eq'' failed: ''aleo16w8t56s7v6ud7vu33fr388ph0dq0c7yhp597cyjt88rr3nultcyqcyk9yy'' is not equal to ''aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx'' (should be equal)'
+- execute: 'Process execution failed: Stack execution failed: Instruction (call child.aleo/foo into r0 r1;) at index 0 failed: Failed to evaluate: Call failed: Substack evaluation failed: Instruction (assert.eq self.caller self.signer;) at index 0 failed: ''assert.eq'' failed: ''aleo16w8t56s7v6ud7vu33fr388ph0dq0c7yhp597cyjt88rr3nultcyqcyk9yy'' is not equal to ''aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx'' (should be equal)'
 additional:
 - child_outputs:
     credits.aleo/fee_public:


### PR DESCRIPTION
***NOTE: This is PR #3064 but from a branch on this repo rather than my fork. See [this comment](https://github.com/ProvableHQ/snarkVM/pull/3064#issuecomment-3721734520) for context.***

## Motivation

This partly addresses #3055, ensuring that we expose the failing Aleo instruction from the top-level VM methods.

This does _not_ address the halt=panic issue discussed in #2941, though should pave the way so that when we do introduce better error handling for halts, we have a clear path to propagate these errors up to the VM user.

## Overview

When an instruction fails, the new `StackExecError::Instruction` variant now captures:

1. Index in the function's instruction list
2. The formatted instruction (e.g., "add r0 r1 into r2" or "call foo.aleo/bar")
3. The failure reason

The error format is: "Instruction ({instruction_string}) at index {index} failed: {error}"

For nested calls, you get a "stack trace" of instruction contexts, e.g.

```
Stack execution failed:
  Instruction (call foo.aleo/bar) at index 3 failed:
    Call failed:
      Substack execution failed:
        Instruction (add r0 r1 into r2) at index 7 failed: {actual error}
```

This is propagated up through to the main public VM methods (authorize, execute, evaluate, deploy).

Where necessary, an `Anyhow` variant has been added to the new error types in order to keep the changes minimal and focused on our instruction context. Ideally, we can remove these catch-all `Anyhow` variants as we migrate errors over to dedicated types with `thiserror` (see #3056).

## Follow-up

- [ ] Address #2941, replacing `panic!` behaviour with error handling.