### PR TITLE
feat: Use `Result` for constraint enforcement and assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,6 +2943,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ dependencies = [
  "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "thiserror 2.0.17",
  "tiny-keccak",
 ]
 

--- a/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/circuit/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -73,7 +73,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
 
             // Ensure `lambda` is correct by enforcing:
             // `(that_x - this_x) * lambda == (that_y - this_y)`
-            E::enforce(|| (that_x - this_x, &lambda, that_y - this_y));
+            E::enforce(|| (that_x - this_x, &lambda, that_y - this_y)).expect("BHP lambda constraint unsatisfied");
 
             // Construct `sum_x` as a witness defined as:
             // `sum_x := (B * lambda^2) - A - this_x - that_x`
@@ -83,7 +83,8 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
 
             // Ensure `sum_x` is correct by enforcing:
             // `(B * lambda) * lambda == (A + this_x + that_x + sum_x)`
-            E::enforce(|| (&coeff_b * &lambda, &lambda, &coeff_a + this_x + that_x + &sum_x));
+            E::enforce(|| (&coeff_b * &lambda, &lambda, &coeff_a + this_x + that_x + &sum_x))
+                .expect("BHP sum_x constraint unsatisfied");
 
             // Construct `sum_y` as a witness defined as:
             // `sum_y := -(this_y + (lambda * (this_x - sum_x)))`
@@ -91,7 +92,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
 
             // Ensure `sum_y` is correct by enforcing:
             // `(this_x - sum_x) * lambda == (this_y + sum_y)`
-            E::enforce(|| (this_x - &sum_x, &lambda, this_y + &sum_y));
+            E::enforce(|| (this_x - &sum_x, &lambda, this_y + &sum_y)).expect("BHP sum_y constraint unsatisfied");
 
             (sum_x, sum_y)
         };
@@ -144,7 +145,8 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
                         // which is equivalent to:
                         //     if `bit_2 == 0`, then `montgomery_y = -1/2 * -2 * y = y`
                         //     if `bit_2 == 1`, then `montgomery_y = 1/2 * -2 * y = -y`
-                        E::enforce(|| (-y.double(), bit_2 - &one_half, &montgomery_y)); // 1 constraint
+                        E::enforce(|| (-y.double(), bit_2 - &one_half, &montgomery_y))
+                            .expect("BHP montgomery_y constraint unsatisfied"); // 1 constraint
 
                         montgomery_y
                     };

--- a/circuit/algorithms/src/elligator2/encode.rs
+++ b/circuit/algorithms/src/elligator2/encode.rs
@@ -23,7 +23,7 @@ impl<E: Environment> Elligator2<E> {
         debug_assert!(console::Group::<E::Network>::EDWARDS_D.legendre().is_qnr());
 
         // Ensure the input is nonzero.
-        E::assert_neq(input, Field::<E>::zero());
+        E::assert_neq(input, Field::<E>::zero()).expect("Elligator2 input must be nonzero");
 
         // Define `1` as a constant.
         let one = Field::one();
@@ -55,7 +55,8 @@ impl<E: Environment> Elligator2<E> {
             let ur2 = edwards_d * input.square();
             let one_plus_ur2 = &one + &ur2;
             // Verify A^2 * ur^2 != B(1 + ur^2)^2.
-            E::assert_neq(a.square() * &ur2, &b * one_plus_ur2.square());
+            E::assert_neq(a.square() * &ur2, &b * one_plus_ur2.square())
+                .expect("Elligator2 mapping constraint unsatisfied");
 
             // Let v = -A / (1 + ur^2).
             let v = -&a / one_plus_ur2;
@@ -90,16 +91,16 @@ impl<E: Environment> Elligator2<E> {
             });
             // Verify that the square root is even.
             // Note that the unwrap is safe since the number of bits is always greater than zero,
-            E::assert(!rhs_square_root.to_bits_be().last().unwrap());
+            E::assert(!rhs_square_root.to_bits_be().last().unwrap()).expect("Elligator2 square root must be even");
 
             let y = -&e * rhs_square_root;
 
             // Ensure v * e * x * y != 0.
-            E::assert_neq(&v * &e * &x * &y, Field::<E>::zero());
+            E::assert_neq(&v * &e * &x * &y, Field::<E>::zero()).expect("Elligator2 v*e*x*y must be nonzero");
 
             // Ensure (x, y) is a valid Weierstrass element on: y^2 == x^3 + A * x^2 + B * x.
             let y2 = y.square();
-            E::assert_eq(&y2, rhs);
+            E::assert_eq(&y2, rhs).expect("Elligator2 Weierstrass constraint unsatisfied");
 
             // Convert the Weierstrass element (x, y) to Montgomery element (u, v).
             let u = x * &montgomery_b;
@@ -109,7 +110,7 @@ impl<E: Environment> Elligator2<E> {
             let u2 = &x2 * &montgomery_b2;
             let u3 = &x3 * &montgomery_b3;
             let v2 = &y2 * &montgomery_b3;
-            E::assert_eq(v2, u3 + (montgomery_a * u2) + &u);
+            E::assert_eq(v2, u3 + (montgomery_a * u2) + &u).expect("Elligator2 Montgomery constraint unsatisfied");
 
             (u, v)
         };

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -51,6 +51,9 @@ optional = true
 [dependencies.smallvec]
 workspace = true
 
+[dependencies.thiserror]
+workspace = true
+
 [dev-dependencies.snarkvm-algorithms]
 workspace = true
 features = [ "test" ]

--- a/circuit/environment/src/canary_circuit.rs
+++ b/circuit/environment/src/canary_circuit.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Mode, helpers::Constraint, *};
+use crate::{ConstraintUnsatisfied, Mode, helpers::Constraint, *};
 
 use core::{
     cell::{Cell, RefCell},
@@ -122,7 +122,7 @@ impl Environment for CanaryCircuit {
     }
 
     /// Adds one constraint enforcing that `(A * B) == C`.
-    fn enforce<Fn, A, B, C>(constraint: Fn)
+    fn enforce<Fn, A, B, C>(constraint: Fn) -> Result<(), ConstraintUnsatisfied>
     where
         Fn: FnOnce() -> (A, B, C),
         A: Into<LinearCombination<Self::BaseField>>,
@@ -149,19 +149,13 @@ impl Environment for CanaryCircuit {
                     match a.is_constant() && b.is_constant() && c.is_constant() {
                         true => {
                             // Evaluate the constant constraint.
-                            assert_eq!(
-                                a.value() * b.value(),
-                                c.value(),
-                                "Constant constraint failed: ({a} * {b}) =?= {c}"
-                            );
-
-                            // match self.counter.scope().is_empty() {
-                            //     true => println!("Enforced constraint with constant terms: ({} * {}) =?= {}", a, b, c),
-                            //     false => println!(
-                            //         "Enforced constraint with constant terms ({}): ({} * {}) =?= {}",
-                            //         self.counter.scope(), a, b, c
-                            //     ),
-                            // }
+                            if a.value() * b.value() != c.value() {
+                                return Err(ConstraintUnsatisfied {
+                                    a: a.to_string(),
+                                    b: b.to_string(),
+                                    c: c.to_string(),
+                                });
+                            }
                         }
                         false => {
                             // Construct the constraint object.
@@ -170,7 +164,8 @@ impl Environment for CanaryCircuit {
                             circuit.borrow_mut().enforce(constraint)
                         }
                     }
-                });
+                    Ok(())
+                })
             } else {
                 Self::halt("Tried to add a new constraint in witness mode")
             }

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Mode, helpers::Constraint, *};
+use crate::{ConstraintUnsatisfied, Mode, helpers::Constraint, *};
 
 use core::{
     cell::{Cell, RefCell},
@@ -146,7 +146,7 @@ impl Environment for Circuit {
     }
 
     /// Adds one constraint enforcing that `(A * B) == C`.
-    fn enforce<Fn, A, B, C>(constraint: Fn)
+    fn enforce<Fn, A, B, C>(constraint: Fn) -> Result<(), ConstraintUnsatisfied>
     where
         Fn: FnOnce() -> (A, B, C),
         A: Into<LinearCombination<Self::BaseField>>,
@@ -173,19 +173,13 @@ impl Environment for Circuit {
                     match a.is_constant() && b.is_constant() && c.is_constant() {
                         true => {
                             // Evaluate the constant constraint.
-                            assert_eq!(
-                                a.value() * b.value(),
-                                c.value(),
-                                "Constant constraint failed: ({a} * {b}) =?= {c}"
-                            );
-
-                            // match self.counter.scope().is_empty() {
-                            //     true => println!("Enforced constraint with constant terms: ({} * {}) =?= {}", a, b, c),
-                            //     false => println!(
-                            //         "Enforced constraint with constant terms ({}): ({} * {}) =?= {}",
-                            //         self.counter.scope(), a, b, c
-                            //     ),
-                            // }
+                            if a.value() * b.value() != c.value() {
+                                return Err(ConstraintUnsatisfied {
+                                    a: a.to_string(),
+                                    b: b.to_string(),
+                                    c: c.to_string(),
+                                });
+                            }
                         }
                         false => {
                             // Construct the constraint object.
@@ -194,7 +188,8 @@ impl Environment for Circuit {
                             circuit.borrow_mut().enforce(constraint)
                         }
                     }
-                });
+                    Ok(())
+                })
             } else {
                 Self::halt("Tried to add a new constraint in witness mode")
             }

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Assignment, Inject, LinearCombination, Mode, R1CS, Variable, witness_mode};
+use crate::{Assignment, ConstraintUnsatisfied, Inject, LinearCombination, Mode, R1CS, Variable, witness_mode};
 use snarkvm_curves::AffineCurve;
 use snarkvm_fields::traits::*;
 
@@ -62,7 +62,7 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
         Fn: FnOnce() -> Output;
 
     /// Adds one constraint enforcing that `(A * B) == C`.
-    fn enforce<Fn, A, B, C>(constraint: Fn)
+    fn enforce<Fn, A, B, C>(constraint: Fn) -> Result<(), ConstraintUnsatisfied>
     where
         Fn: FnOnce() -> (A, B, C),
         A: Into<LinearCombination<Self::BaseField>>,
@@ -70,12 +70,14 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
         C: Into<LinearCombination<Self::BaseField>>;
 
     /// Adds one constraint enforcing that the given boolean is `true`.
-    fn assert<Boolean: Into<LinearCombination<Self::BaseField>>>(boolean: Boolean) {
+    fn assert<Boolean: Into<LinearCombination<Self::BaseField>>>(
+        boolean: Boolean,
+    ) -> Result<(), ConstraintUnsatisfied> {
         Self::enforce(|| (boolean, Self::one(), Self::one()))
     }
 
     /// Adds one constraint enforcing that the `A == B`.
-    fn assert_eq<A, B>(a: A, b: B)
+    fn assert_eq<A, B>(a: A, b: B) -> Result<(), ConstraintUnsatisfied>
     where
         A: Into<LinearCombination<Self::BaseField>>,
         B: Into<LinearCombination<Self::BaseField>>,
@@ -84,7 +86,7 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     }
 
     /// Adds one constraint enforcing that the `A != B`.
-    fn assert_neq<A, B>(a: A, b: B)
+    fn assert_neq<A, B>(a: A, b: B) -> Result<(), ConstraintUnsatisfied>
     where
         A: Into<LinearCombination<Self::BaseField>>,
         B: Into<LinearCombination<Self::BaseField>>,
@@ -102,7 +104,7 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
         };
 
         // Enforce `(a - b) * multiplier == 1`.
-        Self::enforce(|| (a_minus_b, multiplier, Self::one()));
+        Self::enforce(|| (a_minus_b, multiplier, Self::one()))
     }
 
     /// Returns `true` if all constraints in the environment are satisfied.

--- a/circuit/environment/src/error.rs
+++ b/circuit/environment/src/error.rs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::*;
+//! The set of errors that can be encountered within the circuit environment.
 
-impl<E: Environment> Boolean<E> {
-    /// Asserts that all bits in `bits_le` are zero.
-    #[doc(hidden)]
-    pub fn assert_bits_are_zero(bits_le: &[Boolean<E>]) {
-        let mut sum = Self::constant(false).0;
-        for bit in bits_le {
-            sum += &**bit;
-        }
-        E::assert_eq(sum, E::zero()).expect("bits_are_zero assertion failed");
-    }
+use thiserror::Error;
+
+/// A constraint was not satisfied.
+#[derive(Debug, Error)]
+#[error("Constraint unsatisfied: ({a} * {b}) != {c}")]
+pub struct ConstraintUnsatisfied {
+    pub a: String,
+    pub b: String,
+    pub c: String,
 }

--- a/circuit/environment/src/lib.rs
+++ b/circuit/environment/src/lib.rs
@@ -29,6 +29,9 @@ pub use circuit::*;
 pub mod environment;
 pub use environment::*;
 
+pub mod error;
+pub use error::*;
+
 pub mod helpers;
 pub use helpers::*;
 
@@ -45,6 +48,7 @@ pub use traits::*;
 pub mod prelude {
     pub use crate::{
         CircuitType,
+        ConstraintUnsatisfied,
         Count,
         Environment,
         LinearCombination,

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Mode, helpers::Constraint, *};
+use crate::{ConstraintUnsatisfied, Mode, helpers::Constraint, *};
 
 use core::{
     cell::{Cell, RefCell},
@@ -122,7 +122,7 @@ impl Environment for TestnetCircuit {
     }
 
     /// Adds one constraint enforcing that `(A * B) == C`.
-    fn enforce<Fn, A, B, C>(constraint: Fn)
+    fn enforce<Fn, A, B, C>(constraint: Fn) -> Result<(), ConstraintUnsatisfied>
     where
         Fn: FnOnce() -> (A, B, C),
         A: Into<LinearCombination<Self::BaseField>>,
@@ -149,19 +149,13 @@ impl Environment for TestnetCircuit {
                     match a.is_constant() && b.is_constant() && c.is_constant() {
                         true => {
                             // Evaluate the constant constraint.
-                            assert_eq!(
-                                a.value() * b.value(),
-                                c.value(),
-                                "Constant constraint failed: ({a} * {b}) =?= {c}"
-                            );
-
-                            // match self.counter.scope().is_empty() {
-                            //     true => println!("Enforced constraint with constant terms: ({} * {}) =?= {}", a, b, c),
-                            //     false => println!(
-                            //         "Enforced constraint with constant terms ({}): ({} * {}) =?= {}",
-                            //         self.counter.scope(), a, b, c
-                            //     ),
-                            // }
+                            if a.value() * b.value() != c.value() {
+                                return Err(ConstraintUnsatisfied {
+                                    a: a.to_string(),
+                                    b: b.to_string(),
+                                    c: c.to_string(),
+                                });
+                            }
                         }
                         false => {
                             // Construct the constraint object.
@@ -170,7 +164,8 @@ impl Environment for TestnetCircuit {
                             circuit.borrow_mut().enforce(constraint)
                         }
                     }
-                });
+                    Ok(())
+                })
             } else {
                 Self::halt("Tried to add a new constraint in witness mode")
             }

--- a/circuit/network/src/canary_v0.rs
+++ b/circuit/network/src/canary_v0.rs
@@ -423,7 +423,7 @@ impl Environment for AleoCanaryV0 {
     }
 
     /// Adds one constraint enforcing that `(A * B) == C`.
-    fn enforce<Fn, A, B, C>(constraint: Fn)
+    fn enforce<Fn, A, B, C>(constraint: Fn) -> Result<(), ConstraintUnsatisfied>
     where
         Fn: FnOnce() -> (A, B, C),
         A: Into<LinearCombination<Self::BaseField>>,

--- a/circuit/network/src/testnet_v0.rs
+++ b/circuit/network/src/testnet_v0.rs
@@ -423,7 +423,7 @@ impl Environment for AleoTestnetV0 {
     }
 
     /// Adds one constraint enforcing that `(A * B) == C`.
-    fn enforce<Fn, A, B, C>(constraint: Fn)
+    fn enforce<Fn, A, B, C>(constraint: Fn) -> Result<(), ConstraintUnsatisfied>
     where
         Fn: FnOnce() -> (A, B, C),
         A: Into<LinearCombination<Self::BaseField>>,

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -423,7 +423,7 @@ impl Environment for AleoV0 {
     }
 
     /// Adds one constraint enforcing that `(A * B) == C`.
-    fn enforce<Fn, A, B, C>(constraint: Fn)
+    fn enforce<Fn, A, B, C>(constraint: Fn) -> Result<(), ConstraintUnsatisfied>
     where
         Fn: FnOnce() -> (A, B, C),
         A: Into<LinearCombination<Self::BaseField>>,

--- a/circuit/program/src/data/literal/cast/field.rs
+++ b/circuit/program/src/data/literal/cast/field.rs
@@ -35,7 +35,7 @@ impl<E: Environment> Cast<Boolean<E>> for Field<E> {
     #[inline]
     fn cast(&self) -> Boolean<E> {
         let is_one = self.is_one();
-        E::assert(self.is_zero().bitor(&is_one));
+        E::assert(self.is_zero().bitor(&is_one)).expect("Field must be zero or one to cast to Boolean");
         is_one
     }
 }

--- a/circuit/program/src/data/literal/cast/integer.rs
+++ b/circuit/program/src/data/literal/cast/integer.rs
@@ -37,7 +37,7 @@ impl<E: Environment, I: IntegerType> Cast<Boolean<E>> for Integer<E, I> {
     #[inline]
     fn cast(&self) -> Boolean<E> {
         let is_one = self.is_one();
-        E::assert(self.is_zero().bitor(&is_one));
+        E::assert(self.is_zero().bitor(&is_one)).expect("Integer must be zero or one to cast to Boolean");
         is_one
     }
 }
@@ -88,7 +88,8 @@ impl<E: Environment, I0: IntegerType, I1: IntegerType> Cast<Integer<E, I1>> for 
                 // If the source type is smaller than or equal to the destination type, check that the most significant bit is zero.
                 // Then instantiate the new integer from the lower bits.
                 true => {
-                    E::assert(!&bits_le[I0::BITS.saturating_sub(1) as usize]);
+                    E::assert(!&bits_le[I0::BITS.saturating_sub(1) as usize])
+                        .expect("Signed integer MSB must be zero to cast to unsigned");
                     Integer::<E, I1>::from_bits_le(&bits_le)
                 }
                 // If the source type is larger than the destination type, check that the upper bits are zero.
@@ -117,7 +118,7 @@ impl<E: Environment, I0: IntegerType, I1: IntegerType> Cast<Integer<E, I1>> for 
                     // Check that the upper bits match the most significant bit.
                     let upper_bits = bits_le.iter().skip(I1::BITS.saturating_sub(1) as usize);
                     for bit in upper_bits {
-                        E::assert_eq(&msb, bit);
+                        E::assert_eq(&msb, bit).expect("Signed integer upper bits must match MSB for cast");
                     }
                     // Instantiate the new integer from the lower bits and the most significant bit.
                     let mut lower_bits: Vec<_> =

--- a/circuit/program/src/data/literal/cast/scalar.rs
+++ b/circuit/program/src/data/literal/cast/scalar.rs
@@ -37,7 +37,7 @@ impl<E: Environment> Cast<Boolean<E>> for Scalar<E> {
     #[inline]
     fn cast(&self) -> Boolean<E> {
         let is_one = self.is_one();
-        E::assert(self.is_zero().bitor(&is_one));
+        E::assert(self.is_zero().bitor(&is_one)).expect("Scalar must be zero or one to cast to Boolean");
         is_one
     }
 }

--- a/circuit/program/src/data/record/decrypt.rs
+++ b/circuit/program/src/data/record/decrypt.rs
@@ -23,7 +23,7 @@ impl<A: Aleo> Record<A, Ciphertext<A>> {
         // Decrypt the record.
         let record = self.decrypt_symmetric_unchecked(record_view_key);
         // Ensure the view key corresponds to the record owner.
-        A::assert_eq(view_key.to_address(), record.owner().deref());
+        A::assert_eq(view_key.to_address(), record.owner().deref()).expect("View key must match record owner");
         // Return the decrypted record.
         record
     }

--- a/circuit/program/src/data/record/encrypt.rs
+++ b/circuit/program/src/data/record/encrypt.rs
@@ -26,7 +26,8 @@ impl<A: Aleo> Record<A, Plaintext<A>> {
     /// and returns the encrypted record alongside the record view key.
     pub fn encrypt_symmetric(&self, randomizer: &Scalar<A>) -> (Record<A, Ciphertext<A>>, Field<A>) {
         // Ensure the randomizer corresponds to the record nonce.
-        A::assert_eq(&self.nonce, A::g_scalar_multiply(randomizer));
+        A::assert_eq(&self.nonce, A::g_scalar_multiply(randomizer))
+            .expect("Randomizer must correspond to record nonce");
         // Compute the record view key.
         let record_view_key = ((*self.owner).to_group() * randomizer).to_x_coordinate();
         // Encrypt the record.

--- a/circuit/program/src/response/mod.rs
+++ b/circuit/program/src/response/mod.rs
@@ -70,7 +70,7 @@ impl<A: Aleo> OutputID<A> {
         // Inject the expected hash as `Mode::Public`.
         let output_hash = Field::new(Mode::Public, expected_hash.eject_value());
         // Ensure the injected hash matches the given hash.
-        A::assert_eq(&output_hash, expected_hash);
+        A::assert_eq(&output_hash, expected_hash).expect("Constant output hash mismatch");
         // Return the output ID.
         Self::Constant(output_hash)
     }
@@ -80,7 +80,7 @@ impl<A: Aleo> OutputID<A> {
         // Inject the expected hash as `Mode::Public`.
         let output_hash = Field::new(Mode::Public, expected_hash.eject_value());
         // Ensure the injected hash matches the given hash.
-        A::assert_eq(&output_hash, expected_hash);
+        A::assert_eq(&output_hash, expected_hash).expect("Public output hash mismatch");
         // Return the output ID.
         Self::Public(output_hash)
     }
@@ -90,7 +90,7 @@ impl<A: Aleo> OutputID<A> {
         // Inject the ciphertext hash as `Mode::Public`.
         let output_hash = Field::new(Mode::Public, expected_hash.eject_value());
         // Ensure the injected hash matches the given hash.
-        A::assert_eq(&output_hash, expected_hash);
+        A::assert_eq(&output_hash, expected_hash).expect("Private output hash mismatch");
         // Return the output ID.
         Self::Private(output_hash)
     }
@@ -106,14 +106,14 @@ impl<A: Aleo> OutputID<A> {
         let output_checksum = Field::new(Mode::Public, expected_checksum.eject_value());
         let output_sender_ciphertext = Field::new(Mode::Public, expected_sender_ciphertext.eject_value()); // Note: Set to `0field` here and in consensus to make optional or deactivated.
         // Ensure the injected commitment and checksum matches the given commitment and checksum.
-        A::assert_eq(&output_commitment, expected_commitment);
-        A::assert_eq(&output_checksum, expected_checksum);
+        A::assert_eq(&output_commitment, expected_commitment).expect("Record output commitment mismatch");
+        A::assert_eq(&output_checksum, expected_checksum).expect("Record output checksum mismatch");
         // Ensure the sender ciphertext matches, or the sender ciphertext is zero.
         // Note: The option to allow a zero-value in the sender ciphertext allows
         // this feature to become optional or deactivated in the future.
         let is_sender_ciphertext_equal = output_sender_ciphertext.is_equal(&expected_sender_ciphertext);
         let is_sender_ciphertext_zero = output_sender_ciphertext.is_zero();
-        A::assert(is_sender_ciphertext_equal | is_sender_ciphertext_zero);
+        A::assert(is_sender_ciphertext_equal | is_sender_ciphertext_zero).expect("Record sender ciphertext mismatch");
         // Return the output ID.
         Self::Record(output_commitment, output_checksum, output_sender_ciphertext)
     }
@@ -123,7 +123,7 @@ impl<A: Aleo> OutputID<A> {
         // Inject the expected hash as `Mode::Public`.
         let output_hash = Field::new(Mode::Public, expected_hash.eject_value());
         // Ensure the injected hash matches the given commitment.
-        A::assert_eq(&output_hash, expected_hash);
+        A::assert_eq(&output_hash, expected_hash).expect("ExternalRecord output hash mismatch");
         // Return the output ID.
         Self::ExternalRecord(output_hash)
     }
@@ -133,7 +133,7 @@ impl<A: Aleo> OutputID<A> {
         // Inject the expected hash as `Mode::Public`.
         let output_hash = Field::new(Mode::Public, expected_hash.eject_value());
         // Ensure the injected hash matches the given hash.
-        A::assert_eq(&output_hash, expected_hash);
+        A::assert_eq(&output_hash, expected_hash).expect("Future output hash mismatch");
         // Return the output ID.
         Self::Future(output_hash)
     }

--- a/circuit/types/boolean/src/and.rs
+++ b/circuit/types/boolean/src/and.rs
@@ -94,7 +94,7 @@ impl<E: Environment> BitAndAssign<&Boolean<E>> for Boolean<E> {
 
                 // Ensure `self` * `other` = `output`
                 // `output` is `1` iff `self` AND `other` are both `1`.
-                E::enforce(|| (&*self, other, &output));
+                E::enforce(|| (&*self, other, &output)).expect("Boolean AND constraint unsatisfied");
 
                 output
             }

--- a/circuit/types/boolean/src/helpers/comparator.rs
+++ b/circuit/types/boolean/src/helpers/comparator.rs
@@ -38,6 +38,6 @@ impl<E: Environment> Boolean<E> {
         // Compute `!(constant_bits_le < circuit_bits_le)`, equivalent to `constant_bits_le >= circuit_bits_le`.
         let is_less_than_or_equal = Boolean::is_less_than_or_equal_constant(circuit_bits_le, constant_bits_le);
         // Assert that `circuit_bits_le <= constant_bits_le`.
-        E::assert(is_less_than_or_equal);
+        E::assert(is_less_than_or_equal).expect("less_than_or_equal assertion failed");
     }
 }

--- a/circuit/types/boolean/src/lib.rs
+++ b/circuit/types/boolean/src/lib.rs
@@ -66,7 +66,7 @@ impl<E: Environment> Inject for Boolean<E> {
 
         // Ensure (1 - a) * a = 0
         // `a` must be either 0 or 1.
-        E::enforce(|| (E::one() - &variable, &variable, E::zero()));
+        E::enforce(|| (E::one() - &variable, &variable, E::zero())).expect("Boolean variable constraint unsatisfied");
 
         Self(variable.into())
     }
@@ -227,14 +227,8 @@ mod tests {
 
             // Ensure `a` is either 0 or 1:
             // (1 - a) * a = 0
-            assert!(
-                std::panic::catch_unwind(|| Circuit::enforce(|| (
-                    Circuit::one() - &candidate,
-                    candidate,
-                    Circuit::zero()
-                )))
-                .is_err()
-            );
+            // For constant constraints that fail, `enforce` returns Err.
+            assert!(Circuit::enforce(|| (Circuit::one() - &candidate, candidate, Circuit::zero())).is_err());
             assert_eq!(0, Circuit::num_constraints());
 
             Circuit::reset();
@@ -244,7 +238,7 @@ mod tests {
 
             // Ensure `a` is either 0 or 1:
             // (1 - a) * a = 0
-            Circuit::enforce(|| (Circuit::one() - &candidate, candidate, Circuit::zero()));
+            Circuit::enforce(|| (Circuit::one() - &candidate, candidate, Circuit::zero())).unwrap();
             assert!(!Circuit::is_satisfied());
 
             Circuit::reset();
@@ -254,7 +248,7 @@ mod tests {
 
             // Ensure `a` is either 0 or 1:
             // (1 - a) * a = 0
-            Circuit::enforce(|| (Circuit::one() - &candidate, candidate, Circuit::zero()));
+            Circuit::enforce(|| (Circuit::one() - &candidate, candidate, Circuit::zero())).unwrap();
             assert!(!Circuit::is_satisfied());
 
             Circuit::reset();

--- a/circuit/types/boolean/src/nand.rs
+++ b/circuit/types/boolean/src/nand.rs
@@ -49,7 +49,7 @@ impl<E: Environment> Nand<Self> for Boolean<E> {
 
             // Ensure `self` * `other` = (1 - `output`)
             // `output` is `1` iff `self` or `other` is `0`, otherwise `output` is `0`.
-            E::enforce(|| (self, other, E::one() - &output.0));
+            E::enforce(|| (self, other, E::one() - &output.0)).expect("Boolean NAND constraint unsatisfied");
 
             output
         }

--- a/circuit/types/boolean/src/nor.rs
+++ b/circuit/types/boolean/src/nor.rs
@@ -49,7 +49,8 @@ impl<E: Environment> Nor<Self> for Boolean<E> {
 
             // Ensure (1 - `self`) * (1 - `other`) = `output`
             // `output` is `1` iff `self` and `other` are both `0`, otherwise `output` is `0`.
-            E::enforce(|| (E::one() - &self.0, E::one() - &other.0, &output));
+            E::enforce(|| (E::one() - &self.0, E::one() - &other.0, &output))
+                .expect("Boolean NOR constraint unsatisfied");
 
             output
         }

--- a/circuit/types/boolean/src/or.rs
+++ b/circuit/types/boolean/src/or.rs
@@ -95,7 +95,7 @@ impl<E: Environment> BitOrAssign<&Boolean<E>> for Boolean<E> {
 
                 // Ensure (1 - `self`) * (1 - `other`) = (1 - `output`)
                 // `output` is `1` iff `self` OR `other` is `1`.
-                E::enforce(|| (E::one() - &self.0, E::one() - &other.0, E::one() - &output.0));
+                E::enforce(|| (E::one() - &self.0, E::one() - &other.0, E::one() - &output.0)).expect("Boolean OR constraint unsatisfied");
 
                 output
             }

--- a/circuit/types/boolean/src/ternary.rs
+++ b/circuit/types/boolean/src/ternary.rs
@@ -70,7 +70,8 @@ impl<E: Environment> Ternary for Boolean<E> {
             //
             // See `Field::ternary()` for the proof of correctness.
             //
-            E::enforce(|| (condition, (&first.0 - &second.0), (&output.0 - &second.0)));
+            E::enforce(|| (condition, (&first.0 - &second.0), (&output.0 - &second.0)))
+                .expect("Boolean ternary constraint unsatisfied");
 
             output
         }

--- a/circuit/types/boolean/src/xor.rs
+++ b/circuit/types/boolean/src/xor.rs
@@ -112,7 +112,7 @@ impl<E: Environment> BitXorAssign<&Boolean<E>> for Boolean<E> {
                 // 2a * b = a + b - c
                 // (a + a) * b = a + b - c
                 //
-                E::enforce(|| ((&self.0 + &self.0), other, (&self.0 + &other.0 - &output.0)));
+                E::enforce(|| ((&self.0 + &self.0), other, (&self.0 + &other.0 - &output.0))).expect("Boolean XOR constraint unsatisfied");
 
                 output
             }

--- a/circuit/types/field/src/div_unchecked.rs
+++ b/circuit/types/field/src/div_unchecked.rs
@@ -41,7 +41,7 @@ impl<E: Environment> DivUnchecked<Field<E>> for Field<E> {
 
                 // Ensure the quotient is correct by enforcing:
                 // `quotient * other == self`.
-                E::enforce(|| (&quotient, other, self));
+                E::enforce(|| (&quotient, other, self)).expect("Field division constraint unsatisfied");
 
                 // Return the quotient.
                 quotient

--- a/circuit/types/field/src/equal.rs
+++ b/circuit/types/field/src/equal.rs
@@ -121,10 +121,10 @@ impl<E: Environment> Equal<Self> for Field<E> {
                 let is_eq = !is_neq.clone();
 
                 // Check 1: (a - b) * multiplier = is_neq
-                E::enforce(|| (&delta, &multiplier, &is_neq));
+                E::enforce(|| (&delta, &multiplier, &is_neq)).expect("Field equality check 1 failed");
 
                 // Check 2: (a - b) * not(is_neq) = 0
-                E::enforce(|| (delta, is_eq, E::zero()));
+                E::enforce(|| (delta, is_eq, E::zero())).expect("Field equality check 2 failed");
 
                 // Return `is_neq`.
                 is_neq
@@ -305,10 +305,10 @@ mod tests {
             let is_eq = !is_neq.clone();
 
             // Check 1: (a - b) * multiplier = is_neq
-            Circuit::enforce(|| (delta.clone(), multiplier, is_neq.clone()));
+            Circuit::enforce(|| (delta.clone(), multiplier, is_neq.clone())).unwrap();
 
             // Check 2: (a - b) * not(is_neq) = 0
-            Circuit::enforce(|| (delta, is_eq, Circuit::zero()));
+            Circuit::enforce(|| (delta, is_eq, Circuit::zero())).unwrap();
         };
 
         //

--- a/circuit/types/field/src/helpers/to_bits.rs
+++ b/circuit/types/field/src/helpers/to_bits.rs
@@ -78,7 +78,7 @@ impl<E: Environment> Field<E> {
         }
 
         // Ensure value * 1 == (2^i * b_i + ... + 2^0 * b_0)
-        E::assert_eq(self, accumulator);
+        E::assert_eq(self, accumulator).expect("Field to_bits constraint unsatisfied");
 
         bits_le
     }

--- a/circuit/types/field/src/helpers/to_lower_bits.rs
+++ b/circuit/types/field/src/helpers/to_lower_bits.rs
@@ -44,7 +44,7 @@ impl<E: Environment> ToLowerBits for Field<E> {
 
         // Ensure value * 1 == (2^k * b_k + ... + 2^0 * b_0)
         // and ensures that b_n, ..., b_{n-k} are all equal to zero.
-        E::assert_eq(self, accumulator);
+        E::assert_eq(self, accumulator).expect("Field to_lower_bits constraint unsatisfied");
 
         bits
     }

--- a/circuit/types/field/src/helpers/to_upper_bits.rs
+++ b/circuit/types/field/src/helpers/to_upper_bits.rs
@@ -57,7 +57,7 @@ impl<E: Environment> ToUpperBits for Field<E> {
 
         // Ensure value * 1 == (2^n * b_n + ... + 2^{n-k} * b_{n-k})
         // and ensures that b_{n-k-1}, ..., b_0 are all equal to zero.
-        E::assert_eq(self, accumulator);
+        E::assert_eq(self, accumulator).expect("Field to_upper_bits constraint unsatisfied");
 
         bits
     }

--- a/circuit/types/field/src/inverse.rs
+++ b/circuit/types/field/src/inverse.rs
@@ -41,7 +41,7 @@ impl<E: Environment> Inverse for Field<E> {
         });
 
         // Ensure `self` * `self^(-1)` == 1.
-        E::enforce(|| (self, &inverse, E::one()));
+        E::enforce(|| (self, &inverse, E::one())).expect("Field inverse constraint unsatisfied");
 
         inverse
     }

--- a/circuit/types/field/src/mul.rs
+++ b/circuit/types/field/src/mul.rs
@@ -66,7 +66,7 @@ impl<E: Environment> MulAssign<&Field<E>> for Field<E> {
                 let product = witness!(|self, other| self * other);
 
                 // Ensure self * other == product.
-                E::enforce(|| (&*self, other, &product));
+                E::enforce(|| (&*self, other, &product)).expect("Field multiplication constraint unsatisfied");
 
                 *self = product;
             }

--- a/circuit/types/field/src/square_root.rs
+++ b/circuit/types/field/src/square_root.rs
@@ -28,7 +28,7 @@ impl<E: Environment> SquareRoot for Field<E> {
         });
 
         // Ensure `square_root` * `square_root` == `self`.
-        E::enforce(|| (&square_root, &square_root, self));
+        E::enforce(|| (&square_root, &square_root, self)).expect("Square root constraint unsatisfied");
 
         // Define the MODULUS_MINUS_ONE_DIV_TWO as a constant.
         let modulus_minus_one_div_two = match E::BaseField::from_bigint(E::BaseField::modulus_minus_one_div_two()) {
@@ -39,7 +39,7 @@ impl<E: Environment> SquareRoot for Field<E> {
         // Ensure that `square_root` is less than or equal to (MODULUS - 1) / 2.
         // This ensures that the resulting square root is unique.
         let is_less_than_or_equal = square_root.is_less_than_or_equal(&modulus_minus_one_div_two);
-        E::assert(is_less_than_or_equal);
+        E::assert(is_less_than_or_equal).expect("Square root uniqueness constraint unsatisfied");
 
         square_root
     }
@@ -54,11 +54,11 @@ impl<E: Environment> Field<E> {
         });
 
         // Ensure `square_root` * `square_root` == `self`.
-        E::enforce(|| (&square_root, &square_root, self));
+        E::enforce(|| (&square_root, &square_root, self)).expect("Even square root constraint unsatisfied");
 
         // Ensure that the LSB of the square root is zero.
         // Note that this unwrap is safe since the number of bits is always greater than zero.
-        E::assert(!square_root.to_bits_be().last().unwrap());
+        E::assert(!square_root.to_bits_be().last().unwrap()).expect("Even square root LSB constraint unsatisfied");
 
         square_root
     }
@@ -110,7 +110,7 @@ impl<E: Environment> Field<E> {
 
         // Enforce that the first root squared is equal to the square.
         // Note that if `self` is not a square, then `first_root` and `square` are both zero and the constraint is satisfied.
-        E::enforce(|| (&first_root, &first_root, &square));
+        E::enforce(|| (&first_root, &first_root, &square)).expect("Flagged square root constraint unsatisfied");
 
         // Initialize the second root as the negation of the first root.
         let second_root = first_root.clone().neg();

--- a/circuit/types/field/src/ternary.rs
+++ b/circuit/types/field/src/ternary.rs
@@ -84,7 +84,8 @@ impl<E: Environment> Ternary for Field<E> {
             //       a - b = 0
             // => if a != b, as LHS != RHS, the witness is incorrect.
             //
-            E::enforce(|| ((first - second), condition, (&witness - second)));
+            E::enforce(|| ((first - second), condition, (&witness - second)))
+                .expect("Field ternary constraint unsatisfied");
 
             witness
         }

--- a/circuit/types/group/src/add.rs
+++ b/circuit/types/group/src/add.rs
@@ -74,14 +74,14 @@ impl<E: Environment> Add<&Self> for Group<E> {
             // x3 * (v2 + 1) = v0 + v1
             let v2_plus_one = &v2 + &Field::one();
             let v0_plus_v1 = &v0 + &v1;
-            E::enforce(|| (&x3, v2_plus_one, v0_plus_v1));
+            E::enforce(|| (&x3, v2_plus_one, v0_plus_v1)).expect("Group add x3 constraint unsatisfied");
 
             // Ensure y3 is well-formed.
             // y3 * (1 - v2) = u + (a * v0) - v1
             let one_minus_v2 = Field::one() - v2;
             let a_v0 = v0 * a;
             let u_plus_a_v0_minus_v1 = u + a_v0 - v1;
-            E::enforce(|| (&y3, one_minus_v2, u_plus_a_v0_minus_v1));
+            E::enforce(|| (&y3, one_minus_v2, u_plus_a_v0_minus_v1)).expect("Group add y3 constraint unsatisfied");
 
             Self { x: x3, y: y3 }
         }

--- a/circuit/types/group/src/double.rs
+++ b/circuit/types/group/src/double.rs
@@ -48,13 +48,14 @@ impl<E: Environment> Double for Group<E> {
             // x3 * (ax^2 + y^2) = 2xy
             let ax2_plus_y2 = &ax2 + &y2;
             let two_xy = xy.double();
-            E::enforce(|| (&x3, &ax2_plus_y2, two_xy));
+            E::enforce(|| (&x3, &ax2_plus_y2, two_xy)).expect("Group double x3 constraint unsatisfied");
 
             // Ensure y3 is well-formed.
             // y3 * (2 - (ax^2 + y^2)) = y^2 - ax^2
             let y2_minus_a_x2 = y2 - ax2;
             let two_minus_ax2_minus_y2 = two - ax2_plus_y2;
-            E::enforce(|| (&y3, two_minus_ax2_minus_y2, y2_minus_a_x2));
+            E::enforce(|| (&y3, two_minus_ax2_minus_y2, y2_minus_a_x2))
+                .expect("Group double y3 constraint unsatisfied");
 
             Group { x: x3, y: y3 }
         }
@@ -77,13 +78,14 @@ impl<E: Environment> Group<E> {
         // double.x * (ax^2 + y^2) = 2xy
         let ax2_plus_y2 = &ax2 + &y2;
         let two_xy = xy.double();
-        E::enforce(|| (&double.x, &ax2_plus_y2, two_xy));
+        E::enforce(|| (&double.x, &ax2_plus_y2, two_xy)).expect("Group enforce_double x constraint unsatisfied");
 
         // Ensure double.y is the ordinate of the double of self.
         // double.y * (2 - (ax^2 + y^2)) = y^2 - ax^2
         let y2_minus_a_x2 = y2 - ax2;
         let two_minus_ax2_minus_y2 = two - ax2_plus_y2;
-        E::enforce(|| (&double.y, two_minus_ax2_minus_y2, y2_minus_a_x2));
+        E::enforce(|| (&double.y, two_minus_ax2_minus_y2, y2_minus_a_x2))
+            .expect("Group enforce_double y constraint unsatisfied");
     }
 }
 

--- a/circuit/types/group/src/helpers/from_x_coordinate.rs
+++ b/circuit/types/group/src/helpers/from_x_coordinate.rs
@@ -48,7 +48,7 @@ impl<E: Environment> Group<E> {
 
         // Compute y^2 = (a * x^2 - 1) / (d * x^2 - 1), i.e. solve the curve equation for y^2.
         let yy: Field<E> = witness!(|a_xx_minus_1, d_xx_minus_1| { a_xx_minus_1 / d_xx_minus_1 });
-        E::enforce(|| (&yy, &d_xx_minus_1, &a_xx_minus_1));
+        E::enforce(|| (&yy, &d_xx_minus_1, &a_xx_minus_1)).expect("Group from_x_coordinate y^2 constraint unsatisfied");
 
         // Compute both square roots of y^2, with a flag indicating whether y^2 is a square or not.
         // Note that there is **no** ordering on the square roots in the circuit computation.

--- a/circuit/types/group/src/lib.rs
+++ b/circuit/types/group/src/lib.rs
@@ -92,7 +92,7 @@ impl<E: Environment> Group<E> {
         let third = (a * x2) - Field::one();
 
         // Ensure y^2 * (dx^2 - 1) = (ax^2 - 1).
-        E::enforce(|| (first, second, third));
+        E::enforce(|| (first, second, third)).expect("Group enforce_on_curve constraint unsatisfied");
     }
 }
 

--- a/circuit/types/integers/src/add_checked.rs
+++ b/circuit/types/integers/src/add_checked.rs
@@ -94,7 +94,7 @@ impl<E: Environment, I: IntegerType> AddChecked<Self> for Integer<E, I> {
             //   - Note: the result of an overflow and underflow must be negative and positive, respectively.
             let is_same_sign = self.msb().is_equal(other.msb());
             let is_overflow = is_same_sign & sum.msb().is_not_equal(self.msb());
-            E::assert_eq(is_overflow, E::zero());
+            E::assert_eq(is_overflow, E::zero()).expect("Signed integer addition overflow check failed");
 
             sum
         } else {
@@ -104,7 +104,7 @@ impl<E: Environment, I: IntegerType> AddChecked<Self> for Integer<E, I> {
             // Check that the computed sum is equal to the witnessed sum, in the base field.
             let computed_sum = self.to_field() + other.to_field();
             let witnessed_sum = sum.to_field();
-            E::assert_eq(computed_sum, witnessed_sum);
+            E::assert_eq(computed_sum, witnessed_sum).expect("Unsigned integer addition constraint unsatisfied");
 
             sum
         }

--- a/circuit/types/integers/src/div_checked.rs
+++ b/circuit/types/integers/src/div_checked.rs
@@ -84,7 +84,7 @@ impl<E: Environment, I: IntegerType> DivChecked<Self> for Integer<E, I> {
                     let min = Integer::constant(console::Integer::MIN);
                     let neg_one = Integer::constant(-console::Integer::one());
                     let overflows = self.is_equal(&min) & other.is_equal(&neg_one);
-                    E::assert(!overflows);
+                    E::assert(!overflows).expect("Signed integer division overflow check failed");
 
                     // Divide the absolute value of `self` and `other` in the base field.
                     // Note that it is safe to use `abs_wrapped`, since the case for console::Integer::MIN is handled above.

--- a/circuit/types/integers/src/div_wrapped.rs
+++ b/circuit/types/integers/src/div_wrapped.rs
@@ -70,15 +70,17 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
 
         if 2 * I::BITS < E::BaseField::size_in_data_bits() as u64 {
             // Ensure that Euclidean division holds for these values in the base field.
-            E::assert_eq(self.to_field(), quotient.to_field() * other.to_field() + remainder.to_field());
+            E::assert_eq(self.to_field(), quotient.to_field() * other.to_field() + remainder.to_field())
+                .expect("Division Euclidean constraint unsatisfied");
         } else {
             // Ensure that Euclidean division holds for these values as integers.
-            E::assert_eq(self, quotient.mul_checked(other).add_checked(&remainder));
+            E::assert_eq(self, quotient.mul_checked(other).add_checked(&remainder))
+                .expect("Division Euclidean constraint unsatisfied");
         }
 
         // Ensure that the remainder is less than the divisor.
         // Note that if this check is satisfied and `other` is an unsigned integer, then `other` is not zero.
-        E::assert(remainder.is_less_than(other));
+        E::assert(remainder.is_less_than(other)).expect("Division remainder constraint unsatisfied");
 
         // Return the quotient and remainder of `self` and `other`.
         (quotient, remainder)

--- a/circuit/types/integers/src/mul_checked.rs
+++ b/circuit/types/integers/src/mul_checked.rs
@@ -98,7 +98,8 @@ impl<E: Environment, I: IntegerType> MulChecked<Self> for Integer<E, I> {
             // If the product should be positive, then it cannot exceed the signed maximum.
             let operands_same_sign = &self.msb().is_equal(other.msb());
             let positive_product_overflows = operands_same_sign & product.msb();
-            E::assert_eq(positive_product_overflows, E::zero());
+            E::assert_eq(positive_product_overflows, E::zero())
+                .expect("Signed multiplication positive overflow check failed");
 
             // If the product should be negative, then it cannot exceed the absolute value of the signed minimum.
             let negative_product_underflows = {
@@ -108,7 +109,8 @@ impl<E: Environment, I: IntegerType> MulChecked<Self> for Integer<E, I> {
                     !product.msb() | (product.msb() & !lower_product_bits_nonzero);
                 !operands_same_sign & !negative_product_lt_or_eq_signed_min
             };
-            E::assert_eq(negative_product_underflows, E::zero());
+            E::assert_eq(negative_product_underflows, E::zero())
+                .expect("Signed multiplication negative underflow check failed");
 
             // Note that the relevant overflow cases are checked independently above.
             // Return the product of `self` and `other` with the appropriate sign.
@@ -132,7 +134,8 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
 
             // Check that the computed product is equal to witnessed product, in the base field.
             // Note: The multiplication is safe as the field twice as large as the maximum integer type supported.
-            E::enforce(|| (this.to_field(), that.to_field(), product.to_field()));
+            E::enforce(|| (this.to_field(), that.to_field(), product.to_field()))
+                .expect("Integer multiplication constraint unsatisfied");
 
             product
         }
@@ -145,7 +148,7 @@ impl<E: Environment, I: IntegerType> Integer<E, I> {
             Boolean::assert_bits_are_zero(&z_1_upper_bits);
 
             // Check that `z2` is zero.
-            E::assert_eq(z2, E::zero());
+            E::assert_eq(z2, E::zero()).expect("Karatsuba multiplication overflow check failed");
 
             // Return the product of `self` and `other`.
             product

--- a/circuit/types/integers/src/pow_checked.rs
+++ b/circuit/types/integers/src/pow_checked.rs
@@ -79,7 +79,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> PowChecked<Integer<E, M>> for
                     };
 
                     let overflow = overflow | positive_product_overflows | negative_product_underflows;
-                    E::assert_eq(overflow & bit, E::zero());
+                    E::assert_eq(overflow & bit, E::zero()).expect("Integer power overflow check failed");
 
                     // Return the product of `self` and `other` with the appropriate sign.
                     Self::ternary(operands_same_sign, &product, &(!&product).add_wrapped(&Self::one()))
@@ -87,7 +87,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> PowChecked<Integer<E, M>> for
                     let (product, overflow) = Self::mul_with_flags(&result, self);
 
                     // For unsigned multiplication, check that the overflow flag is not set.
-                    E::assert_eq(overflow & bit, E::zero());
+                    E::assert_eq(overflow & bit, E::zero()).expect("Integer power overflow check failed");
 
                     // Return the product of `self` and `other`.
                     product

--- a/circuit/types/integers/src/rem_checked.rs
+++ b/circuit/types/integers/src/rem_checked.rs
@@ -84,7 +84,7 @@ impl<E: Environment, I: IntegerType> RemChecked<Self> for Integer<E, I> {
                     let min = Integer::constant(console::Integer::MIN);
                     let neg_one = Integer::constant(-console::Integer::one());
                     let overflows = self.is_equal(&min) & other.is_equal(&neg_one);
-                    E::assert(!overflows);
+                    E::assert(!overflows).expect("Signed integer remainder overflow check failed");
 
                     // Divide the absolute value of `self` and `other` in the base field.
                     let unsigned_dividend = self.abs_wrapped().cast_as_dual();

--- a/circuit/types/integers/src/shl_checked.rs
+++ b/circuit/types/integers/src/shl_checked.rs
@@ -100,7 +100,7 @@ impl<E: Environment, I: IntegerType, M: Magnitude> ShlChecked<Integer<E, M>> for
                     let result = Self { bits_le: lower_bits_le.to_vec(), phantom: Default::default() };
                     // Ensure that the sign of the first I::BITS upper bits match the sign of the result.
                     for bit in &upper_bits_le[..(I::BITS as usize)] {
-                        E::assert_eq(bit, result.msb());
+                        E::assert_eq(bit, result.msb()).expect("Signed shift left overflow check failed");
                     }
                     // Return the result.
                     result

--- a/circuit/types/integers/src/sub_checked.rs
+++ b/circuit/types/integers/src/sub_checked.rs
@@ -97,11 +97,12 @@ impl<E: Environment, I: IntegerType> SubChecked<Self> for Integer<E, I> {
                 true => {
                     let is_different_signs = self.msb().is_not_equal(other.msb());
                     let is_underflow = is_different_signs & difference.msb().is_equal(other.msb());
-                    E::assert_eq(is_underflow, E::zero());
+                    E::assert_eq(is_underflow, E::zero())
                 }
                 // For unsigned subtraction, ensure the carry bit is one.
                 false => E::assert_eq(carry, E::one()),
             }
+            .expect("Integer subtraction constraint unsatisfied");
 
             // Return the difference of `self` and `other`.
             difference

--- a/circuit/types/string/src/helpers/from_bits.rs
+++ b/circuit/types/string/src/helpers/from_bits.rs
@@ -61,7 +61,8 @@ impl<E: Environment> StringType<E> {
             false => Field::new(Mode::Private, num_bytes),
         };
         // Ensure the witness matches the constant.
-        E::assert_eq(&expected_size_in_bytes, &size_in_bytes);
+        E::assert_eq(&expected_size_in_bytes, &size_in_bytes)
+            .expect("String size witness does not match expected size");
 
         // Return the size in bytes.
         size_in_bytes

--- a/circuit/types/string/src/lib.rs
+++ b/circuit/types/string/src/lib.rs
@@ -59,7 +59,8 @@ impl<E: Environment> Inject for StringType<E> {
             false => Field::new(Mode::Private, num_bytes),
         };
         // Ensure the witness matches the constant.
-        E::assert_eq(&expected_size_in_bytes, &size_in_bytes);
+        E::assert_eq(&expected_size_in_bytes, &size_in_bytes)
+            .expect("String size witness does not match expected size");
 
         Self {
             mode,

--- a/synthesizer/process/src/error.rs
+++ b/synthesizer/process/src/error.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use circuit::environment::ConstraintUnsatisfied;
 use thiserror::Error;
 
 // NOTE: Many errors in this module temporarily contain `Anyhow` variants.
@@ -82,6 +83,9 @@ pub enum CallExecError {
     /// An error occurred during substack evaluation.
     #[error("Substack evaluation failed: {0}")]
     StackEval(#[from] StackEvalError),
+    /// A circuit constraint was not satisfied.
+    #[error(transparent)]
+    Constraint(#[from] ConstraintUnsatisfied),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
@@ -107,6 +111,9 @@ pub enum StackExecError {
     /// Instruction at the given index failed.
     #[error(transparent)]
     Instruction(#[from] IndexedInstructionError<InstructionError>),
+    /// A circuit constraint was not satisfied.
+    #[error(transparent)]
+    Constraint(#[from] ConstraintUnsatisfied),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),

--- a/synthesizer/process/src/error.rs
+++ b/synthesizer/process/src/error.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use circuit::environment::ConstraintUnsatisfied;
+use snarkvm_synthesizer_program::EvalError;
 use thiserror::Error;
 
 // NOTE: Many errors in this module temporarily contain `Anyhow` variants.
@@ -157,6 +158,9 @@ pub enum InstructionError {
 /// An error occurred during the evaluation of an instruction.
 #[derive(Debug, Error)]
 pub enum InstructionEvalError {
+    /// An instruction evaluation failed.
+    #[error(transparent)]
+    Eval(#[from] EvalError),
     /// An error occurred during a `Call` instruction.
     #[error("Call failed: {0}")]
     Call(#[from] Box<CallEvalError>),

--- a/synthesizer/process/src/error.rs
+++ b/synthesizer/process/src/error.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use circuit::environment::ConstraintUnsatisfied;
-use snarkvm_synthesizer_program::EvalError;
+use snarkvm_synthesizer_program::{EvalError, ExecError};
 use thiserror::Error;
 
 // NOTE: Many errors in this module temporarily contain `Anyhow` variants.
@@ -175,6 +175,9 @@ pub enum InstructionExecError {
     /// An error occurred during a `Call` instruction.
     #[error("Call failed: {0}")]
     Call(#[from] Box<CallExecError>),
+    /// An instruction execution error.
+    #[error(transparent)]
+    Exec(#[from] ExecError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -498,7 +498,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             // Compute the transition commitment as `Hash(tvk)`.
             let candidate_tcm = A::hash_psd2(&[tvk.clone()]);
             // Ensure the transition commitment matches the computed transition commitment.
-            A::assert_eq(&tcm, candidate_tcm);
+            A::assert_eq(&tcm, candidate_tcm)?;
             // Inject the input IDs (from the request) as `Mode::Public`.
             let input_ids = request
                 .input_ids()
@@ -520,7 +520,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
                 &tcm,
                 None,
             );
-            A::assert(check_input_ids);
+            A::assert(check_input_ids)?;
             lap!(timer, "Checked the input ids");
 
             // Retrieve the output registers.

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -212,7 +212,7 @@ impl<N: Network> Stack<N> {
                 Instruction::Call(call) => CallTrait::evaluate(call, self, &mut registers, rng)
                     .map_err(|e| InstructionEvalError::Call(Box::new(e))),
                 // Otherwise, evaluate the instruction normally.
-                _ => instruction.evaluate(self, &mut registers).map_err(InstructionEvalError::Anyhow),
+                _ => instruction.evaluate(self, &mut registers).map_err(Into::into),
             };
             // If the evaluation fails, bail and return the error.
             if let Err(error) = result {

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -321,7 +321,7 @@ impl<N: Network> Stack<N> {
                     Instruction::Call(call) => CallTrait::evaluate(call, self, &mut registers, rng)
                         .map_err(|e| InstructionEvalError::Call(Box::new(e))),
                     // Otherwise, evaluate the instruction normally.
-                    _ => instruction.evaluate(self, &mut registers).map_err(InstructionEvalError::Anyhow),
+                    _ => instruction.evaluate(self, &mut registers).map_err(Into::into),
                 };
                 // If the evaluation fails, bail and return the error.
                 if let Err(error) = result {

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -336,7 +336,7 @@ impl<N: Network> Stack<N> {
                 Instruction::Call(call) => CallTrait::execute(call, self, &mut registers, rng)
                     .map_err(|e| InstructionExecError::Call(Box::new(e))),
                 // Otherwise, execute the instruction normally.
-                _ => instruction.execute(self, &mut registers).map_err(InstructionExecError::Anyhow),
+                _ => instruction.execute(self, &mut registers).map_err(InstructionExecError::Exec),
             };
             // If the execution fails, bail and return the error.
             if let Err(error) = result {

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -268,7 +268,7 @@ impl<N: Network> Stack<N> {
         let caller = Ternary::ternary(&is_root, request.signer(), &parent);
 
         // Ensure the request has a valid signature, inputs, and transition view key.
-        A::assert(request.verify(&input_types, &tpk, Some(root_tvk), is_root, program_checksum));
+        A::assert(request.verify(&input_types, &tpk, Some(root_tvk), is_root, program_checksum))?;
         lap!(timer, "Verify the circuit request");
 
         // Set the transition signer.

--- a/synthesizer/process/src/trace/inclusion/assignment.rs
+++ b/synthesizer/process/src/trace/inclusion/assignment.rs
@@ -104,12 +104,12 @@ impl<N: Network> InclusionAssignment<N> {
         let candidate_serial_number =
             circuit::Record::<A, circuit::Plaintext<A>>::serial_number_from_gamma(&gamma, commitment.clone());
         // Enforce that the candidate serial number is equal to the serial number.
-        A::assert_eq(candidate_serial_number, serial_number);
+        A::assert_eq(candidate_serial_number, serial_number)?;
 
         // Enforce the starting leaf is the claimed commitment.
-        A::assert_eq(state_path.transition_leaf().id(), commitment);
+        A::assert_eq(state_path.transition_leaf().id(), commitment)?;
         // Enforce the state path from leaf to root is correct.
-        A::assert(state_path.verify(&is_global, &local_state_root));
+        A::assert(state_path.verify(&is_global, &local_state_root))?;
 
         // Fetch the record block height from the state path.
         let record_block_height = U32::<A>::from_bits_le(&state_path.block_path().leaf_index().to_bits_le());
@@ -120,7 +120,7 @@ impl<N: Network> InclusionAssignment<N> {
         let is_block_height_check_valid =
             is_record_block_height_reached.is_equal(&is_record_block_height_past_upgrade_block_height);
         // Check that the height is valid if the record is from a global state path.
-        A::assert(is_global.not().bitor(is_block_height_check_valid));
+        A::assert(is_global.not().bitor(is_block_height_check_valid))?;
 
         Stack::log_circuit::<A>(format_args!("State Path for {}", self.serial_number));
 

--- a/synthesizer/process/src/trace/inclusion/assignment_v0.rs
+++ b/synthesizer/process/src/trace/inclusion/assignment_v0.rs
@@ -76,12 +76,12 @@ impl<N: Network> InclusionV0Assignment<N> {
         let candidate_serial_number =
             circuit::Record::<A, circuit::Plaintext<A>>::serial_number_from_gamma(&gamma, commitment.clone());
         // Enforce that the candidate serial number is equal to the serial number.
-        A::assert_eq(candidate_serial_number, serial_number);
+        A::assert_eq(candidate_serial_number, serial_number)?;
 
         // Enforce the starting leaf is the claimed commitment.
-        A::assert_eq(state_path.transition_leaf().id(), commitment);
+        A::assert_eq(state_path.transition_leaf().id(), commitment)?;
         // Enforce the state path from leaf to root is correct.
-        A::assert(state_path.verify(&is_global, &local_state_root));
+        A::assert(state_path.verify(&is_global, &local_state_root))?;
 
         Stack::log_circuit::<A>(format_args!("State Path for {}", self.serial_number));
 

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -66,6 +66,9 @@ features = [ "preserve_order" ]
 [dependencies.snarkvm-synthesizer-snark]
 workspace = true
 
+[dependencies.thiserror]
+workspace = true
+
 [dependencies.tiny-keccak]
 version = "2"
 features = [ "sha3" ]

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -171,7 +171,9 @@ impl<N: Network> Command<N> {
     ) -> Result<Option<FinalizeOperation<N>>> {
         match self {
             // Finalize the instruction, and return no finalize operation.
-            Command::Instruction(instruction) => instruction.finalize(stack, registers).map(|_| None),
+            Command::Instruction(instruction) => {
+                instruction.finalize(stack, registers).map_err(Into::into).map(|_| None)
+            }
             // `await` commands are processed by the caller of this method.
             Command::Await(_) => bail!("`await` commands cannot be finalized directly."),
             // Finalize the 'contains' command, and return no finalize operation.

--- a/synthesizer/program/src/logic/instruction/error.rs
+++ b/synthesizer/program/src/logic/instruction/error.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Errors for instruction operations.
+
+use console::network::prelude::Error as AnyhowError;
+use thiserror::Error;
+
+// NOTE: Many errors in this module temporarily contain `Anyhow` variants.
+// TODO: Remove these variants as we migrate errors to thiserror.
+
+/// An error occurred during instruction evaluation.
+#[derive(Debug, Error)]
+pub enum EvalError {
+    /// An assertion instruction failed.
+    #[error(transparent)]
+    Assert(#[from] AssertError),
+    /// A temporary variant for type-erased anyhow errors.
+    /// TODO: Remove this variant as we migrate errors to thiserror.
+    #[error(transparent)]
+    Anyhow(#[from] AnyhowError),
+}
+
+/// An error occurred during instruction finalization.
+#[derive(Debug, Error)]
+pub enum FinalizeError {
+    /// An evaluation error occurred during finalization.
+    #[error(transparent)]
+    Eval(#[from] EvalError),
+    /// A temporary variant for type-erased anyhow errors.
+    /// TODO: Remove this variant as we migrate errors to thiserror.
+    #[error(transparent)]
+    Anyhow(#[from] AnyhowError),
+}
+
+/// An error occurred during an assert instruction.
+#[derive(Debug, Error)]
+pub enum AssertError {
+    /// The assert.eq instruction failed because the operands are not equal.
+    #[error("'assert.eq' failed: '{lhs}' is not equal to '{rhs}' (should be equal)")]
+    Eq {
+        /// The left-hand side operand.
+        lhs: String,
+        /// The right-hand side operand.
+        rhs: String,
+    },
+    /// The assert.neq instruction failed because the operands are equal.
+    #[error("'assert.neq' failed: '{lhs}' is equal to '{rhs}' (should not be equal)")]
+    Neq {
+        /// The left-hand side operand.
+        lhs: String,
+        /// The right-hand side operand.
+        rhs: String,
+    },
+    /// An invalid assert variant was specified.
+    #[error("Invalid 'assert' variant: {variant}")]
+    Invalid {
+        /// The invalid variant.
+        variant: u8,
+    },
+}

--- a/synthesizer/program/src/logic/instruction/error.rs
+++ b/synthesizer/program/src/logic/instruction/error.rs
@@ -15,6 +15,7 @@
 
 //! Errors for instruction operations.
 
+use circuit::environment::ConstraintUnsatisfied;
 use console::network::prelude::Error as AnyhowError;
 use thiserror::Error;
 
@@ -28,7 +29,6 @@ pub enum EvalError {
     #[error(transparent)]
     Assert(#[from] AssertError),
     /// A temporary variant for type-erased anyhow errors.
-    /// TODO: Remove this variant as we migrate errors to thiserror.
     #[error(transparent)]
     Anyhow(#[from] AnyhowError),
 }
@@ -40,7 +40,17 @@ pub enum FinalizeError {
     #[error(transparent)]
     Eval(#[from] EvalError),
     /// A temporary variant for type-erased anyhow errors.
-    /// TODO: Remove this variant as we migrate errors to thiserror.
+    #[error(transparent)]
+    Anyhow(#[from] AnyhowError),
+}
+
+/// An error occurred during instruction execution.
+#[derive(Debug, Error)]
+pub enum ExecError {
+    /// A circuit constraint was unsatisfied during execution.
+    #[error(transparent)]
+    Constraint(#[from] ConstraintUnsatisfied),
+    /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
     Anyhow(#[from] AnyhowError),
 }

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -576,8 +576,8 @@ impl<N: Network> Instruction<N> {
         &self,
         stack: &impl StackTrait<N>,
         registers: &mut impl RegistersCircuit<N, A>,
-    ) -> Result<()> {
-        instruction!(self, |instruction| instruction.execute::<A>(stack, registers))
+    ) -> Result<(), ExecError> {
+        instruction!(self, |instruction| instruction.execute::<A>(stack, registers).map_err(Into::into))
     }
 
     /// Finalizes the instruction.

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod error;
+pub use error::*;
+
 mod opcode;
 pub use opcode::*;
 
@@ -559,8 +562,12 @@ impl<N: Network> Instruction<N> {
 
     /// Evaluates the instruction.
     #[inline]
-    pub fn evaluate(&self, stack: &impl StackTrait<N>, registers: &mut impl RegistersSigner<N>) -> Result<()> {
-        instruction!(self, |instruction| instruction.evaluate(stack, registers))
+    pub fn evaluate(
+        &self,
+        stack: &impl StackTrait<N>,
+        registers: &mut impl RegistersSigner<N>,
+    ) -> Result<(), EvalError> {
+        instruction!(self, |instruction| instruction.evaluate(stack, registers).map_err(Into::into))
     }
 
     /// Executes the instruction.
@@ -575,8 +582,12 @@ impl<N: Network> Instruction<N> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &impl StackTrait<N>, registers: &mut impl RegistersTrait<N>) -> Result<()> {
-        instruction!(self, |instruction| instruction.finalize(stack, registers))
+    pub fn finalize(
+        &self,
+        stack: &impl StackTrait<N>,
+        registers: &mut impl RegistersTrait<N>,
+    ) -> Result<(), FinalizeError> {
+        instruction!(self, |instruction| instruction.finalize(stack, registers).map_err(Into::into))
     }
 
     /// Returns the output type from the given input types.

--- a/synthesizer/program/src/logic/instruction/operation/assert.rs
+++ b/synthesizer/program/src/logic/instruction/operation/assert.rs
@@ -13,7 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Opcode, Operand, RegistersCircuit, RegistersTrait, StackTrait, register_types_equivalent};
+use crate::{
+    AssertError,
+    EvalError,
+    FinalizeError,
+    Opcode,
+    Operand,
+    RegistersCircuit,
+    RegistersTrait,
+    StackTrait,
+    register_types_equivalent,
+};
 use console::{
     network::prelude::*,
     program::{Register, RegisterType},
@@ -80,10 +90,19 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
     /// Evaluates the instruction.
-    pub fn evaluate(&self, stack: &impl StackTrait<N>, registers: &mut impl RegistersTrait<N>) -> Result<()> {
+    pub fn evaluate(
+        &self,
+        stack: &impl StackTrait<N>,
+        registers: &mut impl RegistersTrait<N>,
+    ) -> Result<(), EvalError> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
-            bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
+            return Err(anyhow!(
+                "Instruction '{}' expects 2 operands, found {} operands",
+                Self::opcode(),
+                self.operands.len()
+            )
+            .into());
         }
 
         // Retrieve the inputs.
@@ -94,15 +113,15 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
         match VARIANT {
             0 => {
                 if input_a != input_b {
-                    bail!("'{}' failed: '{input_a}' is not equal to '{input_b}' (should be equal)", Self::opcode())
+                    return Err(AssertError::Eq { lhs: format!("{input_a}"), rhs: format!("{input_b}") }.into());
                 }
             }
             1 => {
                 if input_a == input_b {
-                    bail!("'{}' failed: '{input_a}' is equal to '{input_b}' (should not be equal)", Self::opcode())
+                    return Err(AssertError::Neq { lhs: format!("{input_a}"), rhs: format!("{input_b}") }.into());
                 }
             }
-            _ => bail!("Invalid 'assert' variant: {VARIANT}"),
+            _ => return Err(AssertError::Invalid { variant: VARIANT }.into()),
         }
         Ok(())
     }
@@ -133,8 +152,13 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 
     /// Finalizes the instruction.
     #[inline]
-    pub fn finalize(&self, stack: &impl StackTrait<N>, registers: &mut impl RegistersTrait<N>) -> Result<()> {
-        self.evaluate(stack, registers)
+    pub fn finalize(
+        &self,
+        stack: &impl StackTrait<N>,
+        registers: &mut impl RegistersTrait<N>,
+    ) -> Result<(), FinalizeError> {
+        self.evaluate(stack, registers)?;
+        Ok(())
     }
 
     /// Returns the output type from the given program and input types.

--- a/synthesizer/program/src/logic/instruction/operation/assert.rs
+++ b/synthesizer/program/src/logic/instruction/operation/assert.rs
@@ -124,8 +124,8 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 
         // Assert the inputs.
         match VARIANT {
-            0 => A::assert(input_a.is_equal(&input_b)),
-            1 => A::assert(input_a.is_not_equal(&input_b)),
+            0 => A::assert(input_a.is_equal(&input_b))?,
+            1 => A::assert(input_a.is_not_equal(&input_b))?,
             _ => bail!("Invalid 'assert' variant: {VARIANT}"),
         }
         Ok(())

--- a/synthesizer/program/src/logic/instruction/operation/assert.rs
+++ b/synthesizer/program/src/logic/instruction/operation/assert.rs
@@ -16,6 +16,7 @@
 use crate::{
     AssertError,
     EvalError,
+    ExecError,
     FinalizeError,
     Opcode,
     Operand,
@@ -131,10 +132,15 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
         &self,
         stack: &impl StackTrait<N>,
         registers: &mut impl RegistersCircuit<N, A>,
-    ) -> Result<()> {
+    ) -> Result<(), ExecError> {
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
-            bail!("Instruction '{}' expects 2 operands, found {} operands", Self::opcode(), self.operands.len())
+            return Err(anyhow!(
+                "Instruction '{}' expects 2 operands, found {} operands",
+                Self::opcode(),
+                self.operands.len()
+            )
+            .into());
         }
 
         // Retrieve the inputs.
@@ -145,7 +151,7 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
         match VARIANT {
             0 => A::assert(input_a.is_equal(&input_b))?,
             1 => A::assert(input_a.is_not_equal(&input_b))?,
-            _ => bail!("Invalid 'assert' variant: {VARIANT}"),
+            _ => return Err(anyhow!("Invalid 'assert' variant: {VARIANT}").into()),
         }
         Ok(())
     }

--- a/synthesizer/program/src/logic/instruction/operation/deserialize.rs
+++ b/synthesizer/program/src/logic/instruction/operation/deserialize.rs
@@ -483,11 +483,11 @@ where
         if variant == (DeserializeVariant::FromBits as u8) {
             let plaintext_variant = next_bits(2)?;
             let expected_bits = PlaintextType::<A::Network>::STRUCT_PREFIX_BITS.map(circuit::Boolean::<A>::constant);
-            A::assert_eq(&expected_bits[0], &plaintext_variant[0]);
-            A::assert_eq(&expected_bits[1], &plaintext_variant[1]);
+            A::assert_eq(&expected_bits[0], &plaintext_variant[0])?;
+            A::assert_eq(&expected_bits[1], &plaintext_variant[1])?;
 
             let num_members = circuit::U8::<A>::from_bits_le(next_bits(8)?);
-            A::assert_eq(num_members, circuit::U8::<A>::constant(U8::new(expected_num_members)));
+            A::assert_eq(num_members, circuit::U8::<A>::constant(U8::new(expected_num_members)))?;
         }
 
         // Get the members.
@@ -502,14 +502,14 @@ where
             if variant == (DeserializeVariant::FromBits as u8) {
                 let expected_identifier_size = member_identifier.size_in_bits();
                 let identifier_size = circuit::U8::<A>::from_bits_le(next_bits(8)?);
-                A::assert_eq(&identifier_size, circuit::U8::<A>::constant(U8::new(expected_identifier_size)));
+                A::assert_eq(&identifier_size, circuit::U8::<A>::constant(U8::new(expected_identifier_size)))?;
 
                 let identifier_bits = next_bits(expected_identifier_size as usize)?;
                 let identifier = circuit::Identifier::<A>::from_bits_le(identifier_bits);
-                A::assert_eq(circuit::Identifier::<A>::constant(*member_identifier), &identifier);
+                A::assert_eq(circuit::Identifier::<A>::constant(*member_identifier), &identifier)?;
 
                 let member_size = circuit::U16::<A>::from_bits_le(next_bits(16)?);
-                A::assert_eq(&member_size, circuit::U16::<A>::constant(U16::new(expected_member_size)));
+                A::assert_eq(&member_size, circuit::U16::<A>::constant(U16::new(expected_member_size)))?;
             }
 
             let value = execute_deserialize_internal(
@@ -540,14 +540,14 @@ where
                 let plaintext_variant = next_bits(2)?;
                 let expected_bits =
                     PlaintextType::<A::Network>::LITERAL_PREFIX_BITS.map(circuit::Boolean::<A>::constant);
-                A::assert_eq(&expected_bits[0], &plaintext_variant[0]);
-                A::assert_eq(&expected_bits[1], &plaintext_variant[1]);
+                A::assert_eq(&expected_bits[0], &plaintext_variant[0])?;
+                A::assert_eq(&expected_bits[1], &plaintext_variant[1])?;
 
                 let literal_variant = circuit::U8::<A>::from_bits_le(next_bits(8)?);
-                A::assert_eq(&literal_variant, circuit::U8::<A>::constant(U8::new(literal_type.type_id())));
+                A::assert_eq(&literal_variant, circuit::U8::<A>::constant(U8::new(literal_type.type_id())))?;
 
                 let literal_size = circuit::U16::<A>::from_bits_le(next_bits(16)?);
-                A::assert_eq(&literal_size, circuit::U16::<A>::constant(U16::new(expected_size)));
+                A::assert_eq(&literal_size, circuit::U16::<A>::constant(U16::new(expected_size)))?;
             };
             // Deserialize the literal.
             let literal = circuit::Literal::<A>::from_bits_le(
@@ -574,11 +574,11 @@ where
             if variant == (DeserializeVariant::FromBits as u8) {
                 let plaintext_variant = next_bits(2)?;
                 let expected_bits = PlaintextType::<A::Network>::ARRAY_PREFIX_BITS.map(circuit::Boolean::<A>::constant);
-                A::assert_eq(&expected_bits[0], &plaintext_variant[0]);
-                A::assert_eq(&expected_bits[1], &plaintext_variant[1]);
+                A::assert_eq(&expected_bits[0], &plaintext_variant[0])?;
+                A::assert_eq(&expected_bits[1], &plaintext_variant[1])?;
 
                 let num_elements = circuit::U32::<A>::from_bits_le(next_bits(32)?);
-                A::assert_eq(&num_elements, circuit::U32::<A>::constant(U32::new(expected_length)));
+                A::assert_eq(&num_elements, circuit::U32::<A>::constant(U32::new(expected_length)))?;
             }
 
             let expected_element_type = array_type.next_element_type();
@@ -590,7 +590,7 @@ where
             for _ in 0..**array_type.length() {
                 if variant == (DeserializeVariant::FromBits as u8) {
                     let element_size = circuit::U16::<A>::from_bits_le(next_bits(16)?);
-                    A::assert_eq(&element_size, circuit::U16::<A>::constant(U16::new(expected_element_size)));
+                    A::assert_eq(&element_size, circuit::U16::<A>::constant(U16::new(expected_element_size)))?;
                 }
 
                 let element = execute_deserialize_internal(


### PR DESCRIPTION
## Motivation

This is a follow-up to #3081 and continues to address #2941 and #3055, i.e. replacing `panic!`s with proper error handling.

To keep the changes minimal, this PR specifically focuses on evaluation and execution of the assert operations (a common `panic!` pain-point for leo testing). This has helped to guide the remaining error propagation from the instruction methods (`evaluate`, `execute` and `finalize`) up to the `IndexedInstructionError` introduced in #3081.

This does *not* add error handling for all instructions, but should pave a clear path for doing so.

## Summary

- Make circuit `E::enforce` return `Result<(), ConstraintUnsatisfied>` instead of panicking.
- Add structured error types for assertion instruction evaluation, finalization, and execution (`EvalError`, `FinalizeError`, `ExecError`).
- Propagate constraint errors through the synthesizer stack.

## Details

**Circuit layer**: `E::enforce`, `E::assert`, and `E::assert_eq` now return `Result<(), ConstraintUnsatisfied>`, where previously they would `panic!`. The new `ConstraintUnsatisfied` error captures the constraint values (a, b, c) where the check a * b == c failed.

**Synthesizer layer**: New error types in `synthesizer/program/src/logic/instruction/error.rs`:

- `EvalError` - errors during instruction evaluation.
- `FinalizeError` - errors during finalization.
- `ExecError` - errors during instruction execution.
- `AssertError` - assert instruction failures (the first instruction-associated eval error). 

**Error propagation**: `StackExecError`, `CallExecError`, and `InstructionExecError` now include variants to propagate `ConstraintUnsatisfied` and `ExecError` from the circuit/instruction layers.

**Note:** Many `E::assert`call sites throughout the circuit crates now use `.expect()` to maintain the existing panicking behavior. This is temporary—these sites will be addressed in follow-up PRs. For now, only the assertion instructions (assert.eq, assert.neq) have been fully updated to return `Result` for unsatisfied constraints across all three paths (evaluate, finalize, execute).

## Follow-up

- [ ] Continue on #2941.