### PR TITLE
fix(synthesizer): Allow `useless_conversion` clippy lint for instruction wrappers

### DIFF
--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -561,6 +561,8 @@ impl<N: Network> Instruction<N> {
     }
 
     /// Evaluates the instruction.
+    // Temporary until all instruction evaluate methods return EvalError (#2941, #3055).
+    #[allow(clippy::useless_conversion)]
     #[inline]
     pub fn evaluate(
         &self,
@@ -571,6 +573,8 @@ impl<N: Network> Instruction<N> {
     }
 
     /// Executes the instruction.
+    // Temporary until all instruction execute methods return ExecError (#2941, #3055).
+    #[allow(clippy::useless_conversion)]
     #[inline]
     pub fn execute<A: circuit::Aleo<Network = N>>(
         &self,
@@ -581,6 +585,8 @@ impl<N: Network> Instruction<N> {
     }
 
     /// Finalizes the instruction.
+    // Temporary until all instruction finalize methods return FinalizeError (#2941, #3055).
+    #[allow(clippy::useless_conversion)]
     #[inline]
     pub fn finalize(
         &self,


### PR DESCRIPTION
*Follow-up to #3082.*

Add `#[allow(clippy::useless_conversion)]` to `Instruction::evaluate`, `execute`, and `finalize` methods. The `map_err(Into::into)` is required to convert `anyhow::Error` to structured error types for instructions that haven't yet been migrated.

Temporary until all instruction methods return structured errors (#2941, #3055).