### PR TITLE
[Perf] Speed up sum_of_products

### DIFF
--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -233,8 +233,9 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
     #[inline]
     fn apply_mds(&mut self) {
         let mut new_state = State::default();
+        let curr_state: Vec<F> = self.state.iter().copied().collect::<Vec<_>>();
         new_state.iter_mut().zip(&self.parameters.mds).for_each(|(new_elem, mds_row)| {
-            *new_elem = F::sum_of_products(self.state.iter(), mds_row.iter());
+            *new_elem = F::sum_of_products(&curr_state, mds_row);
         });
         self.state = new_state;
     }

--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -126,8 +126,9 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
     #[inline]
     fn apply_mds(&mut self) {
         let mut new_state = State::default();
+        let curr_state: Vec<<E as Environment>::Field> = self.state.iter().map(|e| *e.deref()).collect::<Vec<_>>();
         new_state.iter_mut().zip(&self.parameters.mds).for_each(|(new_elem, mds_row)| {
-            *new_elem = Field::new(E::Field::sum_of_products(self.state.iter().map(|e| e.deref()), mds_row.iter()));
+            *new_elem = Field::new(E::Field::sum_of_products(curr_state.as_slice(), mds_row));
         });
         self.state = new_state;
     }

--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -182,7 +182,7 @@ fn test_fr_sum_of_products() {
     for i in [2, 4, 8, 16, 32] {
         let a = (0..i).map(|_| rng.r#gen()).collect::<Vec<_>>();
         let b = (0..i).map(|_| rng.r#gen()).collect::<Vec<_>>();
-        assert_eq!(Fr::sum_of_products(a.iter(), b.iter()), a.into_iter().zip(b).map(|(a, b)| a * b).sum());
+        assert_eq!(Fr::sum_of_products(&a, &b), a.into_iter().zip(b).map(|(a, b)| a * b).sum());
     }
 }
 
@@ -192,7 +192,7 @@ fn test_fq_sum_of_products() {
     for i in [2, 4, 8, 16, 32] {
         let a = (0..i).map(|_| rng.r#gen()).collect::<Vec<_>>();
         let b = (0..i).map(|_| rng.r#gen()).collect::<Vec<_>>();
-        assert_eq!(Fq::sum_of_products(a.iter(), b.iter()), a.into_iter().zip(b).map(|(a, b)| a * b).sum());
+        assert_eq!(Fq::sum_of_products(&a, &b), a.into_iter().zip(b).map(|(a, b)| a * b).sum());
     }
 }
 

--- a/curves/src/templates/short_weierstrass_jacobian/projective.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/projective.rs
@@ -278,7 +278,7 @@ impl<P: Parameters> ProjectiveCurve for Projective<P> {
             self.x -= &v.double();
 
             // Y3 = r*(V-X3)-2*Y1*J
-            self.y = P::BaseField::sum_of_products([r, -self.y.double()].iter(), [(v - self.x), j].iter());
+            self.y = P::BaseField::sum_of_products(&[r, -self.y.double()], &[(v - self.x), j]);
 
             // Z3 = (Z1+H)^2-Z1Z1-HH
             self.z += &h;
@@ -457,7 +457,7 @@ impl<'a, P: Parameters> AddAssign<&'a Self> for Projective<P> {
             self.x = r.square() - j - (v.double());
 
             // Y3 = r*(V - X3) - 2*S1*J
-            self.y = P::BaseField::sum_of_products([r, -s1.double()].iter(), [(v - self.x), j].iter());
+            self.y = P::BaseField::sum_of_products(&[r, -s1.double()], &[(v - self.x), j]);
 
             // Z3 = ((Z1+Z2)^2 - Z1Z1 - Z2Z2)*H
             self.z = ((self.z + other.z).square() - z1z1 - z2z2) * h;

--- a/curves/src/traits/tests_field.rs
+++ b/curves/src/traits/tests_field.rs
@@ -495,7 +495,7 @@ pub fn field_test<F: Field>(a: F, b: F, rng: &mut TestRng) {
         for _ in 0..len {
             a.push(F::rand(rng));
             b.push(F::rand(rng));
-            assert_eq!(F::sum_of_products(a.iter(), b.iter()), a.iter().zip(b.iter()).map(|(x, y)| *x * y).sum());
+            assert_eq!(F::sum_of_products(&a, &b), a.iter().zip(b.iter()).map(|(x, y)| *x * y).sum());
         }
     }
 

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -402,8 +402,8 @@ impl<P: Fp2Parameters> MulAssign<&'_ Self> for Fp2<P> {
     #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         *self = Self::new(
-            P::Fp::sum_of_products([self.c0, P::mul_fp_by_nonresidue(&self.c1)].iter(), [other.c0, other.c1].iter()),
-            P::Fp::sum_of_products([self.c0, self.c1].iter(), [other.c1, other.c0].iter()),
+            P::Fp::sum_of_products(&[self.c0, P::mul_fp_by_nonresidue(&self.c1)], &[other.c0, other.c1]),
+            P::Fp::sum_of_products(&[self.c0, self.c1], &[other.c1, other.c0]),
         )
     }
 }

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -164,10 +164,7 @@ impl<P: Fp256Parameters> Field for Fp256<P> {
         Self::from_bigint(two_inv).unwrap() // Guaranteed to be valid.
     }
 
-    fn sum_of_products<'a>(
-        a: impl Iterator<Item = &'a Self> + Clone,
-        b: impl Iterator<Item = &'a Self> + Clone,
-    ) -> Self {
+    fn sum_of_products<'a>(a: &'a [Self], b: &'a [Self]) -> Self {
         // For a single `a x b` multiplication, operand scanning (schoolbook) takes each
         // limb of `a` in turn, and multiplies it by all of the limbs of `b` to compute
         // the result as a double-width intermediate representation, which is then fully
@@ -188,7 +185,7 @@ impl<P: Fp256Parameters> Field for Fp256<P> {
             // Algorithm 2, line 3
             // For each pair in the overall sum of products:
             let (t0, t1, t2, t3, mut t4) =
-                a.clone().zip(b.clone()).fold((u0, u1, u2, u3, 0), |(t0, t1, t2, t3, mut t4), (a, b)| {
+                a.iter().zip(b).fold((u0, u1, u2, u3, 0), |(t0, t1, t2, t3, mut t4), (a, b)| {
                     // Compute digit_j x row and accumulate into `u`.
                     let mut carry = 0;
                     let t0 = fa::mac_with_carry(t0, a.0.0[j], b.0.0[0], &mut carry);

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -197,10 +197,7 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
         Self::from_bigint(two_inv).unwrap() // Guaranteed to be valid.
     }
 
-    fn sum_of_products<'a>(
-        a: impl Iterator<Item = &'a Self> + Clone,
-        b: impl Iterator<Item = &'a Self> + Clone,
-    ) -> Self {
+    fn sum_of_products<'a>(a: &'a [Self], b: &'a [Self]) -> Self {
         // For a single `a x b` multiplication, operand scanning (schoolbook) takes each
         // limb of `a` in turn, and multiplies it by all of the limbs of `b` to compute
         // the result as a double-width intermediate representation, which is then fully
@@ -220,9 +217,8 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
         let (u0, u1, u2, u3, u4, u5) = (0..6).fold((0, 0, 0, 0, 0, 0), |(u0, u1, u2, u3, u4, u5), j| {
             // Algorithm 2, line 3
             // For each pair in the overall sum of products:
-            let (t0, t1, t2, t3, t4, t5, mut t6) = a.clone().zip(b.clone()).fold(
-                (u0, u1, u2, u3, u4, u5, 0),
-                |(t0, t1, t2, t3, t4, t5, mut t6), (a, b)| {
+            let (t0, t1, t2, t3, t4, t5, mut t6) =
+                a.iter().zip(b).fold((u0, u1, u2, u3, u4, u5, 0), |(t0, t1, t2, t3, t4, t5, mut t6), (a, b)| {
                     // Compute digit_j x row and accumulate into `u`.
                     let mut carry = 0;
                     let t0 = fa::mac_with_carry(t0, a.0.0[j], b.0.0[0], &mut carry);
@@ -234,8 +230,7 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
                     let _ = fa::adc(&mut t6, 0, carry);
 
                     (t0, t1, t2, t3, t4, t5, t6)
-                },
-            );
+                });
 
             // Algorithm 2, lines 4-5
             // This is a single step of the usual Montgomery reduction process.

--- a/fields/src/traits/field.rs
+++ b/fields/src/traits/field.rs
@@ -119,11 +119,8 @@ pub trait Field:
     /// Squares `self` in place.
     fn square_in_place(&mut self) -> &mut Self;
 
-    fn sum_of_products<'a>(
-        a: impl Iterator<Item = &'a Self> + Clone,
-        b: impl Iterator<Item = &'a Self> + Clone,
-    ) -> Self {
-        a.zip(b).map(|(a, b)| *a * b).sum::<Self>()
+    fn sum_of_products<'a>(a: &'a [Self], b: &'a [Self]) -> Self {
+        a.iter().zip(b).map(|(a, b)| *a * b).sum::<Self>()
     }
 
     /// Computes the multiplicative inverse of `self` if `self` is nonzero.


### PR DESCRIPTION
This operation is non-negligible when executing transactions; a small optimization results in the following benchmark improvements:
```
Transaction::Execute(transfer_public) - verify
                        time:   [41.303 µs 41.309 µs 41.317 µs]
                        change: [−2.1724% −2.1356% −2.1002%] (p = 0.00 < 0.05)
                        Performance has improved.

Transaction::Execute(transfer_private) - verify
                        time:   [47.150 µs 47.159 µs 47.179 µs]
                        change: [−1.5528% −1.4960% −1.4362%] (p = 0.00 < 0.05)
                        Performance has improved.
```
I've checked all `varuna` and `transaction` benchmarks - the rest are either unaffected or the performance improvement is minimal.

CC @niklaslong 