### PR TITLE
A few fixes to external structs in records and futures

### DIFF
--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -161,7 +161,7 @@ impl<N: Network> FinalizeTypes<N> {
                 }
                 // Access the member on the path to output the register type.
                 (FinalizeType::Plaintext(PlaintextType::ExternalStruct(locator)), Access::Member(identifier)) => {
-                    // Retrieve the member type from the external struct.
+                    // Retrieve the member type from the external struct and check that it exists.
                     let external_stack = stack.get_external_stack(locator.program_id())?;
                     match external_stack.program().get_struct(locator.resource())?.members().get(identifier) {
                         // Qualify local struct references so subsequent accesses use the correct stack.

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -161,11 +161,14 @@ impl<N: Network> FinalizeTypes<N> {
                 }
                 // Access the member on the path to output the register type.
                 (FinalizeType::Plaintext(PlaintextType::ExternalStruct(locator)), Access::Member(identifier)) => {
-                    // Retrieve the member type from the struct and check that it exists.
+                    // Retrieve the member type from the external struct.
                     let external_stack = stack.get_external_stack(locator.program_id())?;
                     match external_stack.program().get_struct(locator.resource())?.members().get(identifier) {
-                        // Retrieve the member and update `finalize_type` for the next iteration.
-                        Some(member_type) => finalize_type = FinalizeType::Plaintext(member_type.clone()),
+                        // Qualify local struct references so subsequent accesses use the correct stack.
+                        Some(member_type) => {
+                            let qualified = member_type.clone().qualify(*locator.program_id());
+                            finalize_type = FinalizeType::Plaintext(qualified);
+                        }
                         // Halts if the member does not exist.
                         None => bail!("'{identifier}' does not exist in struct '{locator}'"),
                     }

--- a/synthesizer/process/src/stack/helpers/sample.rs
+++ b/synthesizer/process/src/stack/helpers/sample.rs
@@ -188,19 +188,28 @@ impl<N: Network> Stack<N> {
             None => bail!("Function '{locator}' does not have a finalize block"),
         };
 
+        // Sample the arguments using the external stack if the future is from an external program.
         let arguments = inputs
             .into_iter()
             .map(|input| {
                 match input.finalize_type() {
                     FinalizeType::Plaintext(plaintext_type) => {
-                        // Sample the plaintext value.
-                        let plaintext = self.sample_plaintext_internal(plaintext_type, depth + 1, rng)?;
+                        // Sample the plaintext value using the appropriate stack.
+                        let plaintext = match &external_stack {
+                            Some(external_stack) => {
+                                external_stack.sample_plaintext_internal(plaintext_type, depth + 1, rng)?
+                            }
+                            None => self.sample_plaintext_internal(plaintext_type, depth + 1, rng)?,
+                        };
                         // Return the argument.
                         Ok(Argument::Plaintext(plaintext))
                     }
                     FinalizeType::Future(locator) => {
-                        // Sample the future value.
-                        let future = self.sample_future_internal(locator, depth + 1, rng)?;
+                        // Sample the future value using the appropriate stack.
+                        let future = match &external_stack {
+                            Some(external_stack) => external_stack.sample_future_internal(locator, depth + 1, rng)?,
+                            None => self.sample_future_internal(locator, depth + 1, rng)?,
+                        };
                         // Return the argument.
                         Ok(Argument::Future(future))
                     }

--- a/synthesizer/process/src/stack/helpers/stack_trait.rs
+++ b/synthesizer/process/src/stack/helpers/stack_trait.rs
@@ -578,14 +578,19 @@ impl<N: Network> Stack<N> {
         ensure!(future.arguments().len() == inputs.len(), "Future arguments do not match");
 
         // Check that the arguments match the inputs.
+        // Use the external stack if the future is from an external program.
         for (argument, input) in future.arguments().iter().zip_eq(inputs.iter()) {
             match (argument, input.finalize_type()) {
-                (Argument::Plaintext(plaintext), FinalizeType::Plaintext(plaintext_type)) => {
-                    self.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?
-                }
-                (Argument::Future(future), FinalizeType::Future(locator)) => {
-                    self.matches_future_internal(future, locator, depth + 1)?
-                }
+                (Argument::Plaintext(plaintext), FinalizeType::Plaintext(plaintext_type)) => match &external_stack {
+                    Some(external_stack) => {
+                        external_stack.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?
+                    }
+                    None => self.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?,
+                },
+                (Argument::Future(future), FinalizeType::Future(locator)) => match &external_stack {
+                    Some(external_stack) => external_stack.matches_future_internal(future, locator, depth + 1)?,
+                    None => self.matches_future_internal(future, locator, depth + 1)?,
+                },
                 (_, input_type) => {
                     bail!("Argument type does not match input type: expected '{input_type}'")
                 }

--- a/synthesizer/process/src/stack/helpers/stack_trait.rs
+++ b/synthesizer/process/src/stack/helpers/stack_trait.rs
@@ -583,7 +583,7 @@ impl<N: Network> Stack<N> {
             match (argument, input.finalize_type()) {
                 (Argument::Plaintext(plaintext), FinalizeType::Plaintext(plaintext_type)) => match &external_stack {
                     Some(external_stack) => {
-                        external_stack.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?,
+                        external_stack.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?
                     }
                     None => self.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?,
                 },

--- a/synthesizer/process/src/stack/helpers/stack_trait.rs
+++ b/synthesizer/process/src/stack/helpers/stack_trait.rs
@@ -583,7 +583,7 @@ impl<N: Network> Stack<N> {
             match (argument, input.finalize_type()) {
                 (Argument::Plaintext(plaintext), FinalizeType::Plaintext(plaintext_type)) => match &external_stack {
                     Some(external_stack) => {
-                        external_stack.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?
+                        external_stack.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?,
                     }
                     None => self.matches_plaintext_internal(plaintext, plaintext_type, depth + 1)?,
                 },

--- a/synthesizer/process/src/stack/helpers/stack_trait.rs
+++ b/synthesizer/process/src/stack/helpers/stack_trait.rs
@@ -69,7 +69,7 @@ impl<N: Network> StackTrait<N> for Stack<N> {
             bail!("Expected external record '{record_name}', found external record '{}'", record_type.name())
         }
 
-        self.matches_record_internal(record, record_type, 0)
+        external_stack.matches_record_internal(record, record_type, 0)
     }
 
     /// Checks that the given record matches the layout of the record type.

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -197,8 +197,11 @@ impl<N: Network> RegisterTypes<N> {
                     };
                     // Retrieve the entry type from the external record.
                     match external_record.entries().get(path_name) {
-                        // Retrieve the plaintext type.
-                        Some(entry_type) => RegisterAccessType::Plaintext(entry_type.plaintext_type().clone()),
+                        // Qualify local struct references so subsequent accesses use the correct stack.
+                        Some(entry_type) => {
+                            let qualified = entry_type.plaintext_type().clone().qualify(*locator.program_id());
+                            RegisterAccessType::Plaintext(qualified)
+                        }
                         None => bail!("'{path_name}' does not exist in external record '{locator}'"),
                     }
                 }
@@ -225,10 +228,13 @@ impl<N: Network> RegisterTypes<N> {
                 }
                 (RegisterAccessType::Plaintext(PlaintextType::ExternalStruct(locator)), Access::Member(identifier)) => {
                     let external_stack = stack.get_external_stack(locator.program_id())?;
-                    // Retrieve the member type from the struct.
+                    // Retrieve the member type from the external struct.
                     match external_stack.program().get_struct(locator.resource())?.members().get(identifier) {
-                        // Update the member type.
-                        Some(member_type) => register_type = RegisterAccessType::Plaintext(member_type.clone()),
+                        // Qualify local struct references so subsequent accesses use the correct stack.
+                        Some(member_type) => {
+                            let qualified = member_type.clone().qualify(*locator.program_id());
+                            register_type = RegisterAccessType::Plaintext(qualified);
+                        }
                         None => bail!("'{identifier}' does not exist in struct '{locator}'"),
                     }
                 }

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -270,7 +270,12 @@ impl<N: Network> RegisterTypes<N> {
                         Some(input) => {
                             register_type = match input.finalize_type() {
                                 FinalizeType::Plaintext(plaintext_type) => {
-                                    RegisterAccessType::Plaintext(plaintext_type.clone())
+                                    let plaintext = match external_stack {
+                                        Some(ref stack) => plaintext_type.clone().qualify(*stack.program_id()),
+                                        None => plaintext_type.clone(),
+                                    };
+
+                                    RegisterAccessType::Plaintext(plaintext)
                                 }
                                 FinalizeType::Future(locator) => RegisterAccessType::Future(*locator),
                             }

--- a/synthesizer/src/vm/tests/test_v13.rs
+++ b/synthesizer/src/vm/tests/test_v13.rs
@@ -223,3 +223,301 @@ constructor:
     let deployment_two = vm.deploy(&caller_private_key, &program_two, None, 0, None, rng).unwrap();
     sample_next_block(&vm, &caller_private_key, &[deployment_two], rng).unwrap()
 }
+
+// This test verifies that path traversal through external structs works correctly when the
+// external struct contains a member that is a LOCAL struct reference (not an ExternalStruct).
+#[test]
+fn test_external_struct_with_local_nested_struct() {
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at V13 height.
+    let height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V13).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
+
+    // Define the first program with nested structs where Inner is a LOCAL reference in Outer.
+    // This is the key distinction: Outer.inner is declared as `inner as Inner` (local), not
+    // `inner as parent.aleo/Inner` (external).
+    let program_parent = Program::from_str(
+        r"
+program parent.aleo;
+
+struct Inner:
+    x as field;
+
+struct Outer:
+    inner as Inner;
+
+function make_outer:
+    cast 42field into r0 as Inner;
+    cast r0 into r1 as Outer;
+    output r1 as Outer.public;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Define the child program that accesses nested path r0.inner.x on an external struct.
+    let program_child = Program::from_str(
+        r"
+import parent.aleo;
+
+program child.aleo;
+
+function access_nested:
+    input r0 as parent.aleo/Outer.private;
+    assert.eq r0.inner.x 42field;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Deploy the parent program.
+    let deployment_parent = vm.deploy(&caller_private_key, &program_parent, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_parent], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    vm.add_next_block(&block).unwrap();
+
+    // Deploy the child program.
+    let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Child program deployment should succeed");
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+}
+
+// This test verifies path traversal through external records when the record entry is a
+// local struct in the external program.
+#[test]
+fn test_external_record_with_local_struct_entry() {
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at V13 height.
+    let height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V13).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
+
+    // Define the parent program with a record containing a local struct.
+    let program_parent = Program::from_str(
+        r"
+program parent.aleo;
+
+struct Data:
+    amount as field;
+
+record Token:
+    owner as address.private;
+    data as Data.private;
+
+function mint:
+    input r0 as address.private;
+    cast 100field into r1 as Data;
+    cast r0 r1 into r2 as Token.record;
+    output r2 as Token.record;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Define the child program that accesses the external record's local struct field.
+    let program_child = Program::from_str(
+        r"
+import parent.aleo;
+
+program child.aleo;
+
+function check_token:
+    input r0 as parent.aleo/Token.record;
+    assert.eq r0.data.amount 100field;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Deploy the parent program.
+    let deployment_parent = vm.deploy(&caller_private_key, &program_parent, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_parent], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    vm.add_next_block(&block).unwrap();
+
+    // Deploy the child program.
+    let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Child program deployment should succeed");
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+}
+
+// This test verifies path traversal through external structs containing arrays of local structs.
+#[test]
+fn test_external_struct_with_array_of_local_structs() {
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at V13 height.
+    let height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V13).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
+
+    // Define the parent program with a struct containing an array of local structs.
+    let program_parent = Program::from_str(
+        r"
+program parent.aleo;
+
+struct Item:
+    x as field;
+
+struct Container:
+    items as [Item; 2u32];
+
+function make_container:
+    cast 1field into r0 as Item;
+    cast 2field into r1 as Item;
+    cast r0 r1 into r2 as [Item; 2u32];
+    cast r2 into r3 as Container;
+    output r3 as Container.public;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Define the child program that accesses the array element's field.
+    let program_child = Program::from_str(
+        r"
+import parent.aleo;
+
+program child.aleo;
+
+function access_array_element:
+    input r0 as parent.aleo/Container.private;
+    assert.eq r0.items[0u32].x 1field;
+    assert.eq r0.items[1u32].x 2field;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Deploy the parent program.
+    let deployment_parent = vm.deploy(&caller_private_key, &program_parent, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_parent], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    vm.add_next_block(&block).unwrap();
+
+    // Deploy the child program.
+    let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Child program deployment should succeed");
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+}
+
+// This test verifies that future validation works correctly when an external function's finalize
+// block takes a local struct as a parameter.
+#[test]
+fn test_external_future_with_local_struct_finalize_param() {
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at V13 height.
+    let height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V13).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
+
+    // Define the parent program with a function that has a finalize block taking a local struct.
+    let program_parent = Program::from_str(
+        r"
+program parent.aleo;
+
+struct Data:
+    amount as field;
+
+mapping store:
+    key as field.public;
+    value as field.public;
+
+function save:
+    input r0 as Data.public;
+    async save r0 into r1;
+    output r1 as parent.aleo/save.future;
+
+finalize save:
+    input r0 as Data.public;
+    set r0.amount into store[0field];
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Define the child program that calls the parent function.
+    let program_child = Program::from_str(
+        r"
+import parent.aleo;
+
+program child.aleo;
+
+function call_save:
+    cast 42field into r0 as parent.aleo/Data;
+    call parent.aleo/save r0 into r1;
+    async call_save r1 into r2;
+    output r2 as child.aleo/call_save.future;
+
+finalize call_save:
+    input r0 as parent.aleo/save.future;
+    await r0;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // Deploy the parent program.
+    let deployment_parent = vm.deploy(&caller_private_key, &program_parent, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_parent], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    vm.add_next_block(&block).unwrap();
+
+    // Deploy the child program.
+    let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Child program deployment should succeed");
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+
+    // Execute the child function to verify runtime validation also works.
+    use console::program::Value;
+    let execution = vm
+        .execute(
+            &caller_private_key,
+            ("child.aleo", "call_save"),
+            Vec::<Value<_>>::new().into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Execution should succeed");
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+}

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct_in_external_record.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct_in_external_record.out
@@ -1,0 +1,17 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    parent.aleo/omega_wrapper:
+      outputs:
+      - '{"type":"external_record","id":"7782460639370601357827224517959964644377683608642233309337355996426880939919field"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    child.aleo/create_another_wrapper:
+      outputs:
+      - '{"type":"record","id":"428824748637879891552200965384806311143702261385469256770183844541599665109field","checksum":"24622741103382436169999555300246398813336935760078646874066994933543155797field","value":"record1qvqsqadqfj3rrh0ct4559hwrws44fqanra7hgjzgxvh7hgpfc8vfewgrqyphwmm0yvqqyqgqx6k9xvt8hlkcstgz35qaw4ef83m8d99xeky5upk4tc0tscsq3yqfyxfkjlukdfzajsd5n7pnu7kl24vpyta5usn4vtyut2urr4k4upsyxj4x9","sender_ciphertext":"6605546081839466942283415683102872639666023321841240562242126304933360138964field"}'
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"771306712284579065623013398678625321338097537024299213367192653856284418385field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx,\n    2043u64\n  ]\n}"}'

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct_in_external_struct.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/external_struct_in_external_struct.out
@@ -1,0 +1,17 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    parent.aleo/omega_wrapper:
+      outputs:
+      - '{"type":"private","id":"3363843273273390426198165786444391623541548663278669491937661308505398161558field","value":"ciphertext1qyqp2zwzxcht8q24drchqazpc43thxdawjj39pg65qchxthh6xtkzps4uhjc0"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    child.aleo/create_another_wrapper:
+      outputs:
+      - '{"type":"private","id":"4824692260451617089111497415237982208204607335711874663334936818492273334999field","value":"ciphertext1qyqr9mndf50sjs27umuqlw95dsv2xz4adtejcve0tfqnrcvh6z5dwrstyzh7z"}'
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"7494830042431285409548813311170788918552054493348379147724850552044969337406field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx,\n    1938u64\n  ]\n}"}'

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/future_with_external_struct.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/future_with_external_struct.out
@@ -1,0 +1,20 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    parent.aleo/omega_wrapper:
+      outputs:
+      - '{"type":"private","id":"5425960946253070001403427918148199347776074874899722914578918723477353015448field","value":"ciphertext1qyqykcr38vv869rqr4zq8uua6nzaefce5ysudf5flst34femjrnyjzsve4yx2"}'
+      - '{"type":"private","id":"1815512567344233675374585336125241874555259173029223827950594156022802513719field","value":"ciphertext1qyqw4xxkuczsrk34kyjrw307ms2hwa2mdvccrfcs2x6zf6d4xpcc5qcw3xm2x"}'
+      - '{"type":"future","id":"4047721909697350236401583038705011357027221806485830520111750970151577869439field","value":"{\n  program_id: parent.aleo,\n  function_name: omega_wrapper,\n  arguments: [\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n    {\n      program_id: child.aleo,\n      function_name: create_another_wrapper,\n      arguments: [\n        {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n}\n      ]\n    }\n  \n  ]\n}"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    child.aleo/create_another_wrapper:
+      outputs:
+      - '{"type":"private","id":"421751918727469257149304370319130913908434994672684237790684452498946355219field","value":"ciphertext1qyqy2pr7a6nccdepxmuxdfsl8dujh6u0h0unk6ugc7aqjnj6l22j2zsjfazjf"}'
+      - '{"type":"future","id":"8232099207369325157173988623554923811921564163769060019230618431112212246341field","value":"{\n  program_id: child.aleo,\n  function_name: create_another_wrapper,\n  arguments: [\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n}\n  ]\n}"}'
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"7307483290645901873625407791639529697847500777254727527408166869469393441554field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx,\n    2354u64\n  ]\n}"}'

--- a/synthesizer/tests/expectations/vm/execute_and_finalize/future_with_external_struct_complex.out
+++ b/synthesizer/tests/expectations/vm/execute_and_finalize/future_with_external_struct_complex.out
@@ -1,0 +1,27 @@
+errors: []
+outputs:
+- verified: true
+  execute:
+    parent.aleo/omega_wrapper:
+      outputs:
+      - '{"type":"private","id":"4675793934937298621122062123701739934880742456757637841837013485160807503660field","value":"ciphertext1qyqr3crnpv73xznrluzwdsya70s3l35vsvvrmwnkq0nzc3lx5uv6kygew5nu0"}'
+      - '{"type":"private","id":"3053945501260729000695698196735197946017541733857068475657494865203775312625field","value":"ciphertext1qyq047u9xtuwc0gkdelh2dr4npql08zy726cx4myy0vufa9e5gx2cqq0hrlxk"}'
+      - '{"type":"private","id":"7358934916849303580463983566249605298125048408057681175294434159310772683478field","value":"ciphertext1qyqqqcva4e5n05p0efkv82w7tvghjqvz2llkr34ldj79q8pyx7pgxqsxxhhsa"}'
+      - '{"type":"private","id":"915086399949988356450769098232259338793534430915905502538892997974628284852field","value":"ciphertext1qyqwchrh3v4awmh49hhy8rxtkpqvtsprtrjkx4h96snjkp6882kkgqqgrtlan"}'
+      - '{"type":"future","id":"4541214116906893519210822342586827160679692104186298589997457909010317216073field","value":"{\n  program_id: parent.aleo,\n  function_name: omega_wrapper,\n  arguments: [\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n    {\n      program_id: child.aleo,\n      function_name: create_another_wrapper,\n      arguments: [\n        {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n        {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n        {\n          program_id: grandchild.aleo,\n          function_name: create_wrapper,\n          arguments: [\n            {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n}\n          ]\n        }\n      \n      ]\n    }\n  \n  ]\n}"}'
+  speculate: the execution was accepted
+  add_next_block: succeeded.
+additional:
+- child_outputs:
+    grandchild.aleo/create_wrapper:
+      outputs:
+      - '{"type":"private","id":"4421963093694946765876876069055306684230243590451080632470858991903304294363field","value":"ciphertext1qyqxy47p64m50569akzzhfxpq39gslnse6awf4qrqcf28a8qmevvjpclf2v63"}'
+      - '{"type":"future","id":"5153228234212313646934683033426349428379464704619593800297792975595950783181field","value":"{\n  program_id: grandchild.aleo,\n  function_name: create_wrapper,\n  arguments: [\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n}\n  ]\n}"}'
+    child.aleo/create_another_wrapper:
+      outputs:
+      - '{"type":"private","id":"5358866554580335194002059818190692340704557233388424761977690404171499584623field","value":"ciphertext1qyqrdz7q8z0js6y67h5ky7rgc6mkd9aclk5n37q0f90gwky7hhltqyq90g6mw"}'
+      - '{"type":"private","id":"8030808015996529202648632916535460391554704452891115090147801198769781576309field","value":"ciphertext1qyqpa6e9c9la3w6fxnfpgj3qacsuqzhdnqs37c6upeur2tjydwhhupsaszv7u"}'
+      - '{"type":"future","id":"5589725477753718246269930226510290357600022655326629862906973654067565145618field","value":"{\n  program_id: child.aleo,\n  function_name: create_another_wrapper,\n  arguments: [\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n    {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n},\n    {\n      program_id: grandchild.aleo,\n      function_name: create_wrapper,\n      arguments: [\n        {\n  woo: {\n    a: 1u32,\n    b: 2u32\n  }\n}\n      ]\n    }\n  \n  ]\n}"}'
+    credits.aleo/fee_public:
+      outputs:
+      - '{"type":"future","id":"7455094196984727947016319553521560466238140354269735676690602286742356003409field","value":"{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1qr2ha4pfs5l28aze88yn6fhleeythklkczrule2v838uwj65n5gqxt9djx,\n    3642u64\n  ]\n}"}'

--- a/synthesizer/tests/tests/vm/execute_and_finalize/external_struct_in_external_record.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/external_struct_in_external_record.aleo
@@ -1,0 +1,38 @@
+/*
+start_height: 19
+randomness: 45791624
+cases:
+  - program: parent.aleo
+    function: omega_wrapper 
+    inputs: []
+*/
+
+program child.aleo;
+
+struct Woo:
+    a as u32;
+    b as u32;
+
+record BooHoo:
+    owner as address.private;
+    woo as Woo.private;
+
+function create_another_wrapper:
+    cast 1u32 2u32 into r0 as Woo;
+    cast self.signer r0 into r1 as BooHoo.record;
+    output r1 as BooHoo.record;
+
+constructor:
+    assert.eq edition 0u16;
+
+/////////////////////////////////////////////////
+
+import child.aleo;
+program parent.aleo;
+
+function omega_wrapper:
+    call child.aleo/create_another_wrapper into r0;
+    output r0 as child.aleo/BooHoo.record;
+
+constructor:
+    assert.eq edition 0u16;

--- a/synthesizer/tests/tests/vm/execute_and_finalize/external_struct_in_external_struct.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/external_struct_in_external_struct.aleo
@@ -1,0 +1,37 @@
+/*
+start_height: 19
+randomness: 45791624
+cases:
+  - program: parent.aleo
+    function: omega_wrapper 
+    inputs: []
+*/
+
+program child.aleo;
+
+struct Woo:
+    a as u32;
+    b as u32;
+
+struct BooHoo:
+    woo as Woo;
+
+function create_another_wrapper:
+    cast 1u32 2u32 into r0 as Woo;
+    cast r0 into r1 as BooHoo;
+    output r1 as BooHoo.private;
+
+constructor:
+    assert.eq edition 0u16;
+
+/////////////////////////////////////////////////
+
+import child.aleo;
+program parent.aleo;
+
+function omega_wrapper:
+    call child.aleo/create_another_wrapper into r0;
+    output r0 as child.aleo/BooHoo.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/synthesizer/tests/tests/vm/execute_and_finalize/future_with_external_struct.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/future_with_external_struct.aleo
@@ -1,0 +1,53 @@
+/*
+randomness: 45791624
+cases:
+  - program: parent.aleo
+    function: omega_wrapper
+    inputs: []
+*/
+
+program child.aleo;
+
+struct Woo:
+    a as u32;
+    b as u32;
+
+struct BooHoo:
+    woo as Woo;
+
+function create_another_wrapper:
+    cast 1u32 2u32 into r0 as Woo;
+    cast r0 into r1 as BooHoo;
+    async create_another_wrapper r1 into r2;
+    output r2[0u32] as BooHoo.private;
+    output r2 as child.aleo/create_another_wrapper.future;
+
+finalize create_another_wrapper:
+    input r0 as BooHoo.public;
+    assert.eq true true;
+
+constructor:
+    assert.eq edition 0u16;
+
+/////////////////////////////////////////////////
+
+import child.aleo;
+program parent.aleo;
+
+function omega_wrapper:
+    call child.aleo/create_another_wrapper into r0 r1;
+    cast 1u32 2u32 into r2 as child.aleo/Woo;
+    cast r2 into r3 as child.aleo/BooHoo;
+    async omega_wrapper r3 r0 r1 into r4;
+    output r4[0u32] as child.aleo/BooHoo.private;
+    output r4[1u32] as child.aleo/BooHoo.private;
+    output r4 as parent.aleo/omega_wrapper.future;
+
+finalize omega_wrapper:
+    input r0 as child.aleo/BooHoo.public;
+    input r1 as child.aleo/BooHoo.public;
+    input r2 as child.aleo/create_another_wrapper.future;
+    await r2;
+
+constructor:
+    assert.eq edition 0u16;

--- a/synthesizer/tests/tests/vm/execute_and_finalize/future_with_external_struct_complex.aleo
+++ b/synthesizer/tests/tests/vm/execute_and_finalize/future_with_external_struct_complex.aleo
@@ -1,0 +1,87 @@
+/*
+randomness: 45791624
+cases:
+  - program: parent.aleo
+    function: omega_wrapper
+    inputs: []
+*/
+
+program grandchild.aleo;
+
+struct Woo:
+    a as u32;
+    b as u32;
+
+struct BooHoo:
+    woo as Woo;
+
+function create_wrapper:
+    cast 1u32 2u32 into r0 as Woo;
+    cast r0 into r1 as BooHoo;
+    async create_wrapper r1 into r2;
+    output r2[0u32] as BooHoo.private;
+    output r2 as grandchild.aleo/create_wrapper.future;
+
+finalize create_wrapper:
+    input r0 as BooHoo.public;
+    assert.eq true true;
+
+constructor:
+    assert.eq edition 0u16;
+
+/////////////////////////////////////////////////
+
+import grandchild.aleo;
+program child.aleo;
+
+struct Woo:
+    a as u32;
+    b as u32;
+
+struct BooHoo:
+    woo as Woo;
+
+function create_another_wrapper:
+    call grandchild.aleo/create_wrapper into r0 r1;
+    cast 1u32 2u32 into r2 as Woo;
+    cast r2 into r3 as BooHoo;
+    async create_another_wrapper r3 r0 r1 into r4;
+    output r4[0u32] as BooHoo.private;
+    output r4[1u32] as grandchild.aleo/BooHoo.private;
+    output r4 as child.aleo/create_another_wrapper.future;
+
+finalize create_another_wrapper:
+    input r0 as BooHoo.public;
+    input r1 as grandchild.aleo/BooHoo.public;
+    input r2 as grandchild.aleo/create_wrapper.future;
+    await r2;
+
+constructor:
+    assert.eq edition 0u16;
+
+/////////////////////////////////////////////////
+
+import grandchild.aleo;
+import child.aleo;
+program parent.aleo;
+
+function omega_wrapper:
+    call child.aleo/create_another_wrapper into r0 r1 r2;
+    cast 1u32 2u32 into r3 as child.aleo/Woo;
+    cast r3 into r4 as child.aleo/BooHoo;
+    async omega_wrapper r4 r0 r1 r2 into r5;
+    output r5[0u32] as child.aleo/BooHoo.private;
+    output r5[1u32] as child.aleo/BooHoo.private;
+    output r5[2u32] as grandchild.aleo/BooHoo.private;
+    output r2[2u32][0u32] as grandchild.aleo/BooHoo.private;
+    output r5 as parent.aleo/omega_wrapper.future;
+
+finalize omega_wrapper:
+    input r0 as child.aleo/BooHoo.public;
+    input r1 as child.aleo/BooHoo.public;
+    input r2 as grandchild.aleo/BooHoo.public;
+    input r3 as child.aleo/create_another_wrapper.future;
+    await r3;
+
+constructor:
+    assert.eq edition 0u16;


### PR DESCRIPTION
1. When checking that an external record matches its type, we need to use the external stack of the external program that contains the record. This is important because if the external record uses an external struct, we want to make sure that the external struct can be found. Previously, it didn't matter because, other than records, all types were visible everywhere. Now, that's changed.

2. Similar issue occurs with future arguments where, before comparing them when they are `Plaintext`, we have to select the right stack.

3. One more issue related to futures in `RegisterTypes::get_type` where finalize inputs need to be qualified with the program name when they are `Plaintext` from another program.
