### PR TITLE
perf: remove epoch heights allocation

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -320,9 +320,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
 
         // Collect the addresses of the solutions submitted in the current epoch.
-        let existing_epoch_blocks: Vec<_> = (start..=current_block_height).collect();
-        let solution_addresses = cfg_iter!(existing_epoch_blocks)
-            .flat_map(|height| match self.get_solutions(*height).as_deref() {
+        let solution_addresses = cfg_into_iter!(start..=current_block_height)
+            .flat_map(|height| match self.get_solutions(height).as_deref() {
                 Ok(Some(solutions)) => solutions.iter().map(|(_, s)| s.address()).collect::<Vec<_>>(),
                 _ => vec![],
             })


### PR DESCRIPTION
<!-- Why are these changes necessary? -->
Previously, load_epoch_provers allocated a Vec of block heights solely to support cfg_iter!, even though the range itself can be iterated in parallel. This added an unnecessary allocation and pass during ledger startup.

<!-- What changes does this PR make? -->
Replaced the intermediate Vec allocation with direct range iteration using cfg_into_iter!, keeping the same behavior while removing the extra allocation.