### PR TITLE
[Build] Check the license year

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,8 @@ use std::{
     fs::{self, File},
     io::Read,
     path::Path,
+    process::Command,
+    str,
 };
 
 use walkdir::WalkDir;
@@ -134,6 +136,20 @@ fn check_locktick_imports<P: AsRef<Path>>(path: P) {
 
 fn check_file_licenses<P: AsRef<Path>>(path: P) {
     let path = path.as_ref();
+
+    // Perform the license year check if on Linux.
+    if cfg!(target_os = "linux") {
+        // Get the current year from the OS
+        let os_year = Command::new("date")
+            .arg("+%Y") // ask only for the year
+            .output()
+            .expect("Failed to execute 'date' command");
+        let current_year = str::from_utf8(&os_year.stdout).expect("Date output was not valid UTF-8").trim();
+
+        // Check if the end of the year range in the license matches the OS year.
+        let license_year = str::from_utf8(&EXPECTED_LICENSE_TEXT[22..][..4]).unwrap();
+        assert_eq!(license_year, current_year, "The license year doesn't match the current OS year");
+    }
 
     let mut iter = WalkDir::new(path).into_iter();
     while let Some(entry) = iter.next() {


### PR DESCRIPTION
A simple Linux-only (which is good enough for CI purposes) check in the build script.

Will file the same in snarkOS when accepted.

Closes https://github.com/ProvableHQ/snarkVM/issues/3115.