### PR TITLE
Introduce coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 !**/neg-powers-of-beta.usrs
 **/proptest-regressions/
 artifacts
+coverage/

--- a/README-coverage.md
+++ b/README-coverage.md
@@ -1,0 +1,245 @@
+# coverage.sh — local SnarkVM coverage runner
+
+This repository includes `coverage.sh`, a **local** helper for running `cargo llvm-cov nextest` coverage **for groups** (circuit, ledger, synthesizer, etc.) and generating per-group HTML/LCOV reports. It also supports a **merge mode** that combines previously-saved group coverage state into one combined report.
+
+> This is intended for **local runs** (not CI). It mirrors the CI job “shape” but avoids `--workspace` all-at-once failures by running crate groups separately.
+> It is a very heavy and time taking script (for some of the groups), that's why it is not OK to be ran on a CI. Requires a very powerful machine/VM for the heavier groups.
+
+---
+
+## Prerequisites
+
+You need:
+
+- Rust toolchain via `rustup`
+- `cargo-nextest`
+- `cargo-llvm-cov`
+- LLVM coverage tools: `llvm-tools-preview` rustup component
+
+The script checks for:
+- `cargo`
+- `cargo-nextest`
+- `cargo-llvm-cov`
+
+…and will install `llvm-tools-preview` automatically if missing.
+
+---
+
+## Quick start
+
+From the repo root:
+
+```bash
+chmod +x ./coverage.sh
+./coverage.sh
+```
+
+By default, it runs these groups:
+
+- `circuit,console,ledger,synthesizer,misc`
+
+and writes reports to:
+
+- `./coverage/<group>/index.html` (HTML)
+- `./coverage/<group>/lcov.info` (LCOV)
+
+---
+
+## Running specific groups
+
+Use `COV_GROUPS` (comma-separated):
+
+```bash
+COV_GROUPS=ledger ./coverage.sh
+COV_GROUPS=circuit,ledger,synthesizer ./coverage.sh
+COV_GROUPS=ledger-slow ./coverage.sh
+```
+
+### Available groups
+
+- `circuit`
+- `console`
+- `ledger`
+- `ledger-slow` (rocks feature, partitions, ignored-only, ledger-block)
+- `synthesizer`
+- `synthesizer-slow` (partitions, integration, program shards, process rocks)
+- `misc` (algorithms, curves, fields, parameters, utilities, derives)
+- `snarkvm`
+
+---
+
+## Reports output directory
+
+Reports go under `OUT_DIR`:
+
+```bash
+OUT_DIR=coverage ./coverage.sh
+OUT_DIR=/tmp/snarkvm-coverage ./coverage.sh
+```
+
+Default:
+
+- `OUT_DIR=coverage`
+
+---
+
+## Parallelism / resource knobs
+
+### Nextest concurrency
+
+```bash
+NEXTEST_JOBS=8 ./coverage.sh
+NEXTEST_JOBS=16 COV_GROUPS=synthesizer ./coverage.sh
+```
+
+Default:
+
+- `NEXTEST_JOBS=8`
+
+### Stack size
+
+```bash
+RUST_MIN_STACK=67108864 ./coverage.sh
+```
+
+Default:
+
+- `RUST_MIN_STACK=67108864` (64 MiB)
+
+---
+
+## Global feature flags
+
+If you want to apply the same cargo build args to *every* run, set `GLOBAL_FEATURES`.
+
+Examples:
+
+```bash
+GLOBAL_FEATURES="--all-features" ./coverage.sh
+GLOBAL_FEATURES="--features rocks" COV_GROUPS=ledger-slow ./coverage.sh
+```
+
+> Note: `GLOBAL_FEATURES` is split on whitespace. Provide it as you would type it on the command line.
+
+---
+
+## Caching behavior
+
+To make it possible to run groups separately and later merge them, the script keeps a saved “coverage state” directory per group:
+
+- Saved state: `coverage/_state/<group>/`
+- Working state: `target/llvm-cov/<group>/`
+
+### What happens on each group run
+
+1. **Restore** previous state (if any): `coverage/_state/<group>` → `target/llvm-cov/<group>`
+2. Run coverage for the group (writes into `target/llvm-cov/<group>`)
+3. Generate the group report into `coverage/<group>/`
+4. **Save** state back: `target/llvm-cov/<group>` → `coverage/_state/<group>`
+
+### Cleaning state
+
+To force a clean slate for a group run:
+
+```bash
+COV_CLEAN=1 COV_GROUPS=ledger ./coverage.sh
+```
+
+This removes both:
+- `target/llvm-cov/<group>`
+- `coverage/_state/<group>`
+
+---
+
+## Merge mode (combine groups)
+
+Merge mode generates a combined report from previously-saved group states.
+
+### Typical workflow
+
+Run groups separately:
+
+```bash
+COV_GROUPS=circuit ./coverage.sh
+COV_GROUPS=ledger  ./coverage.sh
+```
+
+Then merge them:
+
+```bash
+COV_MERGE=1 COV_MERGE_GROUPS=circuit,ledger ./coverage.sh
+```
+
+Outputs:
+
+- `coverage/merged/index.html`
+- `coverage/merged/lcov.info`
+
+### Merge variables
+
+- `COV_MERGE=1`
+  Enables merge mode (the script will **only** merge and exit).
+
+- `COV_MERGE_GROUPS=<comma-separated>`
+  Which groups to merge. If omitted, it defaults to `COV_GROUPS`.
+
+- `COV_MERGE_CLEAN=1` (default)
+  Controls whether merge mode clears the merge working directory first.
+
+---
+
+## Interpreting failures
+
+The script tries to continue through variants. If a variant fails, it is recorded in `FAILURES` and the script exits non-zero at the end while still producing whatever reports it could.
+
+You will see a summary like:
+
+- `ledger:default:snarkvm-ledger`
+
+---
+
+## Troubleshooting
+
+### “Coverage report is empty” / merge only shows one group
+This merge is **heuristic**: it relies on the contents of each group’s `LLVM_COV_TARGET_DIR` state being sufficient for a combined report.
+
+If the merged report is incomplete, the robust approach is:
+
+1. Force a stable `LLVM_PROFILE_FILE` output location per group (e.g. `coverage/profiles/<group>/*.profraw`)
+2. Merge with `llvm-profdata merge` into a single `merged.profdata`
+3. Generate HTML/LCOV from that merged profdata
+
+If you hit this, inspect what got saved:
+
+```bash
+find coverage/_state/ledger -maxdepth 3 -type f | head -n 50
+```
+
+### Tooling not found
+Install the required tools:
+
+```bash
+cargo install cargo-nextest --locked
+cargo install cargo-llvm-cov --locked
+rustup component add llvm-tools-preview
+```
+
+---
+
+## Examples
+
+### Fast per-group run
+```bash
+COV_GROUPS=circuit OUT_DIR=coverage ./coverage.sh
+```
+
+### Heavy group with more concurrency
+```bash
+COV_GROUPS=synthesizer-slow NEXTEST_JOBS=16 ./coverage.sh
+```
+
+### Clean + run + merge
+```bash
+COV_CLEAN=1 COV_GROUPS=circuit,ledger ./coverage.sh
+COV_MERGE=1 COV_MERGE_GROUPS=circuit,ledger ./coverage.sh
+```

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,505 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# From the CI definitions:
+RUST_MIN_STACK="${RUST_MIN_STACK:-67108864}"
+JOBS="${NEXTEST_JOBS:-8}"
+OUT_DIR="${OUT_DIR:-coverage}"
+
+# Optional build args applied to every run (array)
+# For very custom runs. Added so if somethig is new or skipped by new code a new run/pseudo-group can be created,
+# through the CLI. Can be ignored for normal runs.
+#
+# Examples:
+#   GLOBAL_BUILD_ARGS=(--all-features)
+#   GLOBAL_BUILD_ARGS=(--features rocksdb,test)
+GLOBAL_BUILD_ARGS=()
+
+if [ -n "${GLOBAL_FEATURES:-}" ]; then
+  GLOBAL_BUILD_ARGS=(${GLOBAL_FEATURES})
+fi
+
+FAILURES=()
+
+# Check that everything needed is installed:
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing: $1" >&2; exit 1; }; }
+need_cmd cargo
+need_cmd cargo-nextest
+need_cmd cargo-llvm-cov
+
+if ! rustup component list --installed | grep -q '^llvm-tools-preview'; then
+  echo "Installing rustup component llvm-tools-preview..."
+  rustup component add llvm-tools-preview
+fi
+
+mkdir -p "$OUT_DIR" "coverage/_state"
+
+# Decided to move the state under coverage (not target) as target is sometimes deleted, so these functions copy it
+# and restore it.
+restore_cov_state() {
+  local group="$1"
+  local src="coverage/_state/${group}"
+  local dst="coverage/_merge_state/${group}"
+
+  if [ -d "$src" ]; then
+    echo "==> Restoring cached cov state: $src -> $dst"
+    mkdir -p "$(dirname "$dst")"
+    rm -rf "$dst"
+    cp -a "$src" "$dst"
+  fi
+}
+
+save_cov_state() {
+  local group="$1"
+  local src="target/llvm-cov/${group}"
+  local dst="coverage/_state/${group}"
+
+  echo "==> Saving cov state: $src -> $dst"
+  mkdir -p "$(dirname "$dst")"
+  rm -rf "$dst"
+  if [ -d "$src" ]; then
+    cp -a "$src" "$dst"
+  else
+    echo "WARN: no cov state dir found at $src" >&2
+  fi
+}
+
+maybe_clean_cov_state() {
+  local group="$1"
+  if [ "${COV_CLEAN:-0}" = "1" ]; then
+    echo "==> Cleaning cov state for group '$group'"
+    rm -rf "target/llvm-cov/${group}" "coverage/_state/${group}"
+  fi
+}
+
+# Usage:
+#   run_cov_variant <group> <pkg> <variant> [build-args...] [-- libtest-args...]
+#
+# Examples:
+#   run_cov_variant ledger snarkvm-ledger default
+#   run_cov_variant ledger-slow snarkvm-ledger with-rocks --features rocks
+#   run_cov_variant ledger-slow snarkvm-ledger-store -- --ignored --test-threads 2
+run_cov_variant() {
+  local group="$1"; shift
+  local pkg="$1"; shift
+  local variant="$1"; shift
+
+  local cov_target_dir="target/llvm-cov/${group}"
+  mkdir -p "$cov_target_dir"
+
+  # Split args around optional "--" Similar to the run code in the CI:
+  local build_args=()
+  local test_args=()
+  local seen_sep=0
+  while (($#)); do
+    if [ "$1" = "--" ]; then
+      seen_sep=1
+      shift
+      continue
+    fi
+    if [ $seen_sep -eq 0 ]; then
+      build_args+=("$1")
+    else
+      test_args+=("$1")
+    fi
+    shift
+  done
+
+  echo ""
+  echo "=== [${group}] ${variant} ==="
+  echo "pkg: ${pkg}"
+  echo "cov_target_dir: ${cov_target_dir}"
+  if ((${#build_args[@]})); then
+    echo "build_args: ${build_args[*]}"
+  else
+    echo "build_args: <none>"
+  fi
+  if ((${#test_args[@]})); then
+    echo "libtest_args: ${test_args[*]}"
+  else
+    echo "libtest_args: <none>"
+  fi
+  echo ""
+
+  local cmd=(
+    cargo llvm-cov nextest
+    --no-report
+    -p "$pkg"
+    --no-fail-fast
+    -j "$JOBS"
+  )
+
+  local -a global_build_args=()
+
+  if [ -n "${GLOBAL_FEATURES:-}" ]; then
+    global_build_args=(${GLOBAL_FEATURES})
+  fi
+
+  if ((${#global_build_args[@]})); then
+    cmd+=("${global_build_args[@]}")
+  fi
+
+  # Only add "--" if we actually have libtest args
+  if ((${#test_args[@]})); then
+    cmd+=(-- "${test_args[@]}")
+  fi
+
+  if ! LLVM_COV_TARGET_DIR="$cov_target_dir" \
+      RUST_MIN_STACK="$RUST_MIN_STACK" \
+      "${cmd[@]}"
+  then
+    FAILURES+=("${group}:${variant}:${pkg}")
+  fi
+}
+
+finalize_group_report() {
+  local group="$1"
+  local cov_target_dir="target/llvm-cov/${group}"
+  local group_out="${OUT_DIR}/${group}"
+
+  mkdir -p "$group_out"
+
+  echo ""
+  echo "=== [${group}] generating report ==="
+  echo "raw data: ${cov_target_dir}"
+  echo "html: ${group_out}/index.html"
+  echo "lcov: ${group_out}/lcov.info"
+  echo ""
+
+  LLVM_COV_TARGET_DIR="$cov_target_dir" \
+    cargo llvm-cov report --html --output-dir "$group_out"
+
+  LLVM_COV_TARGET_DIR="$cov_target_dir" \
+    cargo llvm-cov report --lcov --output-path "${group_out}/lcov.info"
+}
+
+# ===== Groups (Like CI workflows) =====
+
+run_circuit_group() {
+  local group="circuit"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  local pkgs=(
+    snarkvm-circuit
+    snarkvm-circuit-account
+    snarkvm-circuit-algorithms
+    snarkvm-circuit-collections
+    snarkvm-circuit-environment
+    snarkvm-circuit-network
+    snarkvm-circuit-program
+    snarkvm-circuit-types
+    snarkvm-circuit-types-address
+    snarkvm-circuit-types-boolean
+    snarkvm-circuit-types-field
+    snarkvm-circuit-types-group
+    snarkvm-circuit-types-integers
+    snarkvm-circuit-types-scalar
+    snarkvm-circuit-types-string
+  )
+
+  for p in "${pkgs[@]}"; do
+    run_cov_variant "$group" "$p" "default"
+  done
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+run_console_group() {
+  local group="console"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  local pkgs=(
+    snarkvm-console
+    snarkvm-console-account
+    snarkvm-console-algorithms
+    snarkvm-console-collections
+    snarkvm-console-network
+    snarkvm-console-network-environment
+    snarkvm-console-program
+    snarkvm-console-types
+    snarkvm-console-types-address
+    snarkvm-console-types-boolean
+    snarkvm-console-types-field
+    snarkvm-console-types-group
+    snarkvm-console-types-integers
+    snarkvm-console-types-scalar
+    snarkvm-console-types-string
+  )
+
+  for p in "${pkgs[@]}"; do
+    run_cov_variant "$group" "$p" "default"
+  done
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+# Fast ledger: matches ledger-workflow (excluding heavy merge/release extras)
+run_ledger_group() {
+  local group="ledger"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  local pkgs=(
+    snarkvm-ledger
+    snarkvm-ledger-authority
+    snarkvm-ledger-committee
+    snarkvm-ledger-narwhal
+    snarkvm-ledger-narwhal-batch-certificate
+    snarkvm-ledger-narwhal-batch-header
+    snarkvm-ledger-narwhal-data
+    snarkvm-ledger-narwhal-subdag
+    snarkvm-ledger-narwhal-transmission
+    snarkvm-ledger-narwhal-transmission-id
+    snarkvm-ledger-puzzle
+    snarkvm-ledger-puzzle-epoch
+    snarkvm-ledger-query
+    snarkvm-ledger-store
+    snarkvm-ledger-test-helpers
+  )
+
+  for p in "${pkgs[@]}"; do
+    run_cov_variant "$group" "$p" "default"
+  done
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+# Slow ledger: rocks partitions, ignored-only, ledger-block (merge-workflow + release-workflow)
+run_ledger_slow_group() {
+  local group="ledger-slow"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  # Heavy: ledger-block
+  run_cov_variant "$group" "snarkvm-ledger-block" "ledger-block"
+
+  # Heavy-ish: rocks feature
+  run_cov_variant "$group" "snarkvm-ledger" "rocks" --release --features rocks
+  run_cov_variant "$group" "snarkvm-ledger-store" "store-rocks" --features rocks
+
+  # Very heavy: ignored-only
+  run_cov_variant "$group" "snarkvm-ledger-store" "store-ignored" \
+    -- --run-ignored ignored-only --test-threads 2
+
+  run_cov_variant "$group" "snarkvm-ledger" "rocks-partition-1" \
+    --release --features rocks --partition count:1/2 -- --test-threads 10
+  run_cov_variant "$group" "snarkvm-ledger" "rocks-partition-2" \
+    --release --features rocks --partition count:2/2 -- --test-threads 10
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+# Fast synthesizer: synthesizer-workflow
+run_synthesizer_group() {
+  local group="synthesizer"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  local pkgs=(
+    snarkvm-synthesizer
+    snarkvm-synthesizer-process
+    snarkvm-synthesizer-program
+    snarkvm-synthesizer-snark
+  )
+
+  for p in "${pkgs[@]}"; do
+    run_cov_variant "$group" "$p" "default"
+  done
+
+  run_cov_variant "$group" "snarkvm-synthesizer" "lib-bins" --lib --bins -- --test-threads 16
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+# Slow synthesizer: partitions, integration, program integration shards, process rocks
+run_synthesizer_slow_group() {
+  local group="synthesizer-slow"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  run_cov_variant "$group" "snarkvm-synthesizer" "ignored-only" \
+    --features test \
+    -- --run-ignored ignored-only --test-threads 2
+
+  run_cov_variant "$group" "snarkvm-synthesizer" "test-partition-1" \
+    --lib --bins --features test --partition count:1/2 -- --test-threads 8
+  run_cov_variant "$group" "snarkvm-synthesizer" "test-partition-2" \
+    --lib --bins --features test --partition count:2/2 -- --test-threads 8
+
+  run_cov_variant "$group" "snarkvm-synthesizer" "integration" \
+    --test '*' --features test -- --test-threads 4
+
+  run_cov_variant "$group" "snarkvm-synthesizer-process" "with-rocksdb" \
+    --features rocks -- --test-threads 4
+
+  run_cov_variant "$group" "snarkvm-synthesizer-program" "integration" \
+    -- --skip keccak --skip psd --skip sha --skip instruction::is --skip instruction::equal --skip instruction::commit --test-threads 8
+
+  run_cov_variant "$group" "snarkvm-synthesizer-program" "integration-keccak" keccak
+  run_cov_variant "$group" "snarkvm-synthesizer-program" "integration-psd" psd
+  run_cov_variant "$group" "snarkvm-synthesizer-program" "integration-sha" sha
+  run_cov_variant "$group" "snarkvm-synthesizer-program" "integration-instruction-is" instruction::is
+  run_cov_variant "$group" "snarkvm-synthesizer-program" "integration-instruction-equal" instruction::equal
+  run_cov_variant "$group" "snarkvm-synthesizer-program" "integration-instruction-commit" instruction::commit
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+run_misc_group() {
+  local group="misc"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  local pkgs=(
+    snarkvm-algorithms
+    snarkvm-curves
+    snarkvm-fields
+    snarkvm-parameters
+    snarkvm-utilities
+    snarkvm-utilities-derives
+  )
+
+  for p in "${pkgs[@]}"; do
+    run_cov_variant "$group" "$p" "default"
+  done
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+run_snarkvm_group() {
+  local group="snarkvm"
+  maybe_clean_cov_state "$group"
+  restore_cov_state "$group"
+
+  run_cov_variant "$group" "snarkvm" "default"
+
+  finalize_group_report "$group"
+  save_cov_state "$group"
+}
+
+merge_restore_group_state() {
+  local group="$1"
+  local src="coverage/_state/${group}"
+  local dst="target/llvm-cov/_merge/${group}"
+
+  if [ ! -d "$src" ]; then
+    echo "WARN: no saved cov state for group '$group' at $src (skipping)" >&2
+    return 1
+  fi
+
+  echo "==> Restoring group cov state for merge: $src -> $dst"
+  mkdir -p "$(dirname "$dst")"
+  rm -rf "$dst"
+  cp -a "$src" "$dst"
+}
+
+merge_generate_report() {
+  local merge_groups_raw="$1"
+  local merge_out="${OUT_DIR}/merged"
+  local merge_root="coverage/_merge_state"
+
+  mkdir -p "$merge_out"
+
+  echo ""
+  echo "=== [merge] generating combined report ==="
+  echo "groups: ${merge_groups_raw}"
+  echo "merge_root: ${merge_root}"
+  echo "html: ${merge_out}/index.html"
+  echo "lcov: ${merge_out}/lcov.info"
+  echo ""
+
+  LLVM_COV_TARGET_DIR="$merge_root" \
+    cargo llvm-cov report --html --output-dir "$merge_out"
+
+  LLVM_COV_TARGET_DIR="$merge_root" \
+    cargo llvm-cov report --lcov --output-path "${merge_out}/lcov.info"
+}
+
+run_merge() {
+  local merge_groups_raw="${COV_MERGE_GROUPS:-${COV_GROUPS:-}}"
+  if [ -z "$merge_groups_raw" ]; then
+    echo "ERROR: merge requested but no groups specified (set COV_MERGE_GROUPS or COV_GROUPS)" >&2
+    exit 2
+  fi
+
+  echo "[debug] MERGE_GROUPS='${merge_groups_raw}'"
+
+  # Clean merge root unless disabled
+  if [ "${COV_MERGE_CLEAN:-1}" = "1" ]; then
+    rm -rf "coverage/_merge_state"
+  fi
+  mkdir -p "coverage/_merge_state"
+
+  local IFS=','
+  read -r -a mg <<< "${merge_groups_raw}"
+
+  local restored_any=0
+  for g in "${mg[@]}"; do
+    g="$(printf '%s' "$g" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -z "$g" ] && continue
+    if merge_restore_group_state "$g"; then
+      restored_any=1
+    fi
+  done
+
+  if [ "$restored_any" -eq 0 ]; then
+    echo "ERROR: no groups could be restored for merge; did you run coverage for them first?" >&2
+    exit 2
+  fi
+
+  merge_generate_report "$merge_groups_raw"
+}
+
+main() {
+  if [ "${COV_MERGE:-0}" = "1" ]; then
+    run_merge
+    return 0
+  fi
+
+  local groups_raw="${COV_GROUPS:-circuit,console,ledger,synthesizer,misc}"
+  echo "[debug] GROUPS='${groups_raw}'"
+
+  local IFS=','
+  read -r -a gs <<< "${groups_raw}"
+
+  for g in "${gs[@]}"; do
+    g="$(printf '%s' "$g" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -z "$g" ] && continue
+
+    case "$g" in
+      circuit)           run_circuit_group ;;
+      console)           run_console_group ;;
+      ledger)            run_ledger_group ;;
+      ledger-slow)       run_ledger_slow_group ;;
+      synthesizer)       run_synthesizer_group ;;
+      synthesizer-slow)  run_synthesizer_slow_group ;;
+      misc)              run_misc_group ;;
+      snarkvm)           run_snarkvm_group ;;
+      *)
+        echo "WARN: ignoring unknown group token: '$g'" >&2
+        ;;
+    esac
+  done
+
+  echo ""
+  echo "==== Coverage complete ===="
+  echo "Reports in: ${OUT_DIR}/"
+  echo ""
+
+  if ((${#FAILURES[@]} > 0)); then
+    echo "Some variants failed (coverage still generated from successful runs):"
+    printf ' - %s\n' "${FAILURES[@]}"
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION

## Motivation

Generating test coverage reports for the SnarkVM repo is very CPU/RAM heavy and time taking (days). Because of that I am introducing a new script that mirrors the CI (by dividing the tests in groups/workflows) and coverage reports can be sone by groups.

The script has the ability to merge these reports and to cover all tests like that.

The idea is to run this script for every group on a very powerful machine/VM from time to time and then generate a report.
I do not recommend this to be done on the CI, but the CI may create some VM that does it and can gather results after it is done on specific branch, or something similar to the stress tests manager can do that.

All depends on the costs. I spent some time trying to make it work and came with this idea. I have an idea for code analysis for a very loose coverage report, but won't be including it here, as it is very experimental.

 ## Test Plan

I successfully ran two groups locally and merged them. Couldn't run heavier groups like the `ledger` on my machine, tried to make it lighter and do it but was not really possible. Can be done with the optional custom filters I left in the script as logic and test tagging, but the idea is not to see what my machine can run, so with the `circuit` and `misc` groups I had success.

## Documentation

This script has a README in the PR.

## Backwards compatibility

