### PR TITLE
Fix CI compilation for failing jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,6 +358,7 @@ commands:
               RUST_MIN_STACK=67108864 cargo test --package="<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED | tee "$OUT"
               : > "$CSV"; : > "$TOP"
             else
+              rm -rf target
               RUST_MIN_STACK=67108864 \
               cargo nextest run \
                 -p "<< parameters.workspace_member >>" $BUILD_FLAGS_SANITIZED \


### PR DESCRIPTION

## Motivation

Some jobs are broken because of the cache, in another PR we are removing the target from the cache anyway, so the fix should be removing the target before compilation of the tests.

Closes https://github.com/ProvableHQ/snarkVM/issues/3120

## Test Plan

The CI runs OK with this change.
