### PR TITLE
[Refactor] Isolate a synthesizer-error crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,6 +3344,7 @@ dependencies = [
  "snarkvm-ledger-store",
  "snarkvm-ledger-test-helpers",
  "snarkvm-synthesizer",
+ "snarkvm-synthesizer-error",
  "snarkvm-utilities",
  "thiserror 2.0.17",
  "time",
@@ -3683,6 +3684,7 @@ dependencies = [
  "snarkvm-ledger-query",
  "snarkvm-ledger-store",
  "snarkvm-ledger-test-helpers",
+ "snarkvm-synthesizer-error",
  "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
@@ -3692,6 +3694,16 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-error"
+version = "4.4.0"
+dependencies = [
+ "anyhow",
+ "snarkvm-circuit-environment",
+ "snarkvm-console-network",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3718,6 +3730,7 @@ dependencies = [
  "snarkvm-ledger-query",
  "snarkvm-ledger-store",
  "snarkvm-ledger-test-helpers",
+ "snarkvm-synthesizer-error",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
@@ -3741,6 +3754,7 @@ dependencies = [
  "serde_json",
  "snarkvm-circuit",
  "snarkvm-console",
+ "snarkvm-synthesizer-error",
  "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
   "metrics",
   "parameters",
   "synthesizer",
+  "synthesizer/error",
   "synthesizer/process",
   "synthesizer/program",
   "synthesizer/snark",
@@ -399,6 +400,10 @@ version = "=4.4.0"
 
 [workspace.dependencies.snarkvm-synthesizer]
 path = "synthesizer"
+version = "=4.4.0"
+
+[workspace.dependencies.snarkvm-synthesizer-error]
+path = "synthesizer/error"
 version = "=4.4.0"
 
 [workspace.dependencies.snarkvm-synthesizer-process]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -134,6 +134,9 @@ optional = true
 [dependencies.snarkvm-synthesizer]
 workspace = true
 
+[dependencies.snarkvm-synthesizer-error]
+workspace = true
+
 [dependencies.snarkvm-utilities]
 workspace = true
 

--- a/ledger/src/error.rs
+++ b/ledger/src/error.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkvm_synthesizer::{VmDeployError, VmExecError};
+use snarkvm_synthesizer_error::{VmDeployError, VmExecError};
 use thiserror::Error;
 
 // NOTE: Many errors in this module temporarily contain `Anyhow` variants.

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -99,6 +99,9 @@ features = [ "query" ]
 [dependencies.snarkvm-ledger-store]
 workspace = true
 
+[dependencies.snarkvm-synthesizer-error]
+workspace = true
+
 [dependencies.snarkvm-synthesizer-process]
 workspace = true
 

--- a/synthesizer/error/Cargo.toml
+++ b/synthesizer/error/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "snarkvm-synthesizer-error"
+version = "4.4.0"
+authors = [ "The Aleo Team <hello@aleo.org>" ]
+description = "A decentralized virtual machine"
+homepage = "https://aleo.org"
+repository = "https://github.com/ProvableHQ/snarkVM"
+keywords = [
+  "aleo",
+  "cryptography",
+  "blockchain",
+  "decentralized",
+  "zero-knowledge"
+]
+categories = [
+  "compilers",
+  "cryptography",
+  "mathematics",
+  "wasm",
+  "web-programming"
+]
+include = [ "Cargo.toml", "vm", "README.md", "LICENSE.md" ]
+license = "Apache-2.0"
+edition = "2024"
+rust-version = "1.88.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
+
+[dependencies.snarkvm-circuit-environment]
+workspace = true
+
+[dependencies.snarkvm-console-network]
+workspace = true
+
+[dependencies.anyhow]
+workspace = true
+
+[dependencies.thiserror]
+workspace = true

--- a/synthesizer/error/LICENSE.md
+++ b/synthesizer/error/LICENSE.md
@@ -1,0 +1,194 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/synthesizer/error/src/lib.rs
+++ b/synthesizer/error/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod process;
+pub use process::*;
+
+mod program;
+pub use program::*;
+
+mod vm;
+pub use vm::*;

--- a/synthesizer/error/src/process.rs
+++ b/synthesizer/error/src/process.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use circuit::environment::ConstraintUnsatisfied;
-use snarkvm_synthesizer_program::{EvalError, ExecError};
+use crate::{EvalError, ExecError};
+use snarkvm_circuit_environment::ConstraintUnsatisfied;
 use thiserror::Error;
 
 // NOTE: Many errors in this module temporarily contain `Anyhow` variants.
@@ -185,7 +185,7 @@ pub enum InstructionExecError {
 
 impl<E> IndexedInstructionError<E> {
     /// Short-hand constructor for the `IndexedInstructionError` type.
-    pub(crate) fn new(index: usize, instruction: String, error: E) -> Self {
+    pub fn new(index: usize, instruction: String, error: E) -> Self {
         Self { index, instruction, error }
     }
 }

--- a/synthesizer/error/src/program.rs
+++ b/synthesizer/error/src/program.rs
@@ -15,8 +15,8 @@
 
 //! Errors for instruction operations.
 
-use circuit::environment::ConstraintUnsatisfied;
-use console::network::prelude::Error as AnyhowError;
+use snarkvm_circuit_environment::ConstraintUnsatisfied;
+use snarkvm_console_network::prelude::Error as AnyhowError;
 use thiserror::Error;
 
 // NOTE: Many errors in this module temporarily contain `Anyhow` variants.

--- a/synthesizer/error/src/vm.rs
+++ b/synthesizer/error/src/vm.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkvm_synthesizer_process::{ProcessAuthError, ProcessDeployError, ProcessExecError};
+use crate::{ProcessAuthError, ProcessDeployError, ProcessExecError};
 use thiserror::Error;
 
 // NOTE: Many errors in this module temporarily contain `Anyhow` variants.

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -79,6 +79,9 @@ workspace = true
 [dependencies.snarkvm-ledger-store]
 workspace = true
 
+[dependencies.snarkvm-synthesizer-error]
+workspace = true
+
 [dependencies.snarkvm-synthesizer-program]
 workspace = true
 

--- a/synthesizer/process/src/authorize.rs
+++ b/synthesizer/process/src/authorize.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use snarkvm_synthesizer_error::*;
+
 impl<N: Network> Process<N> {
     /// Authorizes a call to the program function for the given inputs.
     #[inline]

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::error::ProcessDeployError;
+use snarkvm_synthesizer_error::*;
 
 impl<N: Network> Process<N> {
     /// Deploys the given program ID, if it does not exist.

--- a/synthesizer/process/src/evaluate.rs
+++ b/synthesizer/process/src/evaluate.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::error::ProcessEvalError;
+use snarkvm_synthesizer_error::*;
 
 impl<N: Network> Process<N> {
     /// Evaluates a program function on the given request.

--- a/synthesizer/process/src/execute.rs
+++ b/synthesizer/process/src/execute.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::error::ProcessExecError;
+use snarkvm_synthesizer_error::*;
 
 impl<N: Network> Process<N> {
     /// Executes the given authorization.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -25,9 +25,6 @@ extern crate snarkvm_console as console;
 mod cost;
 pub use cost::*;
 
-mod error;
-pub use error::*;
-
 mod stack;
 pub use stack::*;
 

--- a/synthesizer/process/src/stack/authorize.rs
+++ b/synthesizer/process/src/stack/authorize.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::error::*;
+use snarkvm_synthesizer_error::*;
 
 impl<N: Network> Stack<N> {
     /// Authorizes a call to the program function for the given inputs.

--- a/synthesizer/process/src/stack/call/mod.rs
+++ b/synthesizer/process/src/stack/call/mod.rs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{CallStack, Registers, Stack, error::*, stack::Address};
+use crate::{CallStack, Registers, Stack, stack::Address};
 use aleo_std::prelude::{finish, lap, timer};
 use console::{
     account::Field,
     network::prelude::*,
     program::{Register, Request, Value, ValueType},
 };
+use snarkvm_synthesizer_error::*;
 use snarkvm_synthesizer_program::{
     Call,
     CallOperator,

--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::error::*;
+use snarkvm_synthesizer_error::*;
 
 use std::sync::OnceLock;
 

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::error::*;
+use snarkvm_synthesizer_error::*;
 
 impl<N: Network> Stack<N> {
     /// Executes a program closure on the given inputs.

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -39,9 +39,7 @@ features = [ "account", "network", "program", "types" ]
 workspace = true
 
 [dependencies.snarkvm-utilities]
-path = "../../utilities"
-version = "=4.4.0"
-default-features = false
+workspace = true
 
 [dependencies.enum-iterator]
 workspace = true

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -35,6 +35,9 @@ workspace = true
 workspace = true
 features = [ "account", "network", "program", "types" ]
 
+[dependencies.snarkvm-synthesizer-error]
+workspace = true
+
 [dependencies.snarkvm-utilities]
 path = "../../utilities"
 version = "=4.4.0"

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod error;
-pub use error::*;
-
 mod opcode;
 pub use opcode::*;
 
@@ -56,6 +53,7 @@ use console::{
     },
     program::{Register, RegisterType},
 };
+use snarkvm_synthesizer_error::*;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Instruction<N: Network> {

--- a/synthesizer/program/src/logic/instruction/operation/assert.rs
+++ b/synthesizer/program/src/logic/instruction/operation/assert.rs
@@ -13,22 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    AssertError,
-    EvalError,
-    ExecError,
-    FinalizeError,
-    Opcode,
-    Operand,
-    RegistersCircuit,
-    RegistersTrait,
-    StackTrait,
-    register_types_equivalent,
-};
+use crate::{Opcode, Operand, RegistersCircuit, RegistersTrait, StackTrait, register_types_equivalent};
 use console::{
     network::prelude::*,
     program::{Register, RegisterType},
 };
+use snarkvm_synthesizer_error::*;
 
 /// Asserts two operands are equal to each other.
 pub type AssertEq<N> = AssertInstruction<N, { Variant::AssertEq as u8 }>;

--- a/synthesizer/src/vm/authorize.rs
+++ b/synthesizer/src/vm/authorize.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use snarkvm_synthesizer_error::*;
+
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Authorizes a call to the program function for the given inputs.
     #[inline]

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use snarkvm_synthesizer_error::*;
+
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Returns a new deploy transaction.
     ///

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -17,6 +17,8 @@
 
 use super::*;
 
+use snarkvm_synthesizer_error::*;
+
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Returns a new execute transaction.
     ///

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -16,9 +16,6 @@
 mod helpers;
 pub use helpers::*;
 
-mod error;
-pub use error::*;
-
 mod authorize;
 mod deploy;
 mod execute;


### PR DESCRIPTION
This PR facilitates concrete error use in crates which would otherwise run into circular dependencies (e.g. https://github.com/ProvableHQ/snarkVM/pull/3101).

The only "internal" dependencies of the new crate are `circuit-environment` and `console-network`, and they should remain minimal to ensure broad applicability.