### PR TITLE
Fix external structs access in external mapping;

### DIFF
--- a/console/program/src/data_types/plaintext_type/mod.rs
+++ b/console/program/src/data_types/plaintext_type/mod.rs
@@ -61,6 +61,24 @@ impl<N: Network> PlaintextType<N> {
             }
         }
     }
+
+    /// Removes all program qualification from struct types.
+    pub fn unqualify(self) -> Self {
+        match self {
+            // Already-unqualified or unaffected
+            PlaintextType::Literal(..) | PlaintextType::Struct(..) => self,
+
+            // Drop the program qualification unconditionally
+            PlaintextType::ExternalStruct(locator) => PlaintextType::Struct(*locator.name()),
+
+            // Recurse into arrays
+            PlaintextType::Array(array_type) => {
+                let element_type = array_type.next_element_type().clone().unqualify();
+
+                PlaintextType::Array(ArrayType::new(element_type, vec![*array_type.length()]).unwrap())
+            }
+        }
+    }
 }
 
 impl<N: Network> From<LiteralType> for PlaintextType<N> {

--- a/synthesizer/process/src/stack/finalize_registers/registers_trait.rs
+++ b/synthesizer/process/src/stack/finalize_registers/registers_trait.rs
@@ -135,7 +135,13 @@ impl<N: Network> RegistersTrait<N> for FinalizeRegisters<N> {
                 // Ensure the type of the register is valid.
                 match (self.finalize_types.get_type(stack, register), &stack_value) {
                     // Ensure the plaintext value matches the plaintext type.
-                    (Ok(FinalizeType::Plaintext(plaintext_type)), Value::Plaintext(plaintext_value)) => {
+                    (Ok(FinalizeType::Plaintext(mut plaintext_type)), Value::Plaintext(plaintext_value)) => {
+                        if N::CONSENSUS_VERSION(self.state().block_height())? < ConsensusVersion::V13 {
+                            // Pre-V13, the `ExternalStruct` type did not exist. If the type happens to be qualified in
+                            // `get_type` above, we need to unqualify it (i.e. `ExternalStruct` becomes `Struct`) in order
+                            // to obtain the same behavior we had pre-V13.
+                            plaintext_type = plaintext_type.unqualify();
+                        }
                         stack.matches_plaintext(plaintext_value, &plaintext_type)?
                     }
                     // Ensure the future value matches the future type.

--- a/synthesizer/process/src/stack/finalize_registers/registers_trait.rs
+++ b/synthesizer/process/src/stack/finalize_registers/registers_trait.rs
@@ -140,6 +140,9 @@ impl<N: Network> RegistersTrait<N> for FinalizeRegisters<N> {
                             // Pre-V13, the `ExternalStruct` type did not exist. If the type happens to be qualified in
                             // `get_type` above, we need to unqualify it (i.e. `ExternalStruct` becomes `Struct`) in order
                             // to obtain the same behavior we had pre-V13.
+                            //
+                            // Note: we don't need to rescursively check `Struct` definitions since external structs
+                            // were not allowed before V13.
                             plaintext_type = plaintext_type.unqualify();
                         }
                         stack.matches_plaintext(plaintext_value, &plaintext_type)?

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -281,7 +281,7 @@ impl<N: Network> FinalizeTypes<N> {
     #[inline]
     fn check_contains(&mut self, stack: &Stack<N>, contains: &Contains<N>) -> Result<()> {
         // Retrieve the mapping.
-        let mapping = match contains.mapping() {
+        let (mapping, external_program) = match contains.mapping() {
             CallOperator::Locator(locator) => {
                 // Retrieve the program ID.
                 let program_id = locator.program_id();
@@ -304,7 +304,7 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("Mapping '{mapping_name}' in '{program_id}' is not defined.")
                 }
                 // Retrieve the mapping from the program.
-                external.get_mapping(mapping_name)?
+                (external.get_mapping(mapping_name)?, Some(program_id))
             }
             CallOperator::Resource(mapping_name) => {
                 // Ensure the declared mapping in `contains` is defined in the current program.
@@ -312,12 +312,17 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("Mapping '{mapping_name}' in '{}' is not defined.", stack.program_id())
                 }
                 // Retrieve the mapping from the program.
-                stack.program().get_mapping(mapping_name)?
+                (stack.program().get_mapping(mapping_name)?, None)
             }
         };
 
-        // Get the mapping key type.
-        let mapping_key_type = mapping.key().plaintext_type();
+        // Get the mapping key type. Qualify if necessary.
+        let mapping_key_type = if let Some(external_program) = external_program {
+            mapping.key().plaintext_type().clone().qualify(*external_program)
+        } else {
+            mapping.key().plaintext_type().clone()
+        };
+
         // Retrieve the register type of the key.
         let key_type = match self.get_type_from_operand(stack, contains.key())? {
             // If the register is a plaintext type, return it.
@@ -326,7 +331,7 @@ impl<N: Network> FinalizeTypes<N> {
             FinalizeType::Future(..) => bail!("A future cannot be used as a key in a `contains` command"),
         };
         // Check that the key type in the mapping is equivalent to the key type in the instruction.
-        if !types_equivalent(stack, mapping_key_type, stack, &key_type)? {
+        if !types_equivalent(stack, &mapping_key_type, stack, &key_type)? {
             bail!(
                 "Key type in `contains` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'."
             )
@@ -344,7 +349,7 @@ impl<N: Network> FinalizeTypes<N> {
     #[inline]
     fn check_get(&mut self, stack: &Stack<N>, get: &Get<N>) -> Result<()> {
         // Retrieve the mapping.
-        let mapping = match get.mapping() {
+        let (mapping, external_program) = match get.mapping() {
             CallOperator::Locator(locator) => {
                 // Retrieve the program ID.
                 let program_id = locator.program_id();
@@ -367,7 +372,7 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("Mapping '{mapping_name}' in '{program_id}' is not defined.")
                 }
                 // Retrieve the mapping from the program.
-                external.get_mapping(mapping_name)?
+                (external.get_mapping(mapping_name)?, Some(program_id))
             }
             CallOperator::Resource(mapping_name) => {
                 // Ensure the declared mapping in `get` is defined in the current program.
@@ -375,14 +380,23 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("Mapping '{mapping_name}' in '{}' is not defined.", stack.program_id())
                 }
                 // Retrieve the mapping from the program.
-                stack.program().get_mapping(mapping_name)?
+                (stack.program().get_mapping(mapping_name)?, None)
             }
         };
 
-        // Get the mapping key type.
-        let mapping_key_type = mapping.key().plaintext_type();
-        // Get the mapping value type.
-        let mapping_value_type = mapping.value().plaintext_type();
+        // Get the mapping key type. Qualify if necessary.
+        let mapping_key_type = if let Some(external_program) = external_program {
+            mapping.key().plaintext_type().clone().qualify(*external_program)
+        } else {
+            mapping.key().plaintext_type().clone()
+        };
+        // Get the mapping value type. Qualify if necessary.
+        let mapping_value_type = if let Some(external_program) = external_program {
+            mapping.value().plaintext_type().clone().qualify(*external_program)
+        } else {
+            mapping.value().plaintext_type().clone()
+        };
+
         // Retrieve the register type of the key.
         let key_type = match self.get_type_from_operand(stack, get.key())? {
             // If the register is a plaintext type, return it.
@@ -391,7 +405,7 @@ impl<N: Network> FinalizeTypes<N> {
             FinalizeType::Future(..) => bail!("A future cannot be used as a key in a `get` command"),
         };
         // Check that the key type in the mapping is equivalent to the key type in the instruction.
-        if !types_equivalent(stack, mapping_key_type, stack, &key_type)? {
+        if !types_equivalent(stack, &mapping_key_type, stack, &key_type)? {
             bail!("Key type in `get` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'.")
         }
         // Get the destination register.
@@ -407,7 +421,7 @@ impl<N: Network> FinalizeTypes<N> {
     #[inline]
     fn check_get_or_use(&mut self, stack: &Stack<N>, get_or_use: &GetOrUse<N>) -> Result<()> {
         // Retrieve the mapping.
-        let mapping = match get_or_use.mapping() {
+        let (mapping, external_program) = match get_or_use.mapping() {
             CallOperator::Locator(locator) => {
                 // Retrieve the program ID.
                 let program_id = locator.program_id();
@@ -430,7 +444,7 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("Mapping '{mapping_name}' in '{program_id}' is not defined.")
                 }
                 // Retrieve the mapping from the program.
-                external.get_mapping(mapping_name)?
+                (external.get_mapping(mapping_name)?, Some(program_id))
             }
             CallOperator::Resource(mapping_name) => {
                 // Ensure the declared mapping in `get.or_use` is defined in the current program.
@@ -438,14 +452,23 @@ impl<N: Network> FinalizeTypes<N> {
                     bail!("Mapping '{mapping_name}' in '{}' is not defined.", stack.program_id())
                 }
                 // Retrieve the mapping from the program.
-                stack.program().get_mapping(mapping_name)?
+                (stack.program().get_mapping(mapping_name)?, None)
             }
         };
 
-        // Get the mapping key type.
-        let mapping_key_type = mapping.key().plaintext_type();
-        // Get the mapping value type.
-        let mapping_value_type = mapping.value().plaintext_type();
+        // Get the mapping key type. Qualify if necessary.
+        let mapping_key_type = if let Some(external_program) = external_program {
+            mapping.key().plaintext_type().clone().qualify(*external_program)
+        } else {
+            mapping.key().plaintext_type().clone()
+        };
+        // Get the mapping value type. Qualify if necessary.
+        let mapping_value_type = if let Some(external_program) = external_program {
+            mapping.value().plaintext_type().clone().qualify(*external_program)
+        } else {
+            mapping.value().plaintext_type().clone()
+        };
+
         // Retrieve the register type of the key.
         let key_type = match self.get_type_from_operand(stack, get_or_use.key())? {
             // If the register is a plaintext type, return it.
@@ -454,7 +477,7 @@ impl<N: Network> FinalizeTypes<N> {
             FinalizeType::Future(..) => bail!("A future cannot be used as a key in a `get.or_use` command"),
         };
         // Check that the key type in the mapping is equivalent to the key type.
-        if !types_equivalent(stack, mapping_key_type, stack, &key_type)? {
+        if !types_equivalent(stack, &mapping_key_type, stack, &key_type)? {
             bail!(
                 "Key type in `get.or_use` '{key_type}' does not match the key type in the mapping '{mapping_key_type}'."
             )
@@ -467,7 +490,7 @@ impl<N: Network> FinalizeTypes<N> {
             FinalizeType::Future(..) => bail!("A default value cannot be a future"),
         };
         // Check that the value type in the mapping is equivalent to the default value type.
-        if !types_equivalent(stack, mapping_value_type, stack, &default_value_type)? {
+        if !types_equivalent(stack, &mapping_value_type, stack, &default_value_type)? {
             bail!(
                 "Default value type in `get.or_use` '{default_value_type}' does not match the value type in the mapping '{mapping_value_type}'."
             )

--- a/synthesizer/src/vm/tests/test_v13.rs
+++ b/synthesizer/src/vm/tests/test_v13.rs
@@ -1039,24 +1039,23 @@ constructor:
     assert_eq!(block.aborted_transaction_ids().len(), 0);
 }
 
+/// This test verifies that using the `get` command to read from an external mapping fails on V12
+/// when the mapping value contains an external struct (i.e. a struct that is not local to the program
+/// containing the `get`). The same scenario should succeed on V13, where the underlying bug has
+/// been fixed.
 #[test]
 fn test_external_mapping_external_struct_runtime_pre_post_v13() {
-    // Run the same scenario under a pre-V13 and post-V13 consensus version.
-    // The behavior difference is expected only at execution time.
-    //
-    // Start at V9 to make sure we're still pre-V13 by the time we execute the last transaction
-    for consensus_version in [ConsensusVersion::V9, ConsensusVersion::V13] {
-        let rng = &mut TestRng::default();
+    let rng = &mut TestRng::default();
+    let private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+    // Start the VM at consensus version V9 to ensure we're not at V13 by the time we get to the
+    // execution transaction that calls the second program.
+    let height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V9).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
 
-        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
-
-        let height = CurrentNetwork::CONSENSUS_HEIGHT(consensus_version).unwrap();
-        let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
-
-        // child.aleo defines a local struct `Point` and stores it as the value of
-        // a mapping. This program is always valid across versions.
-        let program_child = Program::from_str(
-            r"
+    // child.aleo defines a local struct `Point` and stores it as the value of
+    // a mapping. This program is always valid across versions.
+    let program_child = Program::from_str(
+        r"
 program child.aleo;
 
 struct Point:
@@ -1078,13 +1077,13 @@ finalize initialize:
 constructor:
     assert.eq edition 0u16;
 ",
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        // test.aleo reads a value from an external mapping whose value type is
-        // an external struct. This is the operation under test.
-        let program_test = Program::from_str(
-            r"
+    // test.aleo reads a value from an external mapping whose value type is
+    // an external struct. This is the operation under test.
+    let program_test = Program::from_str(
+        r"
 import child.aleo;
 
 program test.aleo;
@@ -1099,108 +1098,90 @@ finalize check_initialized:
 constructor:
     assert.eq edition 0u16;
 ",
-        )
+    )
+    .unwrap();
+
+    // ── Deploy child.aleo (always succeeds)
+    let deployment_child = vm.deploy(&private_key, &program_child, None, 0, None, rng).unwrap();
+
+    let block = sample_next_block(&vm, &private_key, &[deployment_child], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    vm.add_next_block(&block).unwrap();
+
+    // ── Deploy test.aleo and execute child.initialize in the same block.
+    // This ensures the mapping is populated before it is read.
+    let deployment_test = vm.deploy(&private_key, &program_test, None, 0, None, rng).unwrap();
+    let execution = vm
+        .execute(&private_key, ("child.aleo", "initialize"), Vec::<Value<_>>::new().into_iter(), None, 0, None, rng)
         .unwrap();
 
-        // ── Deploy child.aleo (always succeeds)
-        let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &private_key, &[deployment_test, execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 2);
+    vm.add_next_block(&block).unwrap();
 
-        let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
-        assert_eq!(block.transactions().num_accepted(), 1);
-        vm.add_next_block(&block).unwrap();
+    // ── Execute test.check_initialized.
+    //
+    // Pre-V13: rejected due to external struct usage in external mapping access.
+    let execution = vm
+        .execute(
+            &private_key,
+            ("test.aleo", "check_initialized"),
+            Vec::<Value<_>>::new().into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+    let block = sample_next_block(&vm, &private_key, &[execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.transactions().num_rejected(), 1);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
 
-        // ── Deploy test.aleo and execute child.initialize in the same block.
-        // This ensures the mapping is populated before it is read.
-        let deployment_test = vm.deploy(&caller_private_key, &program_test, None, 0, None, rng).unwrap();
-
-        let execution = vm
-            .execute(
-                &caller_private_key,
-                ("child.aleo", "initialize"),
-                Vec::<Value<_>>::new().into_iter(),
-                None,
-                0,
-                None,
-                rng,
-            )
-            .unwrap();
-
-        let block = sample_next_block(&vm, &caller_private_key, &[deployment_test, execution], rng).unwrap();
-        assert_eq!(block.transactions().num_accepted(), 2);
-        vm.add_next_block(&block).unwrap();
-
-        // ── Execute test.check_initialized.
-        //
-        // Pre-V13: rejected due to external struct usage in external mapping access.
-        // V13: accepted.
-        let execution = vm
-            .execute(
-                &caller_private_key,
-                ("test.aleo", "check_initialized"),
-                Vec::<Value<_>>::new().into_iter(),
-                None,
-                0,
-                None,
-                rng,
-            )
-            .unwrap();
-
-        let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
-        vm.add_next_block(&block).unwrap();
-
-        match consensus_version {
-            ConsensusVersion::V9 => {
-                assert_eq!(block.transactions().num_accepted(), 0);
-                assert_eq!(block.transactions().num_rejected(), 1);
-                assert_eq!(block.aborted_transaction_ids().len(), 0);
-
-                // Now we try again after we've advanced to V13. The same transaction should now succeed.
-                let execution = vm
-                    .execute(
-                        &caller_private_key,
-                        ("test.aleo", "check_initialized"),
-                        Vec::<Value<_>>::new().into_iter(),
-                        None,
-                        0,
-                        None,
-                        rng,
-                    )
-                    .unwrap();
-
-                let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
-                vm.add_next_block(&block).unwrap();
-                assert_eq!(block.transactions().num_accepted(), 1);
-                assert_eq!(block.transactions().num_rejected(), 0);
-                assert_eq!(block.aborted_transaction_ids().len(), 0);
-            }
-            ConsensusVersion::V13 => {
-                assert_eq!(block.transactions().num_accepted(), 1);
-                assert_eq!(block.transactions().num_rejected(), 0);
-                assert_eq!(block.aborted_transaction_ids().len(), 0);
-            }
-            _ => unreachable!(),
-        }
+    // Advance the ledger past ConsensusVersion::V13.
+    let transactions: [Transaction<CurrentNetwork>; 0] = [];
+    while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V13).unwrap() {
+        let next_block = sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
+        vm.add_next_block(&next_block).unwrap();
     }
+
+    // Now we try again after we've advanced to V13. The same execution transaction should now succeed.
+    let execution = vm
+        .execute(
+            &private_key,
+            ("test.aleo", "check_initialized"),
+            Vec::<Value<_>>::new().into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+    let block = sample_next_block(&vm, &private_key, &[execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
 }
 
+/// This test verifies that using the `get` command to read from an external mapping fails on V12
+/// when the mapping value contains an external struct (i.e. a struct that is not local to the program
+/// containing the `get`). The same scenario should succeed on V13, where the underlying bug has
+/// been fixed.
 #[test]
 fn test_external_mapping_external_struct_in_array_runtime_pre_post_v13() {
-    // Run the same scenario under a pre-V13 and post-V13 consensus version.
-    // The behavior difference is expected only at execution time.
-    //
-    // Start at V9 to make sure we're still pre-V13 by the time we execute the last transaction
-    for consensus_version in [ConsensusVersion::V9, ConsensusVersion::V13] {
-        let rng = &mut TestRng::default();
+    let rng = &mut TestRng::default();
+    let private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+    // Start the VM at consensus version V9 to ensure we're not at V13 by the time we get to the
+    // execution transaction that calls the second program.
+    let height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V9).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
 
-        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
-
-        let height = CurrentNetwork::CONSENSUS_HEIGHT(consensus_version).unwrap();
-        let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
-
-        // child.aleo defines a local array of `Point`s and stores it as the value of
-        // a mapping. This program is always valid across versions.
-        let program_child = Program::from_str(
-            r"
+    // child.aleo defines a local array of `Point`s and stores it as the value of
+    // a mapping. This program is always valid across versions.
+    let program_child = Program::from_str(
+        r"
 program child.aleo;
 
 struct Point:
@@ -1223,13 +1204,13 @@ finalize initialize:
 constructor:
     assert.eq edition 0u16;
 ",
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        // test.aleo reads a value from an external mapping whose value type is
-        // an array of external structs. This is the operation under test.
-        let program_test = Program::from_str(
-            r"
+    // test.aleo reads a value from an external mapping whose value type is
+    // an array of external structs. This is the operation under test.
+    let program_test = Program::from_str(
+        r"
 import child.aleo;
 
 program test.aleo;
@@ -1244,86 +1225,69 @@ finalize check_initialized:
 constructor:
     assert.eq edition 0u16;
 ",
-        )
+    )
+    .unwrap();
+
+    // ── Deploy child.aleo (always succeeds)
+    let deployment_child = vm.deploy(&private_key, &program_child, None, 0, None, rng).unwrap();
+
+    let block = sample_next_block(&vm, &private_key, &[deployment_child], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    vm.add_next_block(&block).unwrap();
+
+    // ── Deploy test.aleo and execute child.initialize in the same block.
+    // This ensures the mapping is populated before it is read.
+    let deployment_test = vm.deploy(&private_key, &program_test, None, 0, None, rng).unwrap();
+    let execution = vm
+        .execute(&private_key, ("child.aleo", "initialize"), Vec::<Value<_>>::new().into_iter(), None, 0, None, rng)
         .unwrap();
 
-        // ── Deploy child.aleo (always succeeds)
-        let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &private_key, &[deployment_test, execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 2);
+    vm.add_next_block(&block).unwrap();
 
-        let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
-        assert_eq!(block.transactions().num_accepted(), 1);
-        vm.add_next_block(&block).unwrap();
+    // ── Execute test.check_initialized.
+    //
+    // Pre-V13: rejected due to external struct usage in external mapping access.
+    let execution = vm
+        .execute(
+            &private_key,
+            ("test.aleo", "check_initialized"),
+            Vec::<Value<_>>::new().into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+    let block = sample_next_block(&vm, &private_key, &[execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.transactions().num_rejected(), 1);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
 
-        // ── Deploy test.aleo and execute child.initialize in the same block.
-        // This ensures the mapping is populated before it is read.
-        let deployment_test = vm.deploy(&caller_private_key, &program_test, None, 0, None, rng).unwrap();
-
-        let execution = vm
-            .execute(
-                &caller_private_key,
-                ("child.aleo", "initialize"),
-                Vec::<Value<_>>::new().into_iter(),
-                None,
-                0,
-                None,
-                rng,
-            )
-            .unwrap();
-
-        let block = sample_next_block(&vm, &caller_private_key, &[deployment_test, execution], rng).unwrap();
-        assert_eq!(block.transactions().num_accepted(), 2);
-        vm.add_next_block(&block).unwrap();
-
-        // ── Execute test.check_initialized.
-        //
-        // Pre-V13: rejected due to external struct usage in external mapping access.
-        // V13: accepted.
-        let execution = vm
-            .execute(
-                &caller_private_key,
-                ("test.aleo", "check_initialized"),
-                Vec::<Value<_>>::new().into_iter(),
-                None,
-                0,
-                None,
-                rng,
-            )
-            .unwrap();
-
-        let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
-        vm.add_next_block(&block).unwrap();
-
-        match consensus_version {
-            ConsensusVersion::V9 => {
-                assert_eq!(block.transactions().num_accepted(), 0);
-                assert_eq!(block.transactions().num_rejected(), 1);
-                assert_eq!(block.aborted_transaction_ids().len(), 0);
-
-                // Now we try again after we've advanced to V13. The same transaction should now succeed.
-                let execution = vm
-                    .execute(
-                        &caller_private_key,
-                        ("test.aleo", "check_initialized"),
-                        Vec::<Value<_>>::new().into_iter(),
-                        None,
-                        0,
-                        None,
-                        rng,
-                    )
-                    .unwrap();
-
-                let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
-                vm.add_next_block(&block).unwrap();
-                assert_eq!(block.transactions().num_accepted(), 1);
-                assert_eq!(block.transactions().num_rejected(), 0);
-                assert_eq!(block.aborted_transaction_ids().len(), 0);
-            }
-            ConsensusVersion::V13 => {
-                assert_eq!(block.transactions().num_accepted(), 1);
-                assert_eq!(block.transactions().num_rejected(), 0);
-                assert_eq!(block.aborted_transaction_ids().len(), 0);
-            }
-            _ => unreachable!(),
-        }
+    // Advance the ledger past ConsensusVersion::V13.
+    let transactions: [Transaction<CurrentNetwork>; 0] = [];
+    while vm.block_store().current_block_height() < CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V13).unwrap() {
+        let next_block = sample_next_block(&vm, &private_key, &transactions, rng).unwrap();
+        vm.add_next_block(&next_block).unwrap();
     }
+
+    // Now we try again after we've advanced to V13. The same execution transaction should now succeed.
+    let execution = vm
+        .execute(
+            &private_key,
+            ("test.aleo", "check_initialized"),
+            Vec::<Value<_>>::new().into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+    let block = sample_next_block(&vm, &private_key, &[execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
 }

--- a/synthesizer/src/vm/tests/test_v13.rs
+++ b/synthesizer/src/vm/tests/test_v13.rs
@@ -473,7 +473,7 @@ struct ExecutionTest<'a> {
 /// # Notes
 /// This helper abstracts VM initialization, block creation, deployment, and optional execution logic
 /// to reduce boilerplate in multiple tests and ensure consistent pre-/post-V13 behavior.
-fn deploy_two_programs_and_execute_v132(
+fn deploy_two_programs_and_execute_v13(
     consensus_version: ConsensusVersion,
     program_one: &Program<CurrentNetwork>,
     program_two: &Program<CurrentNetwork>,
@@ -587,7 +587,7 @@ function second:
 
     // Use V11 rather than V12 to make sure we still won't be on V13
     for consensus_version in [ConsensusVersion::V11, ConsensusVersion::V13] {
-        deploy_two_programs_and_execute_v132(consensus_version, &program_one, &program_two, ExecutionTest {
+        deploy_two_programs_and_execute_v13(consensus_version, &program_one, &program_two, ExecutionTest {
             program: "test_two.aleo",
             function: "second",
             inputs: vec![],
@@ -641,7 +641,7 @@ constructor:
 
     // Use V11 rather than V12 to make sure we still won't be on V13
     for consensus_version in [ConsensusVersion::V11, ConsensusVersion::V13] {
-        deploy_two_programs_and_execute_v132(consensus_version, &program_one, &program_two, ExecutionTest {
+        deploy_two_programs_and_execute_v13(consensus_version, &program_one, &program_two, ExecutionTest {
             program: "external_future.aleo",
             function: "main",
             inputs: vec![],
@@ -696,7 +696,7 @@ constructor:
 
     // Use V11 rather than V12 to make sure we still won't be on V13
     for consensus_version in [ConsensusVersion::V11, ConsensusVersion::V13] {
-        deploy_two_programs_and_execute_v132(consensus_version, &program_one, &program_two, ExecutionTest {
+        deploy_two_programs_and_execute_v13(consensus_version, &program_one, &program_two, ExecutionTest {
             program: "external_future.aleo",
             function: "main",
             inputs: vec![],
@@ -749,7 +749,7 @@ constructor:
 
     // Use V11 rather than V12 to make sure we still won't be on V13
     for consensus_version in [ConsensusVersion::V11, ConsensusVersion::V13] {
-        deploy_two_programs_and_execute_v132(consensus_version, &program_one, &program_two, ExecutionTest {
+        deploy_two_programs_and_execute_v13(consensus_version, &program_one, &program_two, ExecutionTest {
             program: "parent.aleo",
             function: "omega_wrapper",
             inputs: vec![],
@@ -802,7 +802,7 @@ constructor:
 
     // Use V11 rather than V12 to make sure we still won't be on V13
     for consensus_version in [ConsensusVersion::V11, ConsensusVersion::V13] {
-        deploy_two_programs_and_execute_v132(consensus_version, &program_one, &program_two, ExecutionTest {
+        deploy_two_programs_and_execute_v13(consensus_version, &program_one, &program_two, ExecutionTest {
             program: "parent.aleo",
             function: "omega_wrapper",
             inputs: vec![Value::from_str(
@@ -855,7 +855,7 @@ constructor:
 
     // Use V11 rather than V12 to make sure we still won't be on V13
     for consensus_version in [ConsensusVersion::V11, ConsensusVersion::V13] {
-        deploy_two_programs_and_execute_v132(consensus_version, &program_one, &program_two, ExecutionTest {
+        deploy_two_programs_and_execute_v13(consensus_version, &program_one, &program_two, ExecutionTest {
             program: "test.aleo",
             function: "main",
             inputs: vec![Value::from_str(
@@ -923,10 +923,367 @@ constructor:
 
     // Use V11 rather than V12 to make sure we still won't be on V13
     for consensus_version in [ConsensusVersion::V11, ConsensusVersion::V13] {
-        deploy_two_programs_and_execute_v132(consensus_version, &program_one, &program_two, ExecutionTest {
+        deploy_two_programs_and_execute_v13(consensus_version, &program_one, &program_two, ExecutionTest {
             program: "parent.aleo",
             function: "relay",
             inputs: vec![Value::from_str("0u64").unwrap()],
         });
+    }
+}
+
+#[test]
+fn test_external_mapping_external_struct_v13() {
+    let rng = &mut TestRng::default();
+
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    let height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V13).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
+
+    // child.aleo defines a local struct `Point` and stores it as the value of
+    // a mapping. This program is always valid across versions.
+    let program_child = Program::from_str(
+        r"
+program child.aleo;
+
+struct Point:
+    x as field;
+    y as field;
+
+mapping point__:
+    key as Point.public;
+    value as Point.public;
+
+function initialize:
+    async initialize into r0;
+    output r0 as child.aleo/initialize.future;
+
+finalize initialize:
+    cast 0field 0field into r0 as Point;
+    set r0 into point__[r0];
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // test.aleo reads a value from an external mapping whose value type is
+    // an external struct. This is the operation under test.
+    let program_test = Program::from_str(
+        r"
+import child.aleo;
+
+program test.aleo;
+
+function check_initialized:
+    async check_initialized into r0;
+    output r0 as test.aleo/check_initialized.future;
+
+finalize check_initialized:
+    cast 0field 0field into r0 as child.aleo/Point;
+    get child.aleo/point__[r0] into r1;
+    get.or_use child.aleo/point__[r0] r0 into r2;
+    contains child.aleo/point__[r0] into r3;
+
+constructor:
+    assert.eq edition 0u16;
+",
+    )
+    .unwrap();
+
+    // ── Deploy child.aleo
+    let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    vm.add_next_block(&block).unwrap();
+
+    // ── Deploy test.aleo and execute child.initialize in the same block.
+    // This ensures the mapping is populated before it is read.
+    let deployment_test = vm.deploy(&caller_private_key, &program_test, None, 0, None, rng).unwrap();
+
+    let execution = vm
+        .execute(
+            &caller_private_key,
+            ("child.aleo", "initialize"),
+            Vec::<Value<_>>::new().into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment_test, execution], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 2);
+    vm.add_next_block(&block).unwrap();
+
+    // ── Execute test.check_initialized.
+    let execution = vm
+        .execute(
+            &caller_private_key,
+            ("test.aleo", "check_initialized"),
+            Vec::<Value<_>>::new().into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+
+    let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+}
+
+#[test]
+fn test_external_mapping_external_struct_runtime_pre_post_v13() {
+    // Run the same scenario under a pre-V13 and post-V13 consensus version.
+    // The behavior difference is expected only at execution time.
+    //
+    // Start at V9 to make sure we're still pre-V13 by the time we execute the last transaction
+    for consensus_version in [ConsensusVersion::V9, ConsensusVersion::V13] {
+        let rng = &mut TestRng::default();
+
+        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+        let height = CurrentNetwork::CONSENSUS_HEIGHT(consensus_version).unwrap();
+        let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
+
+        // child.aleo defines a local struct `Point` and stores it as the value of
+        // a mapping. This program is always valid across versions.
+        let program_child = Program::from_str(
+            r"
+program child.aleo;
+
+struct Point:
+    x as field;
+    y as field;
+
+mapping point__:
+    key as boolean.public;
+    value as Point.public;
+
+function initialize:
+    async initialize into r0;
+    output r0 as child.aleo/initialize.future;
+
+finalize initialize:
+    cast 0field 0field into r0 as Point;
+    set r0 into point__[true];
+
+constructor:
+    assert.eq edition 0u16;
+",
+        )
+        .unwrap();
+
+        // test.aleo reads a value from an external mapping whose value type is
+        // an external struct. This is the operation under test.
+        let program_test = Program::from_str(
+            r"
+import child.aleo;
+
+program test.aleo;
+
+function check_initialized:
+    async check_initialized into r0;
+    output r0 as test.aleo/check_initialized.future;
+
+finalize check_initialized:
+    get child.aleo/point__[true] into r0;
+
+constructor:
+    assert.eq edition 0u16;
+",
+        )
+        .unwrap();
+
+        // ── Deploy child.aleo (always succeeds)
+        let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+
+        let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
+        assert_eq!(block.transactions().num_accepted(), 1);
+        vm.add_next_block(&block).unwrap();
+
+        // ── Deploy test.aleo and execute child.initialize in the same block.
+        // This ensures the mapping is populated before it is read.
+        let deployment_test = vm.deploy(&caller_private_key, &program_test, None, 0, None, rng).unwrap();
+
+        let execution = vm
+            .execute(
+                &caller_private_key,
+                ("child.aleo", "initialize"),
+                Vec::<Value<_>>::new().into_iter(),
+                None,
+                0,
+                None,
+                rng,
+            )
+            .unwrap();
+
+        let block = sample_next_block(&vm, &caller_private_key, &[deployment_test, execution], rng).unwrap();
+        assert_eq!(block.transactions().num_accepted(), 2);
+        vm.add_next_block(&block).unwrap();
+
+        // ── Execute test.check_initialized.
+        //
+        // Pre-V13: rejected due to external struct usage in external mapping access.
+        // V13: accepted.
+        let execution = vm
+            .execute(
+                &caller_private_key,
+                ("test.aleo", "check_initialized"),
+                Vec::<Value<_>>::new().into_iter(),
+                None,
+                0,
+                None,
+                rng,
+            )
+            .unwrap();
+
+        let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+
+        match consensus_version {
+            ConsensusVersion::V9 => {
+                assert_eq!(block.transactions().num_accepted(), 0);
+                assert_eq!(block.transactions().num_rejected(), 1);
+                assert_eq!(block.aborted_transaction_ids().len(), 0);
+            }
+            ConsensusVersion::V13 => {
+                assert_eq!(block.transactions().num_accepted(), 1);
+                assert_eq!(block.transactions().num_rejected(), 0);
+                assert_eq!(block.aborted_transaction_ids().len(), 0);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn test_external_mapping_external_struct_in_array_runtime_pre_post_v13() {
+    // Run the same scenario under a pre-V13 and post-V13 consensus version.
+    // The behavior difference is expected only at execution time.
+    //
+    // Start at V9 to make sure we're still pre-V13 by the time we execute the last transaction
+    for consensus_version in [ConsensusVersion::V9, ConsensusVersion::V13] {
+        let rng = &mut TestRng::default();
+
+        let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+        let height = CurrentNetwork::CONSENSUS_HEIGHT(consensus_version).unwrap();
+        let vm = crate::vm::test_helpers::sample_vm_at_height(height, rng);
+
+        // child.aleo defines a local array of `Point`s and stores it as the value of
+        // a mapping. This program is always valid across versions.
+        let program_child = Program::from_str(
+            r"
+program child.aleo;
+
+struct Point:
+    x as field;
+    y as field;
+
+mapping point__:
+    key as boolean.public;
+    value as [Point; 2u32].public;
+
+function initialize:
+    async initialize into r0;
+    output r0 as child.aleo/initialize.future;
+
+finalize initialize:
+    cast 0field 0field into r0 as Point;
+    cast r0 r0 into r1 as [Point; 2u32];
+    set r1 into point__[true];
+
+constructor:
+    assert.eq edition 0u16;
+",
+        )
+        .unwrap();
+
+        // test.aleo reads a value from an external mapping whose value type is
+        // an array of external structs. This is the operation under test.
+        let program_test = Program::from_str(
+            r"
+import child.aleo;
+
+program test.aleo;
+
+function check_initialized:
+    async check_initialized into r0;
+    output r0 as test.aleo/check_initialized.future;
+
+finalize check_initialized:
+    get child.aleo/point__[true] into r0;
+
+constructor:
+    assert.eq edition 0u16;
+",
+        )
+        .unwrap();
+
+        // ── Deploy child.aleo (always succeeds)
+        let deployment_child = vm.deploy(&caller_private_key, &program_child, None, 0, None, rng).unwrap();
+
+        let block = sample_next_block(&vm, &caller_private_key, &[deployment_child], rng).unwrap();
+        assert_eq!(block.transactions().num_accepted(), 1);
+        vm.add_next_block(&block).unwrap();
+
+        // ── Deploy test.aleo and execute child.initialize in the same block.
+        // This ensures the mapping is populated before it is read.
+        let deployment_test = vm.deploy(&caller_private_key, &program_test, None, 0, None, rng).unwrap();
+
+        let execution = vm
+            .execute(
+                &caller_private_key,
+                ("child.aleo", "initialize"),
+                Vec::<Value<_>>::new().into_iter(),
+                None,
+                0,
+                None,
+                rng,
+            )
+            .unwrap();
+
+        let block = sample_next_block(&vm, &caller_private_key, &[deployment_test, execution], rng).unwrap();
+        assert_eq!(block.transactions().num_accepted(), 2);
+        vm.add_next_block(&block).unwrap();
+
+        // ── Execute test.check_initialized.
+        //
+        // Pre-V13: rejected due to external struct usage in external mapping access.
+        // V13: accepted.
+        let execution = vm
+            .execute(
+                &caller_private_key,
+                ("test.aleo", "check_initialized"),
+                Vec::<Value<_>>::new().into_iter(),
+                None,
+                0,
+                None,
+                rng,
+            )
+            .unwrap();
+
+        let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+
+        match consensus_version {
+            ConsensusVersion::V9 => {
+                assert_eq!(block.transactions().num_accepted(), 0);
+                assert_eq!(block.transactions().num_rejected(), 1);
+                assert_eq!(block.aborted_transaction_ids().len(), 0);
+            }
+            ConsensusVersion::V13 => {
+                assert_eq!(block.transactions().num_accepted(), 1);
+                assert_eq!(block.transactions().num_rejected(), 0);
+                assert_eq!(block.aborted_transaction_ids().len(), 0);
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/synthesizer/src/vm/tests/test_v13.rs
+++ b/synthesizer/src/vm/tests/test_v13.rs
@@ -1291,6 +1291,7 @@ constructor:
             .unwrap();
 
         let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+        vm.add_next_block(&block).unwrap();
 
         match consensus_version {
             ConsensusVersion::V9 => {

--- a/synthesizer/src/vm/tests/test_v13.rs
+++ b/synthesizer/src/vm/tests/test_v13.rs
@@ -1146,11 +1146,31 @@ constructor:
             .unwrap();
 
         let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+        vm.add_next_block(&block).unwrap();
 
         match consensus_version {
             ConsensusVersion::V9 => {
                 assert_eq!(block.transactions().num_accepted(), 0);
                 assert_eq!(block.transactions().num_rejected(), 1);
+                assert_eq!(block.aborted_transaction_ids().len(), 0);
+
+                // Now we try again after we've advanced to V13. The same transaction should now succeed.
+                let execution = vm
+                    .execute(
+                        &caller_private_key,
+                        ("test.aleo", "check_initialized"),
+                        Vec::<Value<_>>::new().into_iter(),
+                        None,
+                        0,
+                        None,
+                        rng,
+                    )
+                    .unwrap();
+
+                let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+                vm.add_next_block(&block).unwrap();
+                assert_eq!(block.transactions().num_accepted(), 1);
+                assert_eq!(block.transactions().num_rejected(), 0);
                 assert_eq!(block.aborted_transaction_ids().len(), 0);
             }
             ConsensusVersion::V13 => {
@@ -1276,6 +1296,25 @@ constructor:
             ConsensusVersion::V9 => {
                 assert_eq!(block.transactions().num_accepted(), 0);
                 assert_eq!(block.transactions().num_rejected(), 1);
+                assert_eq!(block.aborted_transaction_ids().len(), 0);
+
+                // Now we try again after we've advanced to V13. The same transaction should now succeed.
+                let execution = vm
+                    .execute(
+                        &caller_private_key,
+                        ("test.aleo", "check_initialized"),
+                        Vec::<Value<_>>::new().into_iter(),
+                        None,
+                        0,
+                        None,
+                        rng,
+                    )
+                    .unwrap();
+
+                let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+                vm.add_next_block(&block).unwrap();
+                assert_eq!(block.transactions().num_accepted(), 1);
+                assert_eq!(block.transactions().num_rejected(), 0);
                 assert_eq!(block.aborted_transaction_ids().len(), 0);
             }
             ConsensusVersion::V13 => {


### PR DESCRIPTION
### Summary

This PR addresses qualification handling for external structs in mapping operations and fixes a consensus-version–specific execution issue affecting external mappings in pre-V13.

### Changes

1. **Qualify external struct operands in mapping instructions**

   When external structs are used as operands to mapping instructions, operand types are now properly **qualified** if the mapping itself is external. This ensures that:
   - Mapping key and value types correctly reflect external struct usage.
   - Any structs nested within mapping key or value types are also qualified as external.
   - The type returned from the `get` instruction is qualified when required.

2. **Restore pre-V123behavior for external mapping `get`**

   In consensus version pre-V13 a `get` from an external mapping is valid as long as the key does not contain an external struct, even if the value type does. However, such programs fail to execute on v4.4.0.

   While this issue is fixed by (1), the fix must not apply to pre-V13. Therefore:
   - Any types that were newly qualified for external mappings are **unqualified** when targeting consensus versions prior to V13.
   - This restores correct pre-V13 semantics while preserving the fix for V13.

### Testing

- Added a comprehensive test covering various mapping operations involving external structs.
- Added two targeted tests to ensure that type *unqualification* in pre-V12 is applied correctly.

### A Quick Note

Across PRs #3107, #3128, and #3138, the recurring pattern is that a primary program performs an external call or instruction (e.g. get) that returns an external type (external record, struct, future, etc.), but type resolution is attempted as if the type were local. Under V12, this causes resolution to fail because the returned type is not qualified from the perspective of the primary program.

In V13, we fix this by qualifying externally-owned types at the boundary, using the program that owns the type, so resolution is explicit and unambiguous. This allows otherwise valid programs to pass.

We cannot safely apply the same fix in V12, because changing how external return types are resolved would alter which programs are accepted, creating forking risk. Therefore, these corrections are intentionally scoped to V13 consensus via static checks or execution-time checks.