### PR TITLE
Report mismatching finalized transactions on failure to add block

### DIFF
--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -154,8 +154,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             bail!("The ratifications after speculation do not match the ratifications in the block");
         }
         // Ensure the transactions after speculation match.
-        if transactions != &confirmed_transactions.into_iter().collect() {
-            bail!("The transactions after speculation do not match the transactions in the block");
+        let confirmed_transactions = confirmed_transactions.into_iter().collect();
+        if transactions != &confirmed_transactions {
+            bail!(
+                "The transactions after speculation do not match the transactions in the block: {confirmed_transactions:?}"
+            );
         }
         // Ensure there are no aborted transaction IDs from this speculation.
         // Note: There should be no aborted transactions, because we are checking a block,

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -156,8 +156,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Ensure the transactions after speculation match.
         let confirmed_transactions = confirmed_transactions.into_iter().collect();
         if transactions != &confirmed_transactions {
+            let confirmed_transaction_ids = confirmed_transactions.transaction_ids().collect::<Vec<_>>();
             bail!(
-                "The transactions after speculation do not match the transactions in the block: {confirmed_transactions:?}"
+                "The transactions after speculation do not match the transactions in the block. IDs: {confirmed_transaction_ids:?} - Transactions:{transactions:?}"
             );
         }
         // Ensure there are no aborted transaction IDs from this speculation.


### PR DESCRIPTION
## Motivation

Currently when using CDN sync, when adding a block fails due to mismatching finalization, we get a very opaque error message. To help debugging during testing, this PR proposes to dump the finalized ids and transactions - so they can be compared to the finalized block on the functional production network.

The debug message could be huge, but this is also expected to happen very infrequently - only on faulty nodes.
