### PR TITLE
[Perf] Optimize BigInteger comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,6 +3921,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "colored 3.1.1",
+ "criterion",
  "num-bigint",
  "num_cpus",
  "rand 0.8.5",

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -23,6 +23,11 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "Apache-2.0"
 edition = "2024"
 
+[[bench]]
+name = "bigint"
+path = "benches/bigint.rs"
+harness = false
+
 [dependencies.snarkvm-utilities-derives]
 workspace = true
 optional = true
@@ -77,6 +82,9 @@ default-features = false
 [dependencies.zeroize]
 workspace = true
 features = [ "derive" ]
+
+[dev-dependencies.criterion]
+workspace = true
 
 [dev-dependencies.tracing-test]
 workspace = true

--- a/utilities/benches/bigint.rs
+++ b/utilities/benches/bigint.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Silences the false positives caused by black_box.
+#![allow(clippy::unit_arg)]
+
+use snarkvm_utilities::{BigInteger256, BigInteger384, TestRng};
+
+use criterion::*;
+use rand::Rng;
+use std::hint::black_box;
+
+fn bigint_256(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    let n = 900_000;
+    let values: Vec<BigInteger256> = (0..n).map(|_| rng.r#gen()).collect();
+
+    c.bench_function("bigint_256_cmp", |b| {
+        b.iter_batched(
+            || values.clone(),
+            |mut data_to_sort| {
+                data_to_sort.sort_unstable();
+                black_box(data_to_sort)
+            },
+            criterion::BatchSize::LargeInput,
+        )
+    });
+}
+
+fn bigint_384(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    let n = 500_000;
+    let values: Vec<BigInteger384> = (0..n).map(|_| rng.r#gen()).collect();
+
+    c.bench_function("bigint_384_cmp", |b| {
+        b.iter_batched(
+            || values.clone(),
+            |mut data_to_sort| {
+                data_to_sort.sort_unstable();
+                black_box(data_to_sort)
+            },
+            criterion::BatchSize::LargeInput,
+        )
+    });
+}
+
+criterion_group! {
+    name = bigint;
+    config = Criterion::default();
+    targets = bigint_256, bigint_384
+}
+
+criterion_main!(bigint);

--- a/utilities/src/biginteger/bigint_256.rs
+++ b/utilities/src/biginteger/bigint_256.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::{Read, Result as IoResult, Write};
+use std::{
+    cmp,
+    io::{Read, Result as IoResult, Write},
+};
 
 use crate::{
     FromBits,
@@ -311,16 +314,15 @@ impl Display for BigInteger256 {
 
 impl Ord for BigInteger256 {
     #[inline]
-    #[allow(clippy::comparison_chain)]
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         for (a, b) in self.0.iter().rev().zip(other.0.iter().rev()) {
-            if a < b {
-                return std::cmp::Ordering::Less;
-            } else if a > b {
-                return std::cmp::Ordering::Greater;
+            match a.cmp(b) {
+                cmp::Ordering::Less => return cmp::Ordering::Less,
+                cmp::Ordering::Greater => return cmp::Ordering::Greater,
+                _ => continue,
             }
         }
-        std::cmp::Ordering::Equal
+        cmp::Ordering::Equal
     }
 }
 

--- a/utilities/src/biginteger/bigint_384.rs
+++ b/utilities/src/biginteger/bigint_384.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use std::{
+    cmp,
     fmt::{Debug, Display},
     io::{Read, Result as IoResult, Write},
 };
@@ -309,16 +310,15 @@ impl Display for BigInteger384 {
 }
 impl Ord for BigInteger384 {
     #[inline]
-    #[allow(clippy::comparison_chain)]
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         for (a, b) in self.0.iter().rev().zip(other.0.iter().rev()) {
-            if a < b {
-                return std::cmp::Ordering::Less;
-            } else if a > b {
-                return std::cmp::Ordering::Greater;
+            match a.cmp(b) {
+                cmp::Ordering::Less => return cmp::Ordering::Less,
+                cmp::Ordering::Greater => return cmp::Ordering::Greater,
+                _ => continue,
             }
         }
-        std::cmp::Ordering::Equal
+        cmp::Ordering::Equal
     }
 }
 impl PartialOrd for BigInteger384 {


### PR DESCRIPTION
I've stumbled upon this one while profiling CDN-powered block synchronization. I found it very weird that `BigInteger256` comparisons would take up ~3% of the CPU time, and I realized that the current associated implementation of `Ord::cmp`, while seemingly fine-tuned, is optimized wrongly - it involves double the necessary comparisons, causing some nasty branching.

With this small change, the improvement is clear:
```
bigint_256_cmp          time:   [15.626 ms 15.637 ms 15.649 ms]
                        change: [−66.582% −66.523% −66.469%] (p = 0.00 < 0.05)
                        Performance has improved.

bigint_384_cmp          time:   [9.6980 ms 9.7015 ms 9.7050 ms]
                        change: [−64.058% −64.042% −64.027%] (p = 0.00 < 0.05)
                        Performance has improved.
```
and can barely see the associated method in the CPU profile afterwards.

Note: despite the even simpler implementation:
```
self.0.iter().rev().cmp(other.0.iter().rev())
```
resulting in the same assembly in isolation, the more verbose impl results in slightly better benchmark gains (probably inlining/caching intricacies), so I decided to stick to that one. I also kept the benchmark I was using.