### PR TITLE
fix: remove source error interpolation from `#[error]` format strings

### DIFF
--- a/algorithms/src/errors.rs
+++ b/algorithms/src/errors.rs
@@ -18,10 +18,10 @@ use snarkvm_fields::ConstraintFieldError;
 
 #[derive(Debug, Error)]
 pub enum SNARKError {
-    #[error("{}", _0)]
+    #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
 
-    #[error("{}", _0)]
+    #[error("constraint field error")]
     ConstraintFieldError(#[from] ConstraintFieldError),
 
     #[error("{}: {}", _0, _1)]
@@ -33,7 +33,7 @@ pub enum SNARKError {
     #[error("{}", _0)]
     Message(String),
 
-    #[error("{}", _0)]
+    #[error("synthesis error")]
     SynthesisError(#[from] SynthesisError),
 
     #[error("Batch size was zero; must be at least 1")]

--- a/algorithms/src/polycommit/error.rs
+++ b/algorithms/src/polycommit/error.rs
@@ -16,7 +16,7 @@
 /// The error type for `PolynomialCommitment`.
 #[derive(Debug, Error)]
 pub enum PCError {
-    #[error("{0}")]
+    #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
 
     #[error("QuerySet` refers to polynomial \"{label}\", but it was not provided.")]

--- a/algorithms/src/r1cs/errors.rs
+++ b/algorithms/src/r1cs/errors.rs
@@ -40,18 +40,12 @@ pub enum SynthesisError {
     #[error("Encountered an identity element in the CRS")]
     UnexpectedIdentity,
     /// During proof generation, we encountered an I/O error with the CRS
-    #[error("Encountered an I/O error")]
-    IoError(std::io::Error),
+    #[error("I/O error")]
+    IoError(#[from] std::io::Error),
     /// During verification, our verifying key was malformed.
     #[error("Malformed verifying key, public input count was {} but expected {}", _0, _1)]
     MalformedVerifyingKey(usize, usize),
     /// During CRS generation, we observed an unconstrained auxiliary variable
     #[error("Auxiliary variable was unconstrained")]
     UnconstrainedVariable,
-}
-
-impl From<std::io::Error> for SynthesisError {
-    fn from(e: std::io::Error) -> SynthesisError {
-        SynthesisError::IoError(e)
-    }
 }

--- a/algorithms/src/r1cs/errors.rs
+++ b/algorithms/src/r1cs/errors.rs
@@ -19,7 +19,7 @@ pub type SynthesisResult<T> = Result<T, SynthesisError>;
 /// such as CRS generation, proving or verification.
 #[derive(Debug, Error)]
 pub enum SynthesisError {
-    #[error("{}", _0)]
+    #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
     /// During synthesis, we lacked knowledge of a variable assignment.
     #[error("An assignment for a variable could not be computed")]

--- a/algorithms/src/snark/varuna/ahp/errors.rs
+++ b/algorithms/src/snark/varuna/ahp/errors.rs
@@ -16,7 +16,7 @@
 /// Describes the failure modes of the AHP scheme.
 #[derive(Debug, Error)]
 pub enum AHPError {
-    #[error("{}", _0)]
+    #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
 
     #[error("Batch size was zero; must be at least 1.")]

--- a/algorithms/src/snark/varuna/ahp/errors.rs
+++ b/algorithms/src/snark/varuna/ahp/errors.rs
@@ -22,8 +22,8 @@ pub enum AHPError {
     #[error("Batch size was zero; must be at least 1.")]
     BatchSizeIsZero,
 
-    #[error("An error occurred during constraint generation.")]
-    ConstraintSystemError(crate::r1cs::errors::SynthesisError),
+    #[error("constraint generation error")]
+    ConstraintSystemError(#[from] crate::r1cs::errors::SynthesisError),
 
     #[error("The instance generated during proving does not match that in the index.")]
     InstanceDoesNotMatchIndex,
@@ -39,10 +39,4 @@ pub enum AHPError {
 
     #[error("During synthesis, our polynomials ended up being too high of degree.")]
     PolyTooLarge,
-}
-
-impl From<crate::r1cs::errors::SynthesisError> for AHPError {
-    fn from(other: crate::r1cs::errors::SynthesisError) -> Self {
-        AHPError::ConstraintSystemError(other)
-    }
 }

--- a/curves/src/errors.rs
+++ b/curves/src/errors.rs
@@ -18,8 +18,8 @@ pub enum GroupError {
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 
-    #[error("{}", _0)]
-    FieldError(snarkvm_fields::FieldError),
+    #[error("field error")]
+    FieldError(#[from] snarkvm_fields::FieldError),
 
     #[error("Invalid group element")]
     InvalidGroupElement,
@@ -35,12 +35,6 @@ pub enum GroupError {
 
     #[error("Attempting to parse a non-digit character into a group element")]
     ParsingNonDigitCharacter,
-}
-
-impl From<snarkvm_fields::FieldError> for GroupError {
-    fn from(error: snarkvm_fields::FieldError) -> Self {
-        GroupError::FieldError(error)
-    }
 }
 
 impl From<std::io::Error> for GroupError {

--- a/fields/src/errors/constraint_field.rs
+++ b/fields/src/errors/constraint_field.rs
@@ -15,7 +15,7 @@
 
 #[derive(Debug, Error)]
 pub enum ConstraintFieldError {
-    #[error("{}", _0)]
+    #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
 
     #[error("{}: {}", _0, _1)]

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -54,14 +54,20 @@ pub enum CheckBlockError<N: Network> {
     #[error("Block has invalid hash")]
     InvalidHash,
     /// An error related to the given prefix of pending blocks.
-    #[error("The prefix as an error at index {index} - {error:?}")]
+    #[error("The prefix has an error at index {index}")]
     InvalidPrefix { index: usize, error: Box<CheckBlockError<N>> },
     #[error("The block contains solution '{solution_id}', but it already exists in the ledger")]
     SolutionAlreadyExists { solution_id: SolutionID<N> },
-    #[error("Failed to speculate over unconfirmed transactions - {inner}")]
-    SpeculationFailed { inner: anyhow::Error },
-    #[error("Failed to verify block - {inner}")]
-    VerificationFailed { inner: anyhow::Error },
+    #[error("Failed to speculate over unconfirmed transactions")]
+    SpeculationFailed {
+        #[source]
+        inner: anyhow::Error,
+    },
+    #[error("Failed to verify block")]
+    VerificationFailed {
+        #[source]
+        inner: anyhow::Error,
+    },
     #[error("Prover '{prover_address}' has reached their solution limit for the current epoch")]
     SolutionLimitReached { prover_address: Address<N> },
     #[error("The previous block should contain solution '{solution_id}', but it does not exist in the ledger")]

--- a/ledger/src/error.rs
+++ b/ledger/src/error.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum CreateTransferError {
     /// VM execution failed.
-    #[error("VM execution failed: {0}")]
+    #[error("VM execution failed")]
     VmExec(#[from] VmExecError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -34,7 +34,7 @@ pub enum CreateTransferError {
 #[derive(Debug, Error)]
 pub enum CreateDeployError {
     /// VM deployment failed.
-    #[error("VM deployment failed: {0}")]
+    #[error("VM deployment failed")]
     VmDeploy(#[from] VmDeployError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]

--- a/synthesizer/error/src/process.rs
+++ b/synthesizer/error/src/process.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum ProcessAuthError {
     /// Stack authorization failed.
-    #[error("Stack authorization failed: {0}")]
+    #[error("Stack authorization failed")]
     StackAuth(#[from] StackAuthError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -35,7 +35,7 @@ pub enum ProcessAuthError {
 #[derive(Debug, Error)]
 pub enum ProcessEvalError {
     /// Stack evaluation failed.
-    #[error("Stack evaluation failed: {0}")]
+    #[error("Stack evaluation failed")]
     StackEval(#[from] StackEvalError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -46,7 +46,7 @@ pub enum ProcessEvalError {
 #[derive(Debug, Error)]
 pub enum ProcessExecError {
     /// Stack execution failed.
-    #[error("Stack execution failed: {0}")]
+    #[error("Stack execution failed")]
     StackExec(#[from] StackExecError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -57,7 +57,7 @@ pub enum ProcessExecError {
 #[derive(Debug, Error)]
 pub enum ProcessDeployError {
     /// Stack execution failed during synthesis.
-    #[error("Stack synthesis failed: {0}")]
+    #[error("Stack synthesis failed")]
     StackExec(#[from] StackExecError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -68,7 +68,7 @@ pub enum ProcessDeployError {
 #[derive(Debug, Error)]
 pub enum CallEvalError {
     /// An error occurred during substack evaluation.
-    #[error("Substack evaluation failed: {0}")]
+    #[error("Substack evaluation failed")]
     StackEval(#[from] StackEvalError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -79,10 +79,10 @@ pub enum CallEvalError {
 #[derive(Debug, Error)]
 pub enum CallExecError {
     /// An error occurred during substack execution.
-    #[error("Substack execution failed: {0}")]
+    #[error("Substack execution failed")]
     StackExec(#[from] StackExecError),
     /// An error occurred during substack evaluation.
-    #[error("Substack evaluation failed: {0}")]
+    #[error("Substack evaluation failed")]
     StackEval(#[from] StackEvalError),
     /// A circuit constraint was not satisfied.
     #[error(transparent)]
@@ -96,10 +96,10 @@ pub enum CallExecError {
 #[derive(Debug, Error)]
 pub enum StackAuthError {
     /// Stack execution failed.
-    #[error("Stack execution failed: {0}")]
+    #[error("Stack execution failed")]
     Exec(#[from] StackExecError),
     /// Stack evaluation failed.
-    #[error("Stack evaluation failed: {0}")]
+    #[error("Stack evaluation failed")]
     Eval(#[from] StackEvalError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -133,13 +133,14 @@ pub enum StackEvalError {
 
 /// An instruction error occurred at a particular index.
 #[derive(Debug, Error)]
-#[error("Instruction ({instruction}) at index {index} failed: {error}")]
+#[error("Instruction ({instruction}) at index {index} failed")]
 pub struct IndexedInstructionError<E> {
     /// The index of the failing instruction.
     pub index: usize,
     /// The failing instruction formatted.
     pub instruction: String,
     /// The instruction error.
+    #[source]
     pub error: E,
 }
 
@@ -148,10 +149,10 @@ pub struct IndexedInstructionError<E> {
 #[derive(Debug, Error)]
 pub enum InstructionError {
     /// Failed to evaluate an instruction.
-    #[error("Failed to evaluate: {0}")]
+    #[error("Failed to evaluate")]
     Eval(#[from] InstructionEvalError),
     /// Failed to execute an instruction.
-    #[error("Failed to execute: {0}")]
+    #[error("Failed to execute")]
     Exec(#[from] InstructionExecError),
 }
 
@@ -162,7 +163,7 @@ pub enum InstructionEvalError {
     #[error(transparent)]
     Eval(#[from] EvalError),
     /// An error occurred during a `Call` instruction.
-    #[error("Call failed: {0}")]
+    #[error("Call failed")]
     Call(#[from] Box<CallEvalError>),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -173,7 +174,7 @@ pub enum InstructionEvalError {
 #[derive(Debug, Error)]
 pub enum InstructionExecError {
     /// An error occurred during a `Call` instruction.
-    #[error("Call failed: {0}")]
+    #[error("Call failed")]
     Call(#[from] Box<CallExecError>),
     /// An instruction execution error.
     #[error(transparent)]

--- a/synthesizer/error/src/vm.rs
+++ b/synthesizer/error/src/vm.rs
@@ -23,10 +23,10 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum VmExecError {
     /// Authorization failed.
-    #[error("Authorization failed: {0}")]
+    #[error("Authorization failed")]
     Auth(#[from] VmAuthError),
     /// Process execution failed (contains instruction index).
-    #[error("Process execution failed: {0}")]
+    #[error("Process execution failed")]
     Process(#[from] ProcessExecError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -37,7 +37,7 @@ pub enum VmExecError {
 #[derive(Debug, Error)]
 pub enum VmAuthError {
     /// Process authorization failed.
-    #[error("Process authorization failed: {0}")]
+    #[error("Process authorization failed")]
     Process(#[from] ProcessAuthError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]
@@ -48,10 +48,10 @@ pub enum VmAuthError {
 #[derive(Debug, Error)]
 pub enum VmDeployError {
     /// Process deployment failed.
-    #[error("Process deployment failed: {0}")]
+    #[error("Process deployment failed")]
     Process(#[from] ProcessDeployError),
     /// Fee execution failed.
-    #[error("Fee execution failed: {0}")]
+    #[error("Fee execution failed")]
     FeeExec(#[from] VmExecError),
     /// A temporary variant for type-erased anyhow errors.
     #[error(transparent)]

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -132,9 +132,9 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
                 output.insert(
                     serde_yaml::Value::String("errors".to_string()),
                     serde_yaml::Value::Sequence(vec![serde_yaml::Value::String(format!(
-                        "Failed to run `VM::deploy for program {}: {}",
+                        "Failed to run `VM::deploy for program {}: {:#}",
                         program.id(),
-                        error
+                        anyhow::Error::from(error)
                     ))]),
                 );
                 output
@@ -231,7 +231,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
                     Err(err) => {
                         result.insert(
                             serde_yaml::Value::String("execute".to_string()),
-                            serde_yaml::Value::String(err.to_string()),
+                            serde_yaml::Value::String(format!("{:#}", anyhow::Error::from(err))),
                         );
                         return (serde_yaml::Value::Mapping(result), serde_yaml::Value::Mapping(Default::default()));
                     }

--- a/utilities/src/serialize/error.rs
+++ b/utilities/src/serialize/error.rs
@@ -15,7 +15,7 @@
 
 #[derive(Error, Debug)]
 pub enum SerializationError {
-    #[error("{}", _0)]
+    #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
     /// During serialization with bincode, we encountered a serialization issue
     #[error(transparent)]
@@ -27,7 +27,7 @@ pub enum SerializationError {
     #[error("the input buffer contained invalid data")]
     InvalidData,
     /// During serialization, we countered an I/O error.
-    #[error("IoError: {0}")]
+    #[error("I/O error")]
     IoError(#[from] std::io::Error),
     /// During serialization, we didn't have enough space to write extra info.
     #[error("the last byte does not have enough space to encode the extra info bits")]


### PR DESCRIPTION
## Context

@kaimast mentioned he's looking into improving `Display` consistency for errors across snarkvm, and it made me realise the error formatting of some of the errors I introduced (in #3081, #3082) is incorrect.

Several of the `thiserror` error types I added interpolate `#[from]` fields in their `#[error("...")]` format strings (e.g. `#[error("VM execution failed: {0}")]` where `{0}` is `#[from] SomeError`). Because `#[from]` implies `#[source]`, the inner error's message appears in both `Display` output and the `source()` chain - causing duplication when consumers walk the chain. The `std` `Error` docs [explicitly advise against this](https://doc.rust-lang.org/std/error/trait.Error.html#error-source):

> expose the inner error via `source()` or render it in `Display`, but not both.

## Further Context

This is an issue because when an error is surfaced by an app downstream, they often need to have control over how to format the error. E.g. in some cases they may only want to surface the top-level error, in others they may want to present the full causal chain.

`anyhow` offers the ability to easily format either style:

- `{}` (`Display`) - prints only the outermost error message
- `{:#}` (alternate `Display`) - prints the full chain, e.g. "Failed to read instrs from ./path: No such file or directory (os error 2)"
- `{:?}` (`Debug`) - prints the full chain plus backtrace

which is another part of what makes it better-suited for app-level error handling.

## The Fix

This PR removes the interpolation from the format string so each layer only describes its own context. The inner error remains accessible via `source()`.