### PR TITLE
Backport ledger current_block deadlock fix in subdag validation to mainnet

### DIFF
--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -251,10 +251,14 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         {
             true => (None, vec![], Field::<N>::zero(), 0u128),
             false => {
-                // Retrieve the latest epoch hash.
-                let latest_epoch_hash = self.latest_epoch_hash()?;
+                // Retrieve the latest epoch hash directly from the previous block.
+                // (so we avoid read-locking current_block again)
+                let latest_epoch_hash = match self.current_epoch_hash.read().as_ref() {
+                    Some(epoch_hash) => *epoch_hash,
+                    None => self.get_epoch_hash(previous_block.height())?,
+                };
                 // Retrieve the latest proof target.
-                let latest_proof_target = self.latest_proof_target();
+                let latest_proof_target = previous_block.proof_target();
                 // Separate the candidate solutions into valid and aborted solutions.
                 let mut accepted_solutions: IndexMap<Address<N>, u64> = IndexMap::new();
                 let (valid_candidate_solutions, aborted_candidate_solutions) =

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -148,7 +148,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.check_block_subdag_quorum(block)?;
 
         // Determine if the block subdag is correctly constructed and is not a combination of multiple subdags.
-        self.check_block_subdag_atomicity(block)?;
+        self.check_block_subdag_atomicity(block, &latest_block)?;
 
         // Ensure that all leaves of the subdag point to valid batches in other subdags/blocks.
         self.check_block_subdag_leaves(block, prefix)?;
@@ -254,6 +254,12 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 .ok_or(anyhow!("Failed to fetch committee lookback for round {penultimate_round}"))?
         };
 
+        // Get the latest epoch hash.
+        let latest_epoch_hash = match self.current_epoch_hash.read().as_ref() {
+            Some(epoch_hash) => *epoch_hash,
+            None => self.get_epoch_hash(latest_block.height())?,
+        };
+
         // Ensure the block is correct.
         let (expected_existing_solution_ids, expected_existing_transaction_ids) = block
             .verify(
@@ -262,7 +268,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
                 &previous_committee_lookback,
                 &committee_lookback,
                 self.puzzle(),
-                self.latest_epoch_hash()?,
+                latest_epoch_hash,
                 OffsetDateTime::now_utc().unix_timestamp(),
                 ratified_finalize_operations,
             )
@@ -408,7 +414,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Checks that the block subdag can not be split into multiple valid subdags.
     ///
     /// Called by [`Self::check_block_subdag`]
-    fn check_block_subdag_atomicity(&self, block: &Block<N>) -> Result<()> {
+    fn check_block_subdag_atomicity(&self, block: &Block<N>, latest_block: &Block<N>) -> Result<()> {
+        let latest_round = latest_block.round();
+
         // Returns `true` if there is a path from the previous certificate to the current certificate.
         fn is_linked<N: Network>(
             subdag: &Subdag<N>,
@@ -437,8 +445,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         };
 
         // Iterate over the rounds to find possible leader certificates.
-        for round in (self.latest_round().saturating_add(2)..=subdag.anchor_round().saturating_sub(2)).rev().step_by(2)
-        {
+        for round in (latest_round.saturating_add(2)..=subdag.anchor_round().saturating_sub(2)).rev().step_by(2) {
             // Retrieve the previous committee lookback.
             let previous_committee_lookback = self
                 .get_committee_lookback_for_round(round)?


### PR DESCRIPTION
## Motivation

Follow up the already-merged backport in `ProvableHQ/snarkVM:mainnet` with the second missing `current_block` deadlock fix for the `v4.5.0` release line.

`mainnet` now contains the first backport via merge commit `eb6d42f2b`, but live validators still hung because `check_block_subdag_inner()` can still re-enter `current_block` while holding a read guard:

- `check_block_subdag_inner()` takes `self.current_block.read()`
- it then calls `check_block_subdag_atomicity()`
- the release-line implementation of `check_block_subdag_atomicity()` calls `self.latest_round()`
- `latest_round()` tries to read `current_block` again

When `advance_to_next_block()` queues for the write lock in between those two reads, `parking_lot` blocks the second read behind the queued writer, while the writer waits for the first read guard to drain. That deadlocks the validator.

This was confirmed on a live hung validator on **March 12, 2026** with `gdb`:

- writer side blocked in `advance_to_next_block()`
- checker side blocked in `check_block_subdag_inner()`
- many other threads blocked behind the same `current_block` lock via `latest_block_height()`

This PR backports upstream commit `bf31d55fd08910c0f6ecf317138022c385754b9c` (`fix(ledger): directly fetch latest round and epoch hash`) to `mainnet`.

## Test Plan

Verified on the backport branch with:

```bash
cargo test -p snarkvm-ledger --lib \
  is_solution_limit_reached::tests::test_solution_limit_helper_avoids_current_block_reentry_with_pending_writer \
  -- --exact --nocapture --test-threads=1

cargo test -p snarkvm-ledger --lib \
  tests::test_forged_block_subdags \
  -- --exact --nocapture --test-threads=1

cargo test -p snarkvm-ledger --lib \
  tests::test_subdag_with_gc_length \
  -- --exact --nocapture --test-threads=1

cargo test -p snarkvm-ledger --lib \
  tests::test_subdag_with_long_branch \
  -- --exact --nocapture --test-threads=1
```

All four tests passed locally.

Notes on coverage:

- `test_solution_limit_helper_avoids_current_block_reentry_with_pending_writer` is the existing dedicated regression for the first `current_block` re-entry deadlock already backported to `mainnet`.
- `test_forged_block_subdags`, `test_subdag_with_gc_length`, and `test_subdag_with_long_branch` exercise the subdag validation code path touched by this PR.
- This follow-up backport does **not** add a dedicated lock-interleaving regression for the `check_block_subdag_inner() -> check_block_subdag_atomicity() -> latest_round()` deadlock path. Reproducing that exact interleaving in a focused test is more involved because it requires a valid quorum/subdag setup plus a queued writer on `current_block`.

Given that this PR is a direct backport of upstream commit `bf31d55fd08910c0f6ecf317138022c385754b9c`, I kept the release-line patch minimal and relied on:

- live `gdb` confirmation of the deadlock on an unmodified validator
- passing targeted ledger tests for the touched subdag path
- the fact that this is already the upstream fix on `staging`

## Documentation

No documentation changes.

## Backwards compatibility

This is a bug fix only. It does not change consensus rules, block validity, wire format, or storage format, and it does not require a new `ConsensusVersion`.
