### PR TITLE
[Fix] Restrict closure output.

### DIFF
--- a/console/program/src/data_types/plaintext_type/mod.rs
+++ b/console/program/src/data_types/plaintext_type/mod.rs
@@ -57,6 +57,7 @@ impl<N: Network> PlaintextType<N> {
             PlaintextType::Struct(name) => PlaintextType::ExternalStruct(Locator::new(id, name)),
             PlaintextType::Array(array_type) => {
                 let element_type = array_type.next_element_type().clone().qualify(id);
+                // Safe: the length is preserved from the original array type.
                 PlaintextType::Array(ArrayType::new(element_type, vec![*array_type.length()]).unwrap())
             }
         }

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -102,6 +102,25 @@ impl<N: Network> Stack<N> {
         // Ensure the deployment is ordered.
         deployment.check_is_ordered()?;
 
+        // At V14+, closures must not output ExternalRecord or DynamicRecord.
+        // Pre-V14 programs may have such closures; restricting them unconditionally would break
+        // backward compatibility. The record-existence check (`ensure_records_exist`) relies on
+        // this invariant holding for all programs deployed at V14+.
+        if _consensus_version >= ConsensusVersion::V14 {
+            for closure in deployment.program().closures().values() {
+                for output in closure.outputs() {
+                    ensure!(
+                        !matches!(
+                            output.register_type(),
+                            RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
+                        ),
+                        "At V14+, closure '{}' output cannot be ExternalRecord or DynamicRecord",
+                        closure.name()
+                    );
+                }
+            }
+        }
+
         // Ensure the program in the stack and deployment matches.
         ensure!(&self.program == deployment.program(), "The stack program does not match the deployment program");
         // If the deployment contains a checksum, ensure it matches the one computed by the stack.

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -102,25 +102,6 @@ impl<N: Network> Stack<N> {
         // Ensure the deployment is ordered.
         deployment.check_is_ordered()?;
 
-        // At V14+, closures must not output ExternalRecord or DynamicRecord.
-        // Pre-V14 programs may have such closures; restricting them unconditionally would break
-        // backward compatibility. The record-existence check (`ensure_records_exist`) relies on
-        // this invariant holding for all programs deployed at V14+.
-        if _consensus_version >= ConsensusVersion::V14 {
-            for closure in deployment.program().closures().values() {
-                for output in closure.outputs() {
-                    ensure!(
-                        !matches!(
-                            output.register_type(),
-                            RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
-                        ),
-                        "At V14+, closure '{}' output cannot be ExternalRecord or DynamicRecord",
-                        closure.name()
-                    );
-                }
-            }
-        }
-
         // Ensure the program in the stack and deployment matches.
         ensure!(&self.program == deployment.program(), "The stack program does not match the deployment program");
         // If the deployment contains a checksum, ensure it matches the one computed by the stack.

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -45,10 +45,10 @@ impl<N: Network> RegisterTypes<N> {
         // Step 3. Check the outputs are well-formed.
         for output in closure.outputs() {
             // Ensure the closure output register is not a static record.
-            // Dynamic records are allowed as closure outputs.
+            // ExternalRecord and DynamicRecord are checked at V14+ deployment time (see `verify_deployment`).
             ensure!(
                 !matches!(output.register_type(), RegisterType::Record(..)),
-                "Closure outputs do not support static records"
+                "Closure outputs do not support records"
             );
 
             // Check the output operand type.

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -45,7 +45,7 @@ impl<N: Network> RegisterTypes<N> {
         // Step 3. Check the outputs are well-formed.
         for output in closure.outputs() {
             // Ensure the closure output register is not a static record.
-            // ExternalRecord and DynamicRecord are checked at V14+ deployment time (see `verify_deployment`).
+            // ExternalRecord and DynamicRecord are checked at V14+ deployment time (see `VM::check_transaction`).
             ensure!(
                 !matches!(output.register_type(), RegisterType::Record(..)),
                 "Closure outputs do not support records"

--- a/synthesizer/process/src/verify_execution/ensure_records_exist.rs
+++ b/synthesizer/process/src/verify_execution/ensure_records_exist.rs
@@ -267,28 +267,6 @@ impl<N: Network> Process<N> {
         // Recursively explore the execution, keeping track of record connections across the relevant casts and calls.
         process_transition(self, &mut global_check, root_transition.id(), None, &tid_to_transition, call_graph)?;
 
-        // ExternalRecord root inputs are already verified by an inclusion proof. If such an input was never
-        // cast to a DynamicRecord (i.e. its family was never extended beyond the singleton), the family is
-        // automatically satisfied and does not need further resolution. Families that were extended (e.g. by a
-        // cast-to-DynamicRecord via Case 4) still need explicit resolution, since the derived DynamicRecord
-        // register is a non-ExternalRecord-root member of the family.
-        //
-        // This relies on the invariant that closure calls cannot extend record families. For programs deployed
-        // at V14+, closures are prohibited from outputting ExternalRecord or DynamicRecord types (enforced by
-        // `Stack::verify_deployment`), and static Record outputs are always prohibited (enforced by `add_output()`
-        // and `initialize_closure_types()`). If that restriction were ever relaxed, this logic must be revisited.
-        let root_external_registers: HashSet<(N::TransitionID, u64)> = root_transition
-            .inputs()
-            .iter()
-            .enumerate()
-            .filter(|(_, input)| matches!(input, Input::ExternalRecord(..)))
-            .map(|(i, _)| (*root_transition.id(), i as u64))
-            .collect();
-        // Retain only families that have at least one member outside the ExternalRecord root set,
-        // meaning the family was extended by a DynamicRecord cast or callee boundary and still needs
-        // verification.
-        global_check.families.retain(|family| !family.iter().all(|member| root_external_registers.contains(member)));
-
         // Ensure the global check passes.
         if global_check.non_existent_families().is_empty() {
             Ok(())
@@ -436,12 +414,8 @@ fn process_transition<N: Network>(
                 if let Instruction::Call(call) = instruction
                     && !call.is_function_call(stack.as_ref())?
                 {
-                    // Closure case. This function is only called at V14+.
-                    // Pre-V14 programs may have closures that output ExternalRecord (a pre-V14
-                    // feature). At V14+, such closures bypass the record-existence invariant because
-                    // the algorithm skips closure calls entirely. New V14+ programs are blocked at
-                    // deployment time; this check covers pre-V14 programs deployed before that
-                    // restriction existed.
+                    // Runtime check: reject pre-V14 programs whose closures output records.
+                    // New programs are blocked at deployment time; this covers legacy programs.
                     let has_forbidden_output = match call.operator() {
                         CallOperator::Resource(resource) => {
                             stack.program().get_closure(resource)?.outputs().iter().any(|output| {

--- a/synthesizer/process/src/verify_execution/ensure_records_exist.rs
+++ b/synthesizer/process/src/verify_execution/ensure_records_exist.rs
@@ -68,9 +68,11 @@ use snarkvm_synthesizer_program::CallOperator;
 //
 // The function ensure_records_exist explores the execution tree recursively starting at the root Transition and
 // processing instructions (input/output boundaries, function calls, Record mintings and cast-to-dynamic instructions)
-// in order of execution. Closure calls do not need to be explored since they cannot output Records, DynamicRecords or
-// ExternalRecords and therefore cannot influence any of the checks above (in particular, they cannot lead to
-// connections between Record-like registers in the caller).
+// in order of execution. It also ensures that no closure outputs ExternalRecord or DynamicRecord types, which is
+// enforced at deployment time for V14+ programs and checked at runtime for pre-V14 programs. Closure calls do not
+// need to be explored since they cannot output Records, DynamicRecords or ExternalRecords and therefore cannot
+// influence any of the checks above (in particular, they cannot lead to connections between Record-like registers
+// in the caller).
 //
 // When a function call is encountered, the function process_transition is called. This initialises a
 // FunctionLocalCheck struct which keeps track of which locally minted static Records are passed to callees; or cast to

--- a/synthesizer/process/src/verify_execution/ensure_records_exist.rs
+++ b/synthesizer/process/src/verify_execution/ensure_records_exist.rs
@@ -15,6 +15,9 @@
 
 use super::*;
 
+use console::program::RegisterType;
+use snarkvm_synthesizer_program::CallOperator;
+
 // The checks in this file ensure that every Transition t in the given execution satisfies the following:
 //
 // Guarantee (G): Every non-static record (DynamicRecord or ExternalRecord) input to t or received by t from a
@@ -264,6 +267,28 @@ impl<N: Network> Process<N> {
         // Recursively explore the execution, keeping track of record connections across the relevant casts and calls.
         process_transition(self, &mut global_check, root_transition.id(), None, &tid_to_transition, call_graph)?;
 
+        // ExternalRecord root inputs are already verified by an inclusion proof. If such an input was never
+        // cast to a DynamicRecord (i.e. its family was never extended beyond the singleton), the family is
+        // automatically satisfied and does not need further resolution. Families that were extended (e.g. by a
+        // cast-to-DynamicRecord via Case 4) still need explicit resolution, since the derived DynamicRecord
+        // register is a non-ExternalRecord-root member of the family.
+        //
+        // This relies on the invariant that closure calls cannot extend record families. For programs deployed
+        // at V14+, closures are prohibited from outputting ExternalRecord or DynamicRecord types (enforced by
+        // `Stack::verify_deployment`), and static Record outputs are always prohibited (enforced by `add_output()`
+        // and `initialize_closure_types()`). If that restriction were ever relaxed, this logic must be revisited.
+        let root_external_registers: HashSet<(N::TransitionID, u64)> = root_transition
+            .inputs()
+            .iter()
+            .enumerate()
+            .filter(|(_, input)| matches!(input, Input::ExternalRecord(..)))
+            .map(|(i, _)| (*root_transition.id(), i as u64))
+            .collect();
+        // Retain only families that have at least one member outside the ExternalRecord root set,
+        // meaning the family was extended by a DynamicRecord cast or callee boundary and still needs
+        // verification.
+        global_check.families.retain(|family| !family.iter().all(|member| root_external_registers.contains(member)));
+
         // Ensure the global check passes.
         if global_check.non_existent_families().is_empty() {
             Ok(())
@@ -411,7 +436,49 @@ fn process_transition<N: Network>(
                 if let Instruction::Call(call) = instruction
                     && !call.is_function_call(stack.as_ref())?
                 {
-                    // Closure case: neither the global nor the local check is affected.
+                    // Closure case. This function is only called at V14+.
+                    // Pre-V14 programs may have closures that output ExternalRecord (a pre-V14
+                    // feature). At V14+, such closures bypass the record-existence invariant because
+                    // the algorithm skips closure calls entirely. New V14+ programs are blocked at
+                    // deployment time; this check covers pre-V14 programs deployed before that
+                    // restriction existed.
+                    let has_forbidden_output = match call.operator() {
+                        CallOperator::Resource(resource) => stack
+                            .program()
+                            .get_closure(resource)
+                            .map(|closure| {
+                                closure.outputs().iter().any(|output| {
+                                    matches!(
+                                        output.register_type(),
+                                        RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
+                                    )
+                                })
+                            })
+                            .unwrap_or(false),
+                        CallOperator::Locator(locator) => process
+                            .get_stack(locator.program_id())
+                            .ok()
+                            .map(|ext_stack| {
+                                ext_stack
+                                    .program()
+                                    .get_closure(locator.resource())
+                                    .map(|closure| {
+                                        closure.outputs().iter().any(|output| {
+                                            matches!(
+                                                output.register_type(),
+                                                RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
+                                            )
+                                        })
+                                    })
+                                    .unwrap_or(false)
+                            })
+                            .unwrap_or(false),
+                    };
+                    ensure!(
+                        !has_forbidden_output,
+                        "Closure '{}' outputs ExternalRecord or DynamicRecord, which is disallowed at V14+",
+                        call.operator()
+                    );
                 } else {
                     // Function case
 

--- a/synthesizer/process/src/verify_execution/ensure_records_exist.rs
+++ b/synthesizer/process/src/verify_execution/ensure_records_exist.rs
@@ -443,36 +443,26 @@ fn process_transition<N: Network>(
                     // deployment time; this check covers pre-V14 programs deployed before that
                     // restriction existed.
                     let has_forbidden_output = match call.operator() {
-                        CallOperator::Resource(resource) => stack
-                            .program()
-                            .get_closure(resource)
-                            .map(|closure| {
-                                closure.outputs().iter().any(|output| {
-                                    matches!(
-                                        output.register_type(),
-                                        RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
-                                    )
-                                })
+                        CallOperator::Resource(resource) => {
+                            stack.program().get_closure(resource)?.outputs().iter().any(|output| {
+                                matches!(
+                                    output.register_type(),
+                                    RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
+                                )
                             })
-                            .unwrap_or(false),
+                        }
                         CallOperator::Locator(locator) => process
-                            .get_stack(locator.program_id())
-                            .ok()
-                            .map(|ext_stack| {
-                                ext_stack
-                                    .program()
-                                    .get_closure(locator.resource())
-                                    .map(|closure| {
-                                        closure.outputs().iter().any(|output| {
-                                            matches!(
-                                                output.register_type(),
-                                                RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
-                                            )
-                                        })
-                                    })
-                                    .unwrap_or(false)
-                            })
-                            .unwrap_or(false),
+                            .get_stack(locator.program_id())?
+                            .program()
+                            .get_closure(locator.resource())?
+                            .outputs()
+                            .iter()
+                            .any(|output| {
+                                matches!(
+                                    output.register_type(),
+                                    RegisterType::ExternalRecord(..) | RegisterType::DynamicRecord
+                                )
+                            }),
                     };
                     ensure!(
                         !has_forbidden_output,

--- a/synthesizer/program/src/closure/mod.rs
+++ b/synthesizer/program/src/closure/mod.rs
@@ -179,8 +179,9 @@ impl<N: Network> ClosureCore<N> {
         // Ensure the maximum number of outputs has not been exceeded.
         ensure!(self.outputs.len() < N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
 
-        // Ensure the closure output register is not a record.
-        ensure!(!matches!(output.register_type(), RegisterType::Record(..)), "Output register cannot be a record");
+        // Ensure the closure output register is not a static record.
+        // ExternalRecord and DynamicRecord are checked at V14+ deployment time (see `verify_deployment`).
+        ensure!(!matches!(output.register_type(), RegisterType::Record(..)), "Closure outputs do not support records");
 
         // Insert the output statement.
         self.outputs.insert(output);
@@ -268,5 +269,27 @@ mod tests {
                 false => assert!(closure.add_output(output).is_err()),
             }
         }
+    }
+
+    #[test]
+    fn test_add_output_record_types_rejected() {
+        let name = Identifier::from_str("closure_core_test").unwrap();
+
+        // DynamicRecord output is allowed at parse time (gated at V14+ deployment time).
+        let mut closure = Closure::<CurrentNetwork>::new(name);
+        let output = Output::<CurrentNetwork>::from_str("output r0 as dynamic.record;").unwrap();
+        assert!(closure.add_output(output).is_ok());
+
+        // ExternalRecord output is allowed at parse time (gated at V14+ deployment time).
+        let mut closure = Closure::<CurrentNetwork>::new(name);
+        let output = Output::<CurrentNetwork>::from_str("output r0 as test_prog.aleo/token.record;").unwrap();
+        assert!(closure.add_output(output).is_ok());
+
+        // Static Record output is rejected at parse time.
+        let mut closure = Closure::<CurrentNetwork>::new(name);
+        let output = Output::<CurrentNetwork>::from_str("output r0 as token.record;").unwrap();
+        let result = closure.add_output(output);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Closure outputs do not support records"));
     }
 }

--- a/synthesizer/program/src/closure/mod.rs
+++ b/synthesizer/program/src/closure/mod.rs
@@ -180,7 +180,7 @@ impl<N: Network> ClosureCore<N> {
         ensure!(self.outputs.len() < N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
 
         // Ensure the closure output register is not a static record.
-        // ExternalRecord and DynamicRecord are checked at V14+ deployment time (see `verify_deployment`).
+        // ExternalRecord and DynamicRecord are checked at V14+ deployment time (see `VM::check_transaction`).
         ensure!(!matches!(output.register_type(), RegisterType::Record(..)), "Closure outputs do not support records");
 
         // Insert the output statement.

--- a/synthesizer/program/src/logic/instruction/operation/call/standard.rs
+++ b/synthesizer/program/src/logic/instruction/operation/call/standard.rs
@@ -225,12 +225,11 @@ impl<N: Network> Call<N> {
             if closure.outputs().len() != self.destinations.len() {
                 bail!("Expected {} outputs, found {}", closure.outputs().len(), self.destinations.len())
             }
-            // Return the output register types.
+            // Retrieve the output types.
             Ok(closure
                 .output_types()
                 .into_iter()
-                // If the function is an external program, we need to qualify its structs with
-                // the appropriate `ProgramID`.
+                // If the callee is an external program, qualify its local types with its program ID.
                 .map(|output_type| if is_external { output_type.qualify(*program.id()) } else { output_type })
                 .collect::<Vec<_>>())
         }

--- a/synthesizer/src/vm/tests/test_v14/closure_records.rs
+++ b/synthesizer/src/vm/tests/test_v14/closure_records.rs
@@ -17,6 +17,31 @@ use super::*;
 
 use super::add_and_test;
 
+/// Advances the VM to V14 consensus height by adding empty blocks.
+fn advance_to_v14(
+    vm: &VM<CurrentNetwork, LedgerType>,
+    caller_private_key: &PrivateKey<CurrentNetwork>,
+    rng: &mut TestRng,
+) -> Result<()> {
+    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
+    for _ in vm.block_store().current_block_height()..v14_height {
+        let block = sample_next_block(vm, caller_private_key, &[], rng)?;
+        vm.add_next_block(&block)?;
+    }
+    Ok(())
+}
+
+/// Decrypts the first record output from the first transition in a transaction.
+fn decrypt_first_record(
+    tx: &Transaction<CurrentNetwork>,
+    view_key: &ViewKey<CurrentNetwork>,
+) -> Record<CurrentNetwork, Plaintext<CurrentNetwork>> {
+    match &tx.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(view_key).unwrap(),
+        other => panic!("Expected record output, got: {other:?}"),
+    }
+}
+
 // Tests that a closure can accept a record as input and read its fields.
 #[test]
 fn test_closure_record_input() -> Result<()> {
@@ -187,10 +212,7 @@ fn test_closure_external_record_input() -> Result<()> {
     )?;
 
     // Decrypt the minted record.
-    let item_record = match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, record_ciphertext, _) => record_ciphertext.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("Expected record output"),
-    };
+    let item_record = decrypt_first_record(&transaction, &caller_view_key);
 
     add_and_test(&vm, &caller_private_key, &[transaction], rng);
 
@@ -335,10 +357,7 @@ fn test_closure_dynamic_record_input() -> Result<()> {
     )?;
 
     // Decrypt the minted record.
-    let asset_record = match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, record_ciphertext, _) => record_ciphertext.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("Expected record output"),
-    };
+    let asset_record = decrypt_first_record(&transaction, &caller_view_key);
 
     add_and_test(&vm, &caller_private_key, &[transaction], rng);
 
@@ -491,10 +510,7 @@ fn test_external_record_cast_to_dynamic_then_closure_fails_existence_check() -> 
         rng,
     )?;
 
-    let gem_record = match &tx.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("expected record output"),
-    };
+    let gem_record = decrypt_first_record(&tx, &caller_view_key);
 
     add_and_test(&vm, &caller_private_key, &[tx], rng);
 
@@ -595,18 +611,11 @@ fn test_pre_v14_closure_external_record_input_works_at_v14() -> Result<()> {
         None,
         rng,
     )?;
-    let gem_record = match &mint_tx.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("expected record output"),
-    };
+    let gem_record = decrypt_first_record(&mint_tx, &caller_view_key);
     add_and_test(&vm, &caller_private_key, &[mint_tx], rng);
 
     // Advance to V14 (height 17 in the test schedule) by adding empty blocks.
-    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
-    for _ in vm.block_store().current_block_height()..v14_height {
-        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
-        vm.add_next_block(&block)?;
-    }
+    advance_to_v14(&vm, &caller_private_key, rng)?;
 
     // At V14+, executing a function that calls a closure with an ExternalRecord *input* (but no
     // record output) must succeed. The closure only reads a field, so `ensure_records_exist` has
@@ -706,18 +715,11 @@ fn test_pre_v14_closure_external_record_output_rejected_at_v14_runtime() -> Resu
         None,
         rng,
     )?;
-    let widget_record = match &tx.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("expected record output"),
-    };
+    let widget_record = decrypt_first_record(&tx, &caller_view_key);
     add_and_test(&vm, &caller_private_key, &[tx], rng);
 
     // Advance to V14 (height 17) by adding empty blocks.
-    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
-    for _ in vm.block_store().current_block_height()..v14_height {
-        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
-        vm.add_next_block(&block)?;
-    }
+    advance_to_v14(&vm, &caller_private_key, rng)?;
 
     // At V14+, executing `use_closure` must fail: the runtime `has_forbidden_output` check
     // detects that `passthrough_widget` outputs ExternalRecord and rejects the execution.
@@ -794,18 +796,11 @@ fn test_pre_v14_closure_dynamic_record_output_rejected_at_v14_runtime() -> Resul
         None,
         rng,
     )?;
-    let coin_record = match &tx.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("expected record output"),
-    };
+    let coin_record = decrypt_first_record(&tx, &caller_view_key);
     add_and_test(&vm, &caller_private_key, &[tx], rng);
 
     // Advance to V14 (height 17) by adding empty blocks.
-    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
-    for _ in vm.block_store().current_block_height()..v14_height {
-        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
-        vm.add_next_block(&block)?;
-    }
+    advance_to_v14(&vm, &caller_private_key, rng)?;
 
     // At V14+, executing `use_closure` must fail: the runtime `has_forbidden_output` check
     // detects that `cast_to_dynamic` outputs DynamicRecord and rejects the execution.
@@ -902,18 +897,11 @@ fn test_mixed_closures_forbidden_output_rejected_at_v14_runtime() -> Result<()> 
         None,
         rng,
     )?;
-    let token_record = match &tx.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("expected record output"),
-    };
+    let token_record = decrypt_first_record(&tx, &caller_view_key);
     add_and_test(&vm, &caller_private_key, &[tx], rng);
 
     // Advance to V14.
-    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
-    for _ in vm.block_store().current_block_height()..v14_height {
-        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
-        vm.add_next_block(&block)?;
-    }
+    advance_to_v14(&vm, &caller_private_key, rng)?;
 
     // At V14+, the function calls both a safe closure and a forbidden one. Execution must be
     // rejected because `passthrough` outputs ExternalRecord.
@@ -1028,18 +1016,11 @@ fn test_pre_v14_cross_program_closure_forbidden_output_rejected_at_v14_runtime()
         None,
         rng,
     )?;
-    let widget_record = match &tx.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("expected record output"),
-    };
+    let widget_record = decrypt_first_record(&tx, &caller_view_key);
     add_and_test(&vm, &caller_private_key, &[tx], rng);
 
     // Advance to V14 (height 17) by adding empty blocks.
-    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
-    for _ in vm.block_store().current_block_height()..v14_height {
-        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
-        vm.add_next_block(&block)?;
-    }
+    advance_to_v14(&vm, &caller_private_key, rng)?;
 
     // At V14+, executing `use_external_closure` must fail: the runtime `has_forbidden_output`
     // check (Locator branch) detects that `locator_lib.aleo/passthrough_widget` outputs
@@ -1100,6 +1081,259 @@ fn test_closure_dynamic_record_output_rejected_at_v14() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     let block = sample_next_block(&vm, &caller_private_key, &[tx], rng)?;
     assert_eq!(block.transactions().num_accepted(), 0, "DynamicRecord closure output should be rejected at V14+");
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
+
+    Ok(())
+}
+
+// Tests that a pre-V14 program whose closure outputs ExternalRecord executes successfully
+// *before* V14. This is the backward-compatibility counterpart to
+// `test_pre_v14_closure_external_record_output_rejected_at_v14_runtime`: both deploy at pre-V14,
+// but this test executes before V14 (where the restriction does not apply) and confirms the
+// output is accepted.
+#[test]
+fn test_pre_v14_closure_external_record_output_works_before_v14() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
+
+    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
+    let vm = sample_vm_at_height(12, rng);
+
+    // Parent defines the record.
+    let parent_program = Program::from_str(
+        r"
+        program pre_v14_ok_parent.aleo;
+
+        record widget:
+            owner as address.private;
+            value as u64.private;
+
+        function mint_widget:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as widget.record;
+            output r2 as widget.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Child has a closure that passes an ExternalRecord through as an output.
+    let child_program = Program::from_str(
+        r"
+        import pre_v14_ok_parent.aleo;
+
+        program pre_v14_ok_child.aleo;
+
+        closure passthrough_widget:
+            input r0 as pre_v14_ok_parent.aleo/widget.record;
+            assert.eq true true;
+            output r0 as pre_v14_ok_parent.aleo/widget.record;
+
+        function use_closure:
+            input r0 as pre_v14_ok_parent.aleo/widget.record;
+            call passthrough_widget r0 into r1;
+            output r1 as pre_v14_ok_parent.aleo/widget.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Deploy both programs before V14.
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    let tx = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a widget.
+    let tx = vm.execute(
+        &caller_private_key,
+        ("pre_v14_ok_parent.aleo", "mint_widget"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("42u64")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+    let widget_record = decrypt_first_record(&tx, &caller_view_key);
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Execute at pre-V14. The closure outputs ExternalRecord, which must be accepted.
+    let transaction = vm.execute(
+        &caller_private_key,
+        ("pre_v14_ok_child.aleo", "use_closure"),
+        [Value::<CurrentNetwork>::Record(widget_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+
+    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+
+    Ok(())
+}
+
+// Tests that a pre-V14 program whose closure accepts DynamicRecord as input (but does NOT output
+// it) executes successfully at V14+. This is the DynamicRecord-input counterpart to
+// `test_pre_v14_closure_external_record_input_works_at_v14`.
+#[test]
+fn test_pre_v14_closure_dynamic_record_input_works_at_v14() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
+
+    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
+    let vm = sample_vm_at_height(12, rng);
+
+    // Program with a closure that reads a DynamicRecord field but outputs a plain scalar.
+    let program = Program::from_str(
+        r"
+        program pre_v14_dyn_input_ok.aleo;
+
+        record coin:
+            owner as address.private;
+            amount as u64.private;
+
+        closure read_dynamic_amount:
+            input r0 as dynamic.record;
+            get.record.dynamic r0.amount into r1 as u64;
+            output r1 as u64;
+
+        function mint_coin:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as coin.record;
+            output r2 as coin.record;
+
+        function read_via_closure:
+            input r0 as coin.record;
+            cast r0 into r1 as dynamic.record;
+            call read_dynamic_amount r1 into r2;
+            output r2 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Deploy before V14.
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a coin.
+    let tx = vm.execute(
+        &caller_private_key,
+        ("pre_v14_dyn_input_ok.aleo", "mint_coin"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("123u64")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+    let coin_record = decrypt_first_record(&tx, &caller_view_key);
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Advance to V14 (height 17) by adding empty blocks.
+    advance_to_v14(&vm, &caller_private_key, rng)?;
+
+    // At V14+, executing `read_via_closure` must succeed: the closure only takes DynamicRecord
+    // as input and outputs a plain scalar. The `has_forbidden_output` check only looks at outputs.
+    let transaction = vm.execute(
+        &caller_private_key,
+        ("pre_v14_dyn_input_ok.aleo", "read_via_closure"),
+        [Value::<CurrentNetwork>::Record(coin_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+
+    // Verify the public output matches the minted amount.
+    let expected = Plaintext::from_str("123u64")?;
+    match &transaction.transitions().next().unwrap().outputs()[0] {
+        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
+        other => panic!("Expected public output, got: {other:?}"),
+    }
+
+    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+
+    Ok(())
+}
+
+// Tests that deploying a program at V14+ with mixed closures — one safe (outputs scalar) and one
+// forbidden (outputs ExternalRecord) — is rejected. Ensures the deploy-time check iterates all
+// closures and does not short-circuit after the first safe one.
+#[test]
+fn test_mixed_closures_deploy_rejected_at_v14() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    // Parent defines the record.
+    let parent_program = Program::from_str(
+        r"
+        program mixed_deploy_parent.aleo;
+
+        record token:
+            owner as address.private;
+            amount as u64.private;
+
+        function noop:
+            input r0 as u64.public;
+            output r0 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Child has two closures: one safe (outputs u64), one forbidden (outputs ExternalRecord).
+    let child_program = Program::from_str(
+        r"
+        import mixed_deploy_parent.aleo;
+
+        program mixed_deploy_child.aleo;
+
+        closure safe_extract:
+            input r0 as mixed_deploy_parent.aleo/token.record;
+            add r0.amount 0u64 into r1;
+            output r1 as u64;
+
+        closure bad_passthrough:
+            input r0 as mixed_deploy_parent.aleo/token.record;
+            assert.eq true true;
+            output r0 as mixed_deploy_parent.aleo/token.record;
+
+        function noop:
+            input r0 as u64.public;
+            output r0 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?, rng);
+
+    // Deploy the parent program.
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Deploy the child program. The transaction is created, but rejected during block production
+    // because `bad_passthrough` outputs ExternalRecord.
+    let tx = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
+    let block = sample_next_block(&vm, &caller_private_key, &[tx], rng)?;
+    assert_eq!(
+        block.transactions().num_accepted(),
+        0,
+        "Mixed closures with one forbidden output should be rejected at V14+"
+    );
     assert_eq!(block.aborted_transaction_ids().len(), 1);
 
     Ok(())

--- a/synthesizer/src/vm/tests/test_v14/closure_records.rs
+++ b/synthesizer/src/vm/tests/test_v14/closure_records.rs
@@ -217,108 +217,61 @@ fn test_closure_external_record_input() -> Result<()> {
     Ok(())
 }
 
-// Tests that a closure can output an external record (pass-through).
+// Tests that a closure outputting an ExternalRecord is rejected at V14+ deployment.
+// The program parses successfully, but `verify_deployment` (called during block production)
+// rejects it at V14+ because `ensure_records_exist` assumes closures cannot extend record families.
 #[test]
-fn test_closure_external_record_output() -> Result<()> {
+fn test_closure_external_record_output_rejected_at_v14() -> Result<()> {
     let rng = &mut TestRng::default();
-
     let caller_private_key = sample_genesis_private_key(rng);
-    let caller_address = Address::try_from(&caller_private_key)?;
-    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
 
-    // Parent program defines a record.
     let parent_program = Program::from_str(
         r"
-        program closure_ext_out_parent.aleo;
+        program ext_rec_out_parent.aleo;
 
         record item:
             owner as address.private;
-            worth as u32.private;
+            amount as u64.private;
 
-        function mint_item:
-            input r0 as address.private;
-            input r1 as u32.private;
-            cast r0 r1 into r2 as item.record;
-            output r2 as item.record;
+        function noop:
+            input r0 as u64.public;
+            output r0 as u64.public;
 
         constructor:
             assert.eq true true;
         ",
     )?;
 
-    // Child program has a closure that passes through an external record.
     let child_program = Program::from_str(
         r"
-        import closure_ext_out_parent.aleo;
+        import ext_rec_out_parent.aleo;
 
-        program closure_ext_out_child.aleo;
+        program ext_rec_out_child.aleo;
 
         closure passthrough_external:
-            input r0 as closure_ext_out_parent.aleo/item.record;
+            input r0 as ext_rec_out_parent.aleo/item.record;
             assert.eq true true;
-            output r0 as closure_ext_out_parent.aleo/item.record;
+            output r0 as ext_rec_out_parent.aleo/item.record;
 
-        function roundtrip_value:
-            input r0 as closure_ext_out_parent.aleo/item.record;
-            call passthrough_external r0 into r1;
-            cast r1 into r2 as dynamic.record;
-            get.record.dynamic r2.worth into r3 as u32;
-            output r3 as u32.public;
+        function noop:
+            input r0 as u64.public;
+            output r0 as u64.public;
 
         constructor:
             assert.eq true true;
         ",
     )?;
 
-    // Initialize the VM at V14.
     let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?, rng);
 
-    // Deploy the parent program.
-    let transaction = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
 
-    // Deploy the child program.
-    let transaction = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
-
-    // Mint an item via the parent program.
-    let transaction = vm.execute(
-        &caller_private_key,
-        ("closure_ext_out_parent.aleo", "mint_item"),
-        [Value::from_str(&caller_address.to_string())?, Value::from_str("77u32")?].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    )?;
-
-    // Decrypt the minted record.
-    let item_record = match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, record_ciphertext, _) => record_ciphertext.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("Expected record output"),
-    };
-
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
-
-    // Execute the child function that passes the external record through a closure.
-    let transaction = vm.execute(
-        &caller_private_key,
-        ("closure_ext_out_child.aleo", "roundtrip_value"),
-        [Value::<CurrentNetwork>::Record(item_record)].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    )?;
-
-    // Verify the public output matches the expected value.
-    let expected = Plaintext::from_str("77u32")?;
-    match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
-        other => panic!("Expected public output, got: {other:?}"),
-    }
-
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+    // The deployment transaction is created successfully, but rejected during block production.
+    let tx = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
+    let block = sample_next_block(&vm, &caller_private_key, &[tx], rng)?;
+    assert_eq!(block.transactions().num_accepted(), 0, "ExternalRecord closure output should be rejected at V14+");
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
 
     Ok(())
 }
@@ -412,19 +365,288 @@ fn test_closure_dynamic_record_input() -> Result<()> {
     Ok(())
 }
 
-// Tests that a closure can output a dynamic record by casting from a static record.
+// Tests that closures cannot use `call` instructions (closures are leaf computations).
+// This documents a language constraint: record inputs in closures are read-only —
+// a closure cannot forward a record to another closure or function via `call`.
 #[test]
-fn test_closure_dynamic_record_output() -> Result<()> {
+fn test_closure_cannot_contain_call() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    // A program whose closure body contains a `call` instruction. The program
+    // parses successfully but must be rejected when deployed (stack initialization).
+    let program = Program::<CurrentNetwork>::from_str(
+        r"
+        program closure_call_bad.aleo;
+
+        record coin:
+            owner as address.private;
+            amount as u64.private;
+
+        closure inner_read:
+            input r0 as coin.record;
+            add r0.amount 0u64 into r1;
+            output r1 as u64;
+
+        closure outer_read:
+            input r0 as coin.record;
+            call inner_read r0 into r1;
+            output r1 as u64;
+
+        function use_outer:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as coin.record;
+            call outer_read r2 into r3;
+            output r3 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )
+    .expect("program should parse");
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14).unwrap(), rng);
+    let result = vm.deploy(&caller_private_key, &program, None, 0, None, rng);
+
+    assert!(result.is_err(), "A closure containing a `call` instruction should be rejected at deployment");
+}
+
+// Tests that the existence check is NOT bypassed when an ExternalRecord is cast to a
+// DynamicRecord and then only used in a closure. The `retain()` logic auto-resolves
+// families whose only member is an ExternalRecord root (the inclusion-proof case), but
+// once a cast creates an additional DynamicRecord member the family must still be
+// verified through a function call. This is the closure analog of Antonio's test 4.1.
+#[test]
+fn test_external_record_cast_to_dynamic_then_closure_fails_existence_check() -> Result<()> {
     let rng = &mut TestRng::default();
 
     let caller_private_key = sample_genesis_private_key(rng);
     let caller_address = Address::try_from(&caller_private_key)?;
     let caller_view_key = ViewKey::try_from(&caller_private_key)?;
 
-    // Program with a closure that casts a record to dynamic and outputs it.
+    // Parent program defines the record.
+    let parent_program = Program::from_str(
+        r"
+        program cast_dyn_parent.aleo;
+
+        record gem:
+            owner as address.private;
+            karat as u32.private;
+
+        function mint_gem:
+            input r0 as address.private;
+            input r1 as u32.private;
+            cast r0 r1 into r2 as gem.record;
+            output r2 as gem.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Child program imports parent, casts the ExternalRecord to DynamicRecord, then
+    // passes the DynamicRecord ONLY to a closure (no function call to verify it).
+    let child_program = Program::from_str(
+        r"
+        import cast_dyn_parent.aleo;
+
+        program cast_dyn_child.aleo;
+
+        closure read_dynamic_karat:
+            input r0 as dynamic.record;
+            get.record.dynamic r0.karat into r1 as u32;
+            output r1 as u32;
+
+        // Receives an ExternalRecord, casts it to DynamicRecord, and passes it only
+        // to a closure. The ExternalRecord->DynamicRecord cast creates a two-member
+        // family that cannot be auto-resolved; the closure cannot resolve it either.
+        function read_gem_via_cast_and_closure:
+            input r0 as cast_dyn_parent.aleo/gem.record;
+            cast r0 into r1 as dynamic.record;
+            call read_dynamic_karat r1 into r2;
+            output r2 as u32.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?, rng);
+
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    let tx = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a gem.
+    let tx = vm.execute(
+        &caller_private_key,
+        ("cast_dyn_parent.aleo", "mint_gem"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("24u32")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+
+    let gem_record = match &tx.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
+        _ => panic!("expected record output"),
+    };
+
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Execute the child function. The ExternalRecord is cast to DynamicRecord and passed only
+    // to a closure. The existence check must reject this because the DynamicRecord family
+    // was extended by the cast (so `retain()` does not auto-resolve it) and the closure
+    // cannot provide the function-call verification needed to resolve it.
+    let result = vm.execute(
+        &caller_private_key,
+        ("cast_dyn_child.aleo", "read_gem_via_cast_and_closure"),
+        [Value::<CurrentNetwork>::Record(gem_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    );
+
+    assert!(
+        result.is_err(),
+        "Execution should fail: ExternalRecord cast to DynamicRecord and only passed to closure has no existence verification"
+    );
+
+    Ok(())
+}
+
+// Tests V14 backward compatibility: a program with a closure that accepts an ExternalRecord as
+// input (but does NOT output it) can be deployed before V14 and executed correctly at V14+.
+// This is the happy-path counterpart to `test_closure_external_record_output_rejected_at_v14`.
+#[test]
+fn test_pre_v14_closure_external_record_input_works_at_v14() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
+
+    // Start at V9 (height 12 in the test schedule), which uses Varuna V2 (consistent with V14's
+    // proof system) and supports constructor syntax, but is before V14 (height 17). At this height
+    // the deployment-time closure-output restriction does not yet apply.
+    let vm = sample_vm_at_height(12, rng);
+
+    // Parent defines the record.
+    let parent_program = Program::from_str(
+        r"
+        program closure_legacy_parent.aleo;
+
+        record gem:
+            owner as address.private;
+            amount as u64.private;
+
+        function mint_gem:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as gem.record;
+            output r2 as gem.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Child has a closure that accepts an ExternalRecord as input and extracts a field value,
+    // producing a plain u64. The closure does not output a record.
+    let child_program = Program::from_str(
+        r"
+        import closure_legacy_parent.aleo;
+
+        program closure_legacy_child.aleo;
+
+        closure extract_gem_amount:
+            input r0 as closure_legacy_parent.aleo/gem.record;
+            add r0.amount 0u64 into r1;
+            output r1 as u64;
+
+        function use_gem_closure:
+            input r0 as closure_legacy_parent.aleo/gem.record;
+            call extract_gem_amount r0 into r1;
+            output r1 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Deploy both programs before V14. The deployments must be accepted.
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    let tx = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a gem to use as input to the child function.
+    let mint_tx = vm.execute(
+        &caller_private_key,
+        ("closure_legacy_parent.aleo", "mint_gem"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("77u64")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+    let gem_record = match &mint_tx.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
+        _ => panic!("expected record output"),
+    };
+    add_and_test(&vm, &caller_private_key, &[mint_tx], rng);
+
+    // Advance to V14 (height 17 in the test schedule) by adding empty blocks.
+    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
+    for _ in vm.block_store().current_block_height()..v14_height {
+        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
+        vm.add_next_block(&block)?;
+    }
+
+    // At V14+, executing a function that calls a closure with an ExternalRecord *input* (but no
+    // record output) must succeed. The closure only reads a field, so `ensure_records_exist` has
+    // nothing to validate — no record family is extended.
+    let transaction = vm.execute(
+        &caller_private_key,
+        ("closure_legacy_child.aleo", "use_gem_closure"),
+        [Value::<CurrentNetwork>::Record(gem_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+
+    // Verify the public output equals the minted amount.
+    let expected = Plaintext::from_str("77u64")?;
+    match &transaction.transitions().next().unwrap().outputs()[0] {
+        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
+        other => panic!("Expected public output, got: {other:?}"),
+    }
+
+    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+
+    Ok(())
+}
+
+// Tests that a closure outputting a DynamicRecord is rejected at V14+ deployment.
+// The program parses successfully, but `verify_deployment` (called during block production)
+// rejects it at V14+ because `ensure_records_exist` assumes closures cannot extend record families.
+#[test]
+fn test_closure_dynamic_record_output_rejected_at_v14() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    // A program whose closure casts a record to DynamicRecord and outputs it. This is
+    // rejected at V14+ because `ensure_records_exist` assumes closures cannot extend
+    // record families.
     let program = Program::from_str(
         r"
-        program closure_dyn_output.aleo;
+        program closure_dyn_output_bad.aleo;
 
         record asset:
             owner as address.private;
@@ -435,68 +657,21 @@ fn test_closure_dynamic_record_output() -> Result<()> {
             cast r0 into r1 as dynamic.record;
             output r1 as dynamic.record;
 
-        function mint_asset:
-            input r0 as address.private;
-            input r1 as u64.private;
-            cast r0 r1 into r2 as asset.record;
-            output r2 as asset.record;
-
-        function cast_via_closure:
-            input r0 as asset.record;
-            call cast_to_dynamic r0 into r1;
-            get.record.dynamic r1.quantity into r2 as u64;
-            output r2 as u64.public;
+        function unused:
+            input r0 as u64.public;
+            output r0 as u64.public;
 
         constructor:
             assert.eq true true;
         ",
     )?;
 
-    // Initialize the VM at V14.
+    // The deployment transaction is created successfully, but rejected during block production.
     let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?, rng);
-
-    // Deploy the program.
-    let transaction = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
-
-    // Mint an asset record.
-    let transaction = vm.execute(
-        &caller_private_key,
-        ("closure_dyn_output.aleo", "mint_asset"),
-        [Value::from_str(&caller_address.to_string())?, Value::from_str("250u64")?].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    )?;
-
-    // Decrypt the minted record.
-    let asset_record = match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Record(_, _, record_ciphertext, _) => record_ciphertext.as_ref().unwrap().decrypt(&caller_view_key)?,
-        _ => panic!("Expected record output"),
-    };
-
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
-
-    // Execute the function that casts via the closure and reads the dynamic record.
-    let transaction = vm.execute(
-        &caller_private_key,
-        ("closure_dyn_output.aleo", "cast_via_closure"),
-        [Value::<CurrentNetwork>::Record(asset_record)].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    )?;
-
-    // Verify the public output matches the expected quantity.
-    let expected = Plaintext::from_str("250u64")?;
-    match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
-        other => panic!("Expected public output, got: {other:?}"),
-    }
-
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    let block = sample_next_block(&vm, &caller_private_key, &[tx], rng)?;
+    assert_eq!(block.transactions().num_accepted(), 0, "DynamicRecord closure output should be rejected at V14+");
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
 
     Ok(())
 }

--- a/synthesizer/src/vm/tests/test_v14/closure_records.rs
+++ b/synthesizer/src/vm/tests/test_v14/closure_records.rs
@@ -138,18 +138,16 @@ fn test_closure_record_output_rejected() {
     assert!(result.is_err(), "Program with record output from closure should fail to parse");
 }
 
-// Tests that a function whose only use of an ExternalRecord input is passing it to a closure
-// is rejected by the record-existence check at V14+. The ExternalRecord creates an unresolved
-// family because closures cannot provide existence verification.
+// Tests that a closure can accept an external record as input and read its fields.
 #[test]
-fn test_closure_external_record_input_only_rejected_at_v14() -> Result<()> {
+fn test_closure_external_record_input() -> Result<()> {
     let rng = &mut TestRng::default();
 
     let caller_private_key = sample_genesis_private_key(rng);
     let caller_address = Address::try_from(&caller_private_key)?;
     let caller_view_key = ViewKey::try_from(&caller_private_key)?;
 
-    // Parent program defines a record.
+    // Parent program defines a record and a consume function.
     let parent_program = Program::from_str(
         r"
         program closure_ext_parent.aleo;
@@ -164,14 +162,17 @@ fn test_closure_external_record_input_only_rejected_at_v14() -> Result<()> {
             cast r0 r1 into r2 as item.record;
             output r2 as item.record;
 
+        function consume_item:
+            input r0 as item.record;
+            output r0.worth as u32.public;
+
         constructor:
             assert.eq true true;
         ",
     )?;
 
     // Child program imports parent and has a closure taking the external record.
-    // The function only passes the ExternalRecord to a closure — it never consumes it
-    // via a function call boundary, so the record-existence check cannot verify it.
+    // The function also calls consume_item to resolve the record family.
     let child_program = Program::from_str(
         r"
         import closure_ext_parent.aleo;
@@ -186,6 +187,7 @@ fn test_closure_external_record_input_only_rejected_at_v14() -> Result<()> {
         function extract_external_value:
             input r0 as closure_ext_parent.aleo/item.record;
             call read_external_item r0 into r1;
+            call closure_ext_parent.aleo/consume_item r0 into r2;
             output r1 as u32.public;
 
         constructor:
@@ -216,12 +218,14 @@ fn test_closure_external_record_input_only_rejected_at_v14() -> Result<()> {
     )?;
 
     // Decrypt the minted record.
-    let item_record = decrypt_first_record(&transaction, &caller_view_key);
+    let item_record = match &transaction.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, record_ciphertext, _) => record_ciphertext.as_ref().unwrap().decrypt(&caller_view_key)?,
+        _ => panic!("Expected record output"),
+    };
 
     add_and_test(&vm, &caller_private_key, &[transaction], rng);
 
-    // Execute the child function with the external record. The transaction is created
-    // successfully but will be rejected during verification.
+    // Execute the child function with the external record.
     let transaction = vm.execute(
         &caller_private_key,
         ("closure_ext_child.aleo", "extract_external_value"),
@@ -232,24 +236,23 @@ fn test_closure_external_record_input_only_rejected_at_v14() -> Result<()> {
         rng,
     )?;
 
-    // The transaction should be aborted: the ExternalRecord input creates an unresolved
-    // family because the closure cannot provide record-existence verification.
-    let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
-    assert_eq!(
-        block.transactions().num_accepted(),
-        0,
-        "ExternalRecord used only in closure should fail existence check"
-    );
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+    // Verify the public output matches the expected value.
+    let expected = Plaintext::from_str("99u32")?;
+    match &transaction.transitions().next().unwrap().outputs()[0] {
+        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
+        other => panic!("Expected public output, got: {other:?}"),
+    }
+
+    add_and_test(&vm, &caller_private_key, &[transaction], rng);
 
     Ok(())
 }
 
 // Tests that a closure outputting an ExternalRecord is rejected at V14+ deployment.
 // The program parses successfully, but `verify_deployment` (called during block production)
-// rejects it at V14+ because `ensure_records_exist` assumes closures cannot extend record families.
+// rejects it at V14+ because closures cannot output ExternalRecord or DynamicRecord types.
 #[test]
-fn test_closure_external_record_output_rejected_at_v14() -> Result<()> {
+fn test_closure_external_record_output() -> Result<()> {
     let rng = &mut TestRng::default();
     let caller_private_key = sample_genesis_private_key(rng);
 
@@ -616,9 +619,9 @@ fn test_pre_v14_closure_external_record_input_only_rejected_at_v14() -> Result<(
     // Advance to V14.
     advance_to_v14(&vm, &caller_private_key, rng)?;
 
-    // Execute the function. The transaction is created but rejected during verification:
-    // the ExternalRecord input creates an unresolved family (closures cannot verify existence).
-    let transaction = vm.execute(
+    // Execute the function. The record-existence check rejects the execution because the
+    // ExternalRecord input creates an unresolved family (closures cannot verify existence).
+    let result = vm.execute(
         &caller_private_key,
         ("closure_legacy_child.aleo", "use_gem_closure"),
         [Value::<CurrentNetwork>::Record(gem_record)].into_iter(),
@@ -626,15 +629,9 @@ fn test_pre_v14_closure_external_record_input_only_rejected_at_v14() -> Result<(
         0,
         None,
         rng,
-    )?;
-
-    let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
-    assert_eq!(
-        block.transactions().num_accepted(),
-        0,
-        "ExternalRecord used only in closure should fail existence check at V14+"
     );
-    assert_eq!(block.aborted_transaction_ids().len(), 1);
+
+    assert!(result.is_err(), "ExternalRecord used only in closure should fail existence check at V14+");
 
     Ok(())
 }
@@ -659,7 +656,7 @@ fn test_pre_v14_closure_external_record_output_rejected_at_v14_runtime() -> Resu
 
         record widget:
             owner as address.private;
-            value as u64.private;
+            worth as u64.private;
 
         function mint_widget:
             input r0 as address.private;
@@ -731,87 +728,6 @@ fn test_pre_v14_closure_external_record_output_rejected_at_v14_runtime() -> Resu
     );
 
     assert!(result.is_err(), "Execution must fail: pre-V14 closure outputting ExternalRecord is disallowed at V14+");
-
-    Ok(())
-}
-
-// Tests that executing a pre-V14 program whose closure outputs DynamicRecord is rejected at V14+.
-// Parallel to `test_pre_v14_closure_external_record_output_rejected_at_v14_runtime` but for the
-// DynamicRecord variant of the `has_forbidden_output` check.
-#[test]
-fn test_pre_v14_closure_dynamic_record_output_rejected_at_v14_runtime() -> Result<()> {
-    let rng = &mut TestRng::default();
-    let caller_private_key = sample_genesis_private_key(rng);
-    let caller_address = Address::try_from(&caller_private_key)?;
-    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
-
-    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
-    let vm = sample_vm_at_height(12, rng);
-
-    // Program with a closure that casts a record to DynamicRecord and outputs it.
-    // This is allowed at pre-V14 but forbidden at V14+.
-    let program = Program::from_str(
-        r"
-        program pre_v14_dyn_out.aleo;
-
-        record coin:
-            owner as address.private;
-            amount as u64.private;
-
-        closure cast_to_dynamic:
-            input r0 as coin.record;
-            cast r0 into r1 as dynamic.record;
-            output r1 as dynamic.record;
-
-        function use_closure:
-            input r0 as coin.record;
-            call cast_to_dynamic r0 into r1;
-            output r1 as dynamic.record;
-
-        function mint_coin:
-            input r0 as address.private;
-            input r1 as u64.private;
-            cast r0 r1 into r2 as coin.record;
-            output r2 as coin.record;
-
-        constructor:
-            assert.eq true true;
-        ",
-    )?;
-
-    // Deploy before V14. Deployment must be accepted.
-    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
-    add_and_test(&vm, &caller_private_key, &[tx], rng);
-
-    // Mint a coin to use as input.
-    let tx = vm.execute(
-        &caller_private_key,
-        ("pre_v14_dyn_out.aleo", "mint_coin"),
-        [Value::from_str(&caller_address.to_string())?, Value::from_str("10u64")?].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    )?;
-    let coin_record = decrypt_first_record(&tx, &caller_view_key);
-    add_and_test(&vm, &caller_private_key, &[tx], rng);
-
-    // Advance to V14 (height 17) by adding empty blocks.
-    advance_to_v14(&vm, &caller_private_key, rng)?;
-
-    // At V14+, executing `use_closure` must fail: the runtime `has_forbidden_output` check
-    // detects that `cast_to_dynamic` outputs DynamicRecord and rejects the execution.
-    let result = vm.execute(
-        &caller_private_key,
-        ("pre_v14_dyn_out.aleo", "use_closure"),
-        [Value::<CurrentNetwork>::Record(coin_record)].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    );
-
-    assert!(result.is_err(), "Execution must fail: pre-V14 closure outputting DynamicRecord is disallowed at V14+");
 
     Ok(())
 }
@@ -1042,9 +958,9 @@ fn test_pre_v14_cross_program_closure_forbidden_output_rejected_at_v14_runtime()
 
 // Tests that a closure outputting a DynamicRecord is rejected at V14+ deployment.
 // The program parses successfully, but `verify_deployment` (called during block production)
-// rejects it at V14+ because `ensure_records_exist` assumes closures cannot extend record families.
+// rejects it at V14+ because closures cannot output ExternalRecord or DynamicRecord types.
 #[test]
-fn test_closure_dynamic_record_output_rejected_at_v14() -> Result<()> {
+fn test_closure_dynamic_record_output() -> Result<()> {
     let rng = &mut TestRng::default();
     let caller_private_key = sample_genesis_private_key(rng);
 
@@ -1105,7 +1021,7 @@ fn test_pre_v14_closure_external_record_output_works_before_v14() -> Result<()> 
 
         record widget:
             owner as address.private;
-            value as u64.private;
+            worth as u64.private;
 
         function mint_widget:
             input r0 as address.private;
@@ -1170,94 +1086,6 @@ fn test_pre_v14_closure_external_record_output_works_before_v14() -> Result<()> 
         None,
         rng,
     )?;
-
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
-
-    Ok(())
-}
-
-// Tests that a pre-V14 program whose closure accepts DynamicRecord as input (but does NOT output
-// it) executes successfully at V14+. This is the DynamicRecord-input counterpart to
-// `test_pre_v14_closure_external_record_input_works_at_v14`.
-#[test]
-fn test_pre_v14_closure_dynamic_record_input_works_at_v14() -> Result<()> {
-    let rng = &mut TestRng::default();
-    let caller_private_key = sample_genesis_private_key(rng);
-    let caller_address = Address::try_from(&caller_private_key)?;
-    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
-
-    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
-    let vm = sample_vm_at_height(12, rng);
-
-    // Program with a closure that reads a DynamicRecord field but outputs a plain scalar.
-    let program = Program::from_str(
-        r"
-        program pre_v14_dyn_input_ok.aleo;
-
-        record coin:
-            owner as address.private;
-            amount as u64.private;
-
-        closure read_dynamic_amount:
-            input r0 as dynamic.record;
-            get.record.dynamic r0.amount into r1 as u64;
-            output r1 as u64;
-
-        function mint_coin:
-            input r0 as address.private;
-            input r1 as u64.private;
-            cast r0 r1 into r2 as coin.record;
-            output r2 as coin.record;
-
-        function read_via_closure:
-            input r0 as coin.record;
-            cast r0 into r1 as dynamic.record;
-            call read_dynamic_amount r1 into r2;
-            output r2 as u64.public;
-
-        constructor:
-            assert.eq true true;
-        ",
-    )?;
-
-    // Deploy before V14.
-    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
-    add_and_test(&vm, &caller_private_key, &[tx], rng);
-
-    // Mint a coin.
-    let tx = vm.execute(
-        &caller_private_key,
-        ("pre_v14_dyn_input_ok.aleo", "mint_coin"),
-        [Value::from_str(&caller_address.to_string())?, Value::from_str("123u64")?].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    )?;
-    let coin_record = decrypt_first_record(&tx, &caller_view_key);
-    add_and_test(&vm, &caller_private_key, &[tx], rng);
-
-    // Advance to V14 (height 17) by adding empty blocks.
-    advance_to_v14(&vm, &caller_private_key, rng)?;
-
-    // At V14+, executing `read_via_closure` must succeed: the closure only takes DynamicRecord
-    // as input and outputs a plain scalar. The `has_forbidden_output` check only looks at outputs.
-    let transaction = vm.execute(
-        &caller_private_key,
-        ("pre_v14_dyn_input_ok.aleo", "read_via_closure"),
-        [Value::<CurrentNetwork>::Record(coin_record)].into_iter(),
-        None,
-        0,
-        None,
-        rng,
-    )?;
-
-    // Verify the public output matches the minted amount.
-    let expected = Plaintext::from_str("123u64")?;
-    match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
-        other => panic!("Expected public output, got: {other:?}"),
-    }
 
     add_and_test(&vm, &caller_private_key, &[transaction], rng);
 

--- a/synthesizer/src/vm/tests/test_v14/closure_records.rs
+++ b/synthesizer/src/vm/tests/test_v14/closure_records.rs
@@ -633,6 +633,435 @@ fn test_pre_v14_closure_external_record_input_works_at_v14() -> Result<()> {
     Ok(())
 }
 
+// Tests that executing a pre-V14 program whose closure outputs ExternalRecord is rejected at V14+.
+// This covers the runtime `has_forbidden_output` check, which is the only code path exercising
+// that check — deployment-time rejection prevents new programs from reaching execution.
+#[test]
+fn test_pre_v14_closure_external_record_output_rejected_at_v14_runtime() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
+
+    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
+    let vm = sample_vm_at_height(12, rng);
+
+    // Parent defines the record.
+    let parent_program = Program::from_str(
+        r"
+        program pre_v14_ext_out_parent.aleo;
+
+        record widget:
+            owner as address.private;
+            value as u64.private;
+
+        function mint_widget:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as widget.record;
+            output r2 as widget.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Child has a closure that passes an ExternalRecord through as an output.
+    // This is allowed at pre-V14 but forbidden at V14+.
+    let child_program = Program::from_str(
+        r"
+        import pre_v14_ext_out_parent.aleo;
+
+        program pre_v14_ext_out_child.aleo;
+
+        closure passthrough_widget:
+            input r0 as pre_v14_ext_out_parent.aleo/widget.record;
+            assert.eq true true;
+            output r0 as pre_v14_ext_out_parent.aleo/widget.record;
+
+        function use_closure:
+            input r0 as pre_v14_ext_out_parent.aleo/widget.record;
+            call passthrough_widget r0 into r1;
+            output r1 as pre_v14_ext_out_parent.aleo/widget.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Deploy both programs before V14. Both deployments must be accepted.
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    let tx = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a widget to use as input.
+    let tx = vm.execute(
+        &caller_private_key,
+        ("pre_v14_ext_out_parent.aleo", "mint_widget"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("42u64")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+    let widget_record = match &tx.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
+        _ => panic!("expected record output"),
+    };
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Advance to V14 (height 17) by adding empty blocks.
+    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
+    for _ in vm.block_store().current_block_height()..v14_height {
+        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
+        vm.add_next_block(&block)?;
+    }
+
+    // At V14+, executing `use_closure` must fail: the runtime `has_forbidden_output` check
+    // detects that `passthrough_widget` outputs ExternalRecord and rejects the execution.
+    let result = vm.execute(
+        &caller_private_key,
+        ("pre_v14_ext_out_child.aleo", "use_closure"),
+        [Value::<CurrentNetwork>::Record(widget_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    );
+
+    assert!(result.is_err(), "Execution must fail: pre-V14 closure outputting ExternalRecord is disallowed at V14+");
+
+    Ok(())
+}
+
+// Tests that executing a pre-V14 program whose closure outputs DynamicRecord is rejected at V14+.
+// Parallel to `test_pre_v14_closure_external_record_output_rejected_at_v14_runtime` but for the
+// DynamicRecord variant of the `has_forbidden_output` check.
+#[test]
+fn test_pre_v14_closure_dynamic_record_output_rejected_at_v14_runtime() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
+
+    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
+    let vm = sample_vm_at_height(12, rng);
+
+    // Program with a closure that casts a record to DynamicRecord and outputs it.
+    // This is allowed at pre-V14 but forbidden at V14+.
+    let program = Program::from_str(
+        r"
+        program pre_v14_dyn_out.aleo;
+
+        record coin:
+            owner as address.private;
+            amount as u64.private;
+
+        closure cast_to_dynamic:
+            input r0 as coin.record;
+            cast r0 into r1 as dynamic.record;
+            output r1 as dynamic.record;
+
+        function use_closure:
+            input r0 as coin.record;
+            call cast_to_dynamic r0 into r1;
+            output r1 as dynamic.record;
+
+        function mint_coin:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as coin.record;
+            output r2 as coin.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Deploy before V14. Deployment must be accepted.
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a coin to use as input.
+    let tx = vm.execute(
+        &caller_private_key,
+        ("pre_v14_dyn_out.aleo", "mint_coin"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("10u64")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+    let coin_record = match &tx.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
+        _ => panic!("expected record output"),
+    };
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Advance to V14 (height 17) by adding empty blocks.
+    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
+    for _ in vm.block_store().current_block_height()..v14_height {
+        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
+        vm.add_next_block(&block)?;
+    }
+
+    // At V14+, executing `use_closure` must fail: the runtime `has_forbidden_output` check
+    // detects that `cast_to_dynamic` outputs DynamicRecord and rejects the execution.
+    let result = vm.execute(
+        &caller_private_key,
+        ("pre_v14_dyn_out.aleo", "use_closure"),
+        [Value::<CurrentNetwork>::Record(coin_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    );
+
+    assert!(result.is_err(), "Execution must fail: pre-V14 closure outputting DynamicRecord is disallowed at V14+");
+
+    Ok(())
+}
+
+// Tests that when a function contains multiple closures — one with a forbidden output and one
+// without — execution is rejected. Verifies that the check is per-closure and not accidentally
+// bypassed when benign closures are present.
+#[test]
+fn test_mixed_closures_forbidden_output_rejected_at_v14_runtime() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
+
+    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
+    let vm = sample_vm_at_height(12, rng);
+
+    let parent_program = Program::from_str(
+        r"
+        program mixed_closures_parent.aleo;
+
+        record token:
+            owner as address.private;
+            amount as u64.private;
+
+        function mint_token:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as token.record;
+            output r2 as token.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Child has two closures: one benign (reads a field), one forbidden (outputs ExternalRecord).
+    // The function calls the benign closure first, then the forbidden one.
+    let child_program = Program::from_str(
+        r"
+        import mixed_closures_parent.aleo;
+
+        program mixed_closures_child.aleo;
+
+        closure extract_amount:
+            input r0 as mixed_closures_parent.aleo/token.record;
+            add r0.amount 0u64 into r1;
+            output r1 as u64;
+
+        closure passthrough:
+            input r0 as mixed_closures_parent.aleo/token.record;
+            assert.eq true true;
+            output r0 as mixed_closures_parent.aleo/token.record;
+
+        function use_both_closures:
+            input r0 as mixed_closures_parent.aleo/token.record;
+            call extract_amount r0 into r1;
+            call passthrough r0 into r2;
+            output r1 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Deploy both programs before V14. Both deployments must be accepted.
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    let tx = vm.deploy(&caller_private_key, &child_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a token.
+    let tx = vm.execute(
+        &caller_private_key,
+        ("mixed_closures_parent.aleo", "mint_token"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("50u64")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+    let token_record = match &tx.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
+        _ => panic!("expected record output"),
+    };
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Advance to V14.
+    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
+    for _ in vm.block_store().current_block_height()..v14_height {
+        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
+        vm.add_next_block(&block)?;
+    }
+
+    // At V14+, the function calls both a safe closure and a forbidden one. Execution must be
+    // rejected because `passthrough` outputs ExternalRecord.
+    let result = vm.execute(
+        &caller_private_key,
+        ("mixed_closures_child.aleo", "use_both_closures"),
+        [Value::<CurrentNetwork>::Record(token_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    );
+
+    assert!(result.is_err(), "Execution must fail: function contains a closure with forbidden ExternalRecord output");
+
+    Ok(())
+}
+
+// Tests that executing a pre-V14 cross-program closure call (`CallOperator::Locator`) whose
+// closure outputs ExternalRecord is rejected at V14+ runtime. This covers the Locator branch of
+// `has_forbidden_output`, where the closure lives in a different program and is referenced by
+// `call other_program.aleo/closure_name` syntax.
+#[test]
+fn test_pre_v14_cross_program_closure_forbidden_output_rejected_at_v14_runtime() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+    let caller_view_key = ViewKey::try_from(&caller_private_key)?;
+
+    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
+    let vm = sample_vm_at_height(12, rng);
+
+    // Parent program defines the record.
+    let parent_program = Program::from_str(
+        r"
+        program locator_parent.aleo;
+
+        record widget:
+            owner as address.private;
+            amount as u64.private;
+
+        function mint_widget:
+            input r0 as address.private;
+            input r1 as u64.private;
+            cast r0 r1 into r2 as widget.record;
+            output r2 as widget.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Lib program imports parent and defines a closure that passes an ExternalRecord through as
+    // an output. This is allowed at pre-V14 but forbidden at V14+. A dummy function is required
+    // because programs must have at least one function.
+    let lib_program = Program::from_str(
+        r"
+        import locator_parent.aleo;
+
+        program locator_lib.aleo;
+
+        closure passthrough_widget:
+            input r0 as locator_parent.aleo/widget.record;
+            assert.eq true true;
+            output r0 as locator_parent.aleo/widget.record;
+
+        function noop:
+            input r0 as u64.public;
+            output r0 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Caller program imports both and calls the closure from locator_lib.aleo via a Locator
+    // (`call locator_lib.aleo/passthrough_widget`), creating a `CallOperator::Locator`.
+    let caller_program = Program::from_str(
+        r"
+        import locator_parent.aleo;
+        import locator_lib.aleo;
+
+        program locator_caller.aleo;
+
+        function use_external_closure:
+            input r0 as locator_parent.aleo/widget.record;
+            call locator_lib.aleo/passthrough_widget r0 into r1;
+            output r1 as locator_parent.aleo/widget.record;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    // Deploy all three programs before V14. All deployments must be accepted.
+    let tx = vm.deploy(&caller_private_key, &parent_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    let tx = vm.deploy(&caller_private_key, &lib_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    let tx = vm.deploy(&caller_private_key, &caller_program, None, 0, None, rng)?;
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Mint a widget to use as input.
+    let tx = vm.execute(
+        &caller_private_key,
+        ("locator_parent.aleo", "mint_widget"),
+        [Value::from_str(&caller_address.to_string())?, Value::from_str("42u64")?].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    )?;
+    let widget_record = match &tx.transitions().next().unwrap().outputs()[0] {
+        Output::Record(_, _, ct, _) => ct.as_ref().unwrap().decrypt(&caller_view_key)?,
+        _ => panic!("expected record output"),
+    };
+    add_and_test(&vm, &caller_private_key, &[tx], rng);
+
+    // Advance to V14 (height 17) by adding empty blocks.
+    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?;
+    for _ in vm.block_store().current_block_height()..v14_height {
+        let block = sample_next_block(&vm, &caller_private_key, &[], rng)?;
+        vm.add_next_block(&block)?;
+    }
+
+    // At V14+, executing `use_external_closure` must fail: the runtime `has_forbidden_output`
+    // check (Locator branch) detects that `locator_lib.aleo/passthrough_widget` outputs
+    // ExternalRecord and rejects the execution.
+    let result = vm.execute(
+        &caller_private_key,
+        ("locator_caller.aleo", "use_external_closure"),
+        [Value::<CurrentNetwork>::Record(widget_record)].into_iter(),
+        None,
+        0,
+        None,
+        rng,
+    );
+
+    assert!(
+        result.is_err(),
+        "Execution must fail: pre-V14 cross-program closure (Locator) outputting ExternalRecord is disallowed at V14+"
+    );
+
+    Ok(())
+}
+
 // Tests that a closure outputting a DynamicRecord is rejected at V14+ deployment.
 // The program parses successfully, but `verify_deployment` (called during block production)
 // rejects it at V14+ because `ensure_records_exist` assumes closures cannot extend record families.

--- a/synthesizer/src/vm/tests/test_v14/closure_records.rs
+++ b/synthesizer/src/vm/tests/test_v14/closure_records.rs
@@ -138,9 +138,11 @@ fn test_closure_record_output_rejected() {
     assert!(result.is_err(), "Program with record output from closure should fail to parse");
 }
 
-// Tests that a closure can accept an external record as input and read its fields.
+// Tests that a function whose only use of an ExternalRecord input is passing it to a closure
+// is rejected by the record-existence check at V14+. The ExternalRecord creates an unresolved
+// family because closures cannot provide existence verification.
 #[test]
-fn test_closure_external_record_input() -> Result<()> {
+fn test_closure_external_record_input_only_rejected_at_v14() -> Result<()> {
     let rng = &mut TestRng::default();
 
     let caller_private_key = sample_genesis_private_key(rng);
@@ -168,6 +170,8 @@ fn test_closure_external_record_input() -> Result<()> {
     )?;
 
     // Child program imports parent and has a closure taking the external record.
+    // The function only passes the ExternalRecord to a closure — it never consumes it
+    // via a function call boundary, so the record-existence check cannot verify it.
     let child_program = Program::from_str(
         r"
         import closure_ext_parent.aleo;
@@ -216,7 +220,8 @@ fn test_closure_external_record_input() -> Result<()> {
 
     add_and_test(&vm, &caller_private_key, &[transaction], rng);
 
-    // Execute the child function with the external record.
+    // Execute the child function with the external record. The transaction is created
+    // successfully but will be rejected during verification.
     let transaction = vm.execute(
         &caller_private_key,
         ("closure_ext_child.aleo", "extract_external_value"),
@@ -227,14 +232,15 @@ fn test_closure_external_record_input() -> Result<()> {
         rng,
     )?;
 
-    // Verify the public output matches the expected value.
-    let expected = Plaintext::from_str("99u32")?;
-    match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
-        other => panic!("Expected public output, got: {other:?}"),
-    }
-
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+    // The transaction should be aborted: the ExternalRecord input creates an unresolved
+    // family because the closure cannot provide record-existence verification.
+    let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
+    assert_eq!(
+        block.transactions().num_accepted(),
+        0,
+        "ExternalRecord used only in closure should fail existence check"
+    );
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
 
     Ok(())
 }
@@ -431,11 +437,8 @@ fn test_closure_cannot_contain_call() {
     assert!(result.is_err(), "A closure containing a `call` instruction should be rejected at deployment");
 }
 
-// Tests that the existence check is NOT bypassed when an ExternalRecord is cast to a
-// DynamicRecord and then only used in a closure. The `retain()` logic auto-resolves
-// families whose only member is an ExternalRecord root (the inclusion-proof case), but
-// once a cast creates an additional DynamicRecord member the family must still be
-// verified through a function call. This is the closure analog of Antonio's test 4.1.
+// Tests that the existence check rejects an ExternalRecord cast to DynamicRecord and then
+// only used in a closure. The family is never resolved through a function call boundary.
 #[test]
 fn test_external_record_cast_to_dynamic_then_closure_fails_existence_check() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -478,8 +481,7 @@ fn test_external_record_cast_to_dynamic_then_closure_fails_existence_check() -> 
             output r1 as u32;
 
         // Receives an ExternalRecord, casts it to DynamicRecord, and passes it only
-        // to a closure. The ExternalRecord->DynamicRecord cast creates a two-member
-        // family that cannot be auto-resolved; the closure cannot resolve it either.
+        // to a closure. The family is never resolved through a function call.
         function read_gem_via_cast_and_closure:
             input r0 as cast_dyn_parent.aleo/gem.record;
             cast r0 into r1 as dynamic.record;
@@ -515,9 +517,8 @@ fn test_external_record_cast_to_dynamic_then_closure_fails_existence_check() -> 
     add_and_test(&vm, &caller_private_key, &[tx], rng);
 
     // Execute the child function. The ExternalRecord is cast to DynamicRecord and passed only
-    // to a closure. The existence check must reject this because the DynamicRecord family
-    // was extended by the cast (so `retain()` does not auto-resolve it) and the closure
-    // cannot provide the function-call verification needed to resolve it.
+    // to a closure. The existence check rejects this because the family is never resolved
+    // through a function call boundary.
     let result = vm.execute(
         &caller_private_key,
         ("cast_dyn_child.aleo", "read_gem_via_cast_and_closure"),
@@ -536,19 +537,17 @@ fn test_external_record_cast_to_dynamic_then_closure_fails_existence_check() -> 
     Ok(())
 }
 
-// Tests V14 backward compatibility: a program with a closure that accepts an ExternalRecord as
-// input (but does NOT output it) can be deployed before V14 and executed correctly at V14+.
-// This is the happy-path counterpart to `test_closure_external_record_output_rejected_at_v14`.
+// Tests that a pre-V14 program whose closure accepts an ExternalRecord as input (but does NOT
+// output it) is rejected at V14+ by the record-existence check. The ExternalRecord creates an
+// unresolved family because closures cannot provide existence verification.
 #[test]
-fn test_pre_v14_closure_external_record_input_works_at_v14() -> Result<()> {
+fn test_pre_v14_closure_external_record_input_only_rejected_at_v14() -> Result<()> {
     let rng = &mut TestRng::default();
     let caller_private_key = sample_genesis_private_key(rng);
     let caller_address = Address::try_from(&caller_private_key)?;
     let caller_view_key = ViewKey::try_from(&caller_private_key)?;
 
-    // Start at V9 (height 12 in the test schedule), which uses Varuna V2 (consistent with V14's
-    // proof system) and supports constructor syntax, but is before V14 (height 17). At this height
-    // the deployment-time closure-output restriction does not yet apply.
+    // Start at V9 (height 12), before the V14 closure-output restriction (height 17).
     let vm = sample_vm_at_height(12, rng);
 
     // Parent defines the record.
@@ -571,8 +570,8 @@ fn test_pre_v14_closure_external_record_input_works_at_v14() -> Result<()> {
         ",
     )?;
 
-    // Child has a closure that accepts an ExternalRecord as input and extracts a field value,
-    // producing a plain u64. The closure does not output a record.
+    // Child has a closure that accepts an ExternalRecord as input and extracts a field value.
+    // The function only passes the ExternalRecord to the closure — never to a function call.
     let child_program = Program::from_str(
         r"
         import closure_legacy_parent.aleo;
@@ -614,12 +613,11 @@ fn test_pre_v14_closure_external_record_input_works_at_v14() -> Result<()> {
     let gem_record = decrypt_first_record(&mint_tx, &caller_view_key);
     add_and_test(&vm, &caller_private_key, &[mint_tx], rng);
 
-    // Advance to V14 (height 17 in the test schedule) by adding empty blocks.
+    // Advance to V14.
     advance_to_v14(&vm, &caller_private_key, rng)?;
 
-    // At V14+, executing a function that calls a closure with an ExternalRecord *input* (but no
-    // record output) must succeed. The closure only reads a field, so `ensure_records_exist` has
-    // nothing to validate — no record family is extended.
+    // Execute the function. The transaction is created but rejected during verification:
+    // the ExternalRecord input creates an unresolved family (closures cannot verify existence).
     let transaction = vm.execute(
         &caller_private_key,
         ("closure_legacy_child.aleo", "use_gem_closure"),
@@ -630,14 +628,13 @@ fn test_pre_v14_closure_external_record_input_works_at_v14() -> Result<()> {
         rng,
     )?;
 
-    // Verify the public output equals the minted amount.
-    let expected = Plaintext::from_str("77u64")?;
-    match &transaction.transitions().next().unwrap().outputs()[0] {
-        Output::Public(_, Some(plaintext)) => assert_eq!(*plaintext, expected),
-        other => panic!("Expected public output, got: {other:?}"),
-    }
-
-    add_and_test(&vm, &caller_private_key, &[transaction], rng);
+    let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
+    assert_eq!(
+        block.transactions().num_accepted(),
+        0,
+        "ExternalRecord used only in closure should fail existence check at V14+"
+    );
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
 
     Ok(())
 }

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -297,6 +297,24 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     let stack = Stack::new(&self.process().read(), deployment.program())?;
                     check_future_argument_bit_size(deployment.program(), &stack, u16::MAX as usize)?;
                 }
+                if consensus_version >= ConsensusVersion::V14 {
+                    // At V14+, closures must not output records.
+                    use console::program::RegisterType;
+                    for closure in deployment.program().closures().values() {
+                        for output in closure.outputs() {
+                            ensure!(
+                                !matches!(
+                                    output.register_type(),
+                                    RegisterType::Record(..)
+                                        | RegisterType::ExternalRecord(..)
+                                        | RegisterType::DynamicRecord
+                                ),
+                                "Invalid deployment transaction '{id}' - closure '{}' outputs a record type, which is not allowed at `ConsensusVersion::V14` or later",
+                                closure.name()
+                            );
+                        }
+                    }
+                }
 
                 // Determine if any of the array types exceed the maximum array elements.
                 // Do not perform this check if the consensus version is beyond the latest version threshold for `MAX_ARRAY_ELEMENTS`.


### PR DESCRIPTION
This PR restricts closure outputs from being `Record`, `ExternalRecord`, or `DynamicRecord`s. There are no closures on-chain that output these types and allowing them complicates analysis/execution of programs.