### PR TITLE
[Fix] Reduce locking around the Process

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -98,21 +98,30 @@ fn check_locktick_imports<P: AsRef<Path>>(path: P) {
 
             // Modify the lock balance based on the type of the relevant import.
             if [ImportOfInterest::ParkingLot, ImportOfInterest::Tokio].contains(&ioi) {
-                if line.contains("Mutex") {
-                    lock_balance += 1;
+                lock_balance += line.matches("Mutex").count() as i8;
+                lock_balance += line.matches("RwLock").count() as i8;
+
+                // A correction in case of the `use tokio::Mutex as TMutex` convention.
+                if line.contains("TMutex") {
+                    lock_balance -= 1;
                 }
-                if line.contains("RwLock") {
-                    lock_balance += 1;
+
+                // Account for lock guards, which do not have a locktick counterpart.
+                if line.contains("MutexGuard") {
+                    lock_balance -= 1;
+                }
+                if line.contains("RwLockReadGuard") {
+                    lock_balance -= 1;
+                }
+                if line.contains("RwLockWriteGuard") {
+                    lock_balance -= 1;
                 }
             } else if ioi == ImportOfInterest::Locktick {
                 // Use `matches` instead of just `contains` here, as more than a single
                 // lock type entry is possible in a locktick import.
-                for _hit in line.matches("Mutex") {
-                    lock_balance -= 1;
-                }
-                for _hit in line.matches("RwLock") {
-                    lock_balance -= 1;
-                }
+                lock_balance -= line.matches("Mutex").count() as i8;
+                lock_balance -= line.matches("RwLock").count() as i8;
+
                 // A correction in case of the `use tokio::Mutex as TMutex` convention.
                 if line.contains("TMutex") {
                     lock_balance += 1;

--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -263,7 +263,7 @@ function main:
         let inputs = [Value::from_str("2group").unwrap()].into_iter();
 
         // Add the program to the VM.
-        vm.process().add_program(&program).unwrap();
+        vm.process().lock().add_program(&program).unwrap();
 
         // Create an execution transaction that is 164613 bytes in size.
         let transaction = vm.execute(&private_key, ("too_big.aleo", "main"), inputs, None, 0, None, rng).unwrap();

--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -263,7 +263,7 @@ function main:
         let inputs = [Value::from_str("2group").unwrap()].into_iter();
 
         // Add the program to the VM.
-        vm.process().write().add_program(&program).unwrap();
+        vm.process().add_program(&program).unwrap();
 
         // Create an execution transaction that is 164613 bytes in size.
         let transaction = vm.execute(&private_key, ("too_big.aleo", "main"), inputs, None, 0, None, rng).unwrap();

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -85,7 +85,7 @@ fn create_cache_key(
     // Get the program editions.
     let program_editions = transaction
         .transitions()
-        .map(|transition| vm.process().read().get_stack(transition.program_id()).map(|stack| stack.program_edition()))
+        .map(|transition| vm.process().get_stack(transition.program_id()).map(|stack| stack.program_edition()))
         .collect::<Result<Vec<_>>>()
         .unwrap();
     // Return the cache key.
@@ -2666,7 +2666,7 @@ function foo:
             };
             let deployment = deployment_tx.deployment().unwrap().clone();
             for _ in 0..ITERATIONS {
-                let result = match try_vm_runtime!(|| process.read().verify_deployment::<CurrentAleo, _>(
+                let result = match try_vm_runtime!(|| process.verify_deployment::<CurrentAleo, _>(
                     ConsensusVersion::V8,
                     &deployment,
                     rng

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -581,7 +581,7 @@ pub fn sample_large_execution_transaction(rng: &mut TestRng) -> Transaction<Curr
             let program = large_transaction_program();
 
             // Construct the process.
-            let mut process = snarkvm_synthesizer_process::Process::load().unwrap();
+            let process = snarkvm_synthesizer_process::Process::load().unwrap();
             // Add the program.
             process.add_program(&program).unwrap();
 

--- a/ledger/test-helpers/src/lib.rs
+++ b/ledger/test-helpers/src/lib.rs
@@ -583,7 +583,7 @@ pub fn sample_large_execution_transaction(rng: &mut TestRng) -> Transaction<Curr
             // Construct the process.
             let process = snarkvm_synthesizer_process::Process::load().unwrap();
             // Add the program.
-            process.add_program(&program).unwrap();
+            process.lock().add_program(&program).unwrap();
 
             // Initialize a private key.
             let private_key = PrivateKey::new(rng).unwrap();

--- a/synthesizer/process/benches/stack_operations.rs
+++ b/synthesizer/process/benches/stack_operations.rs
@@ -150,7 +150,7 @@ fn add_program_at_depth(process: &mut Process<CurrentNetwork>, depth: usize) {
     };
 
     // Add the program to the process.
-    process.add_program(&program).unwrap();
+    process.lock().add_program(&program).unwrap();
 }
 
 // Samples a random identifier as a string.

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -1556,7 +1556,7 @@ finalize call_child:
 
         // Build the process with both programs
         let mut process = crate::test_helpers::sample_process(&child_program);
-        process.add_program(&caller_program).unwrap();
+        process.lock().add_program(&caller_program).unwrap();
 
         let function_name = Identifier::from_str("call_child").unwrap();
 
@@ -1729,9 +1729,9 @@ finalize main:
 
         // Build the process with all programs
         let mut process = crate::test_helpers::sample_process(&leaf_program);
-        process.add_program(&level1_a_program).unwrap();
-        process.add_program(&level1_b_program).unwrap();
-        process.add_program(&root_program).unwrap();
+        process.lock().add_program(&level1_a_program).unwrap();
+        process.lock().add_program(&level1_b_program).unwrap();
+        process.lock().add_program(&root_program).unwrap();
 
         let function_name = Identifier::from_str("main").unwrap();
 

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -85,7 +85,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Insert the verifying keys");
 
         // Add the stack to the process.
-        self.add_stack(stack);
+        self.lock().add_stack(stack);
 
         finish!(timer);
 

--- a/synthesizer/process/src/deploy.rs
+++ b/synthesizer/process/src/deploy.rs
@@ -42,7 +42,7 @@ impl<N: Network> Process<N> {
     /// Adds the newly-deployed program.
     /// This method assumes the given deployment **is valid**.
     #[inline]
-    pub fn load_deployment(&mut self, deployment: &Deployment<N>) -> Result<()> {
+    pub fn load_deployment(&self, deployment: &Deployment<N>) -> Result<()> {
         let timer = timer!("Process::load_deployment");
 
         // Get the deployment version.

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -20,7 +20,7 @@ use snarkvm_utilities::try_vm_runtime;
 
 use std::collections::HashSet;
 
-impl<N: Network> Process<N> {
+impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
     /// Finalizes the deployment and fee.
     /// This method assumes the given deployment **is valid**.
     /// This method should **only** be called by `VM::finalize()`.
@@ -41,7 +41,7 @@ impl<N: Network> Process<N> {
         match version {
             DeploymentVersion::V1 | DeploymentVersion::V2 => {
                 // Compute the program stack.
-                let mut stack = Stack::new(self, deployment.program())?;
+                let mut stack = Stack::new(self.process, deployment.program())?;
                 lap!(timer, "Compute the stack");
 
                 // Set the program owner.
@@ -58,7 +58,7 @@ impl<N: Network> Process<N> {
                     true => deployment.program().mappings().values().collect::<Vec<_>>(),
                     false => {
                         // Get the existing stack.
-                        let existing_stack = self.get_stack(deployment.program_id())?;
+                        let existing_stack = self.process.get_stack(deployment.program_id())?;
                         // Get the existing mappings.
                         let existing_mappings = existing_stack.program().mappings();
                         // Determine and return the new mappings
@@ -81,7 +81,7 @@ impl<N: Network> Process<N> {
                     /* Finalize the fee. */
 
                     // Retrieve the fee stack.
-                    let fee_stack = self.get_stack(fee.program_id())?;
+                    let fee_stack = self.process.get_stack(fee.program_id())?;
                     // Finalize the fee transition.
                     finalize_operations.extend(finalize_fee_transition(state, store, &fee_stack, fee)?);
                     lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -118,13 +118,13 @@ impl<N: Network> Process<N> {
                 );
 
                 // Get the existing stack.
-                let existing_stack = self.get_stack(deployment.program_id())?;
+                let existing_stack = self.process.get_stack(deployment.program_id())?;
 
                 // Compute a new stack with the same program and edition.
                 // Note: `Stack::new` cannot be used here because it would increment the edition.
                 // Amendments must preserve the existing edition. Validity is verified by `initialize_and_check`.
-                let mut stack = Stack::new_raw(self, deployment.program(), *existing_stack.program_edition())?;
-                stack.initialize_and_check(self)?;
+                let mut stack = Stack::new_raw(self.process, deployment.program(), *existing_stack.program_edition())?;
+                stack.initialize_and_check(self.process)?;
                 lap!(timer, "Compute the stack");
 
                 // Set the program owner to the existing owner.
@@ -141,7 +141,7 @@ impl<N: Network> Process<N> {
                     let mut finalize_operations = Vec::new();
 
                     // Retrieve the fee stack.
-                    let fee_stack = self.get_stack(fee.program_id())?;
+                    let fee_stack = self.process.get_stack(fee.program_id())?;
                     // Finalize the fee transition.
                     finalize_operations.extend(finalize_fee_transition(state, store, &fee_stack, fee)?);
                     lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -173,7 +173,7 @@ impl<N: Network> Process<N> {
         // Retrieve the root transition (without popping it).
         let transition = execution.peek()?;
         // Retrieve the stack.
-        let stack = self.get_stack(transition.program_id())?;
+        let stack = self.process.get_stack(transition.program_id())?;
         // Calculate the minimum number of calls for the root transition.
         let minimum_number_of_calls = stack.get_minimum_number_of_calls(transition.function_name())?;
         // If the root transition contains a dynamic call,
@@ -217,7 +217,7 @@ impl<N: Network> Process<N> {
         // Construct the call graph.
         let consensus_version = N::CONSENSUS_VERSION(state.block_height())?;
         let call_graph = match (ConsensusVersion::V1..=ConsensusVersion::V2).contains(&consensus_version) {
-            true => self.construct_call_graph(execution.transitions())?,
+            true => self.process.construct_call_graph(execution.transitions())?,
             // If the height is greater than or equal to `ConsensusVersion::V3`, then provide an empty call graph, as it is no longer used during finalization.
             false => HashMap::new(),
         };
@@ -232,7 +232,7 @@ impl<N: Network> Process<N> {
             /* Finalize the fee. */
             if let Some(fee) = fee {
                 // Retrieve the fee stack.
-                let fee_stack = self.get_stack(fee.program_id())?;
+                let fee_stack = self.process.get_stack(fee.program_id())?;
                 // Finalize the fee transition.
                 finalize_operations.extend(finalize_fee_transition(state, store, &fee_stack, fee)?);
                 lap!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -258,7 +258,7 @@ impl<N: Network> Process<N> {
 
         atomic_batch_scope!(store, {
             // Retrieve the stack.
-            let stack = self.get_stack(fee.program_id())?;
+            let stack = self.process.get_stack(fee.program_id())?;
             // Finalize the fee transition.
             let result = finalize_fee_transition(state, store, &stack, fee);
             finish!(timer, "Finalize transition for '{}/{}'", fee.program_id(), fee.function_name());
@@ -769,9 +769,9 @@ function compute:
         let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
         // Finalize the deployment.
         let (stack, _) =
-            process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+            process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
         // Add the stack *manually* to the process.
-        process.add_stack(stack);
+        process.lock().add_stack(stack);
 
         // Ensure the program exists.
         assert!(process.contains_program(program.id()));

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -753,7 +753,7 @@ function compute:
         .unwrap();
 
         // Initialize a new process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Deploy the program.
         let deployment = process.deploy::<CurrentAleo, _>(&program, rng).unwrap();
 

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -112,6 +112,133 @@ pub struct Process<N: Network> {
     lock: Mutex<()>,
 }
 
+/// A wrapper ensuring exclusive access to the Process for the purposes of add_stacks.
+pub struct ProcessExclusiveGuard<'a, N: Network> {
+    process: &'a Process<N>,
+    #[cfg(not(feature = "locktick"))]
+    _guard: MutexGuard<'a, ()>,
+    #[cfg(feature = "locktick")]
+    _guard: LockGuard<MutexGuard<'a, ()>>,
+}
+
+impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
+    /// Adds a new stack to the process.
+    /// If the program already exists, then the existing stack is replaced and the original stack is returned.
+    /// Note. This method assumes that the provided stack is valid.
+    #[inline]
+    pub fn add_stack(&self, stack: Stack<N>) -> Option<Arc<Stack<N>>> {
+        // Get the program ID.
+        let program_id = *stack.program_id();
+        // Arc the stack first to limit the scope of the write lock.
+        let stack = Arc::new(stack);
+        // Insert the stack into the process, replacing the existing stack if it exists.
+        self.process.stacks.write().insert(program_id, stack)
+    }
+
+    /// Stages a stack to be added to the process.
+    /// The new stack is active, while the old stack is retained in `old_stacks`.
+    /// The `commit_stacks` method must be called to finalize the addition of the new stack.
+    /// The `revert_stacks` method can be called to revert the staged stacks.
+    #[inline]
+    pub fn stage_stack(&self, stack: Stack<N>) {
+        // Get the program ID.
+        let program_id = *stack.program_id();
+        // Arc the stack first to limit the scope of the write lock.
+        let stack = Arc::new(stack);
+        // If no entry in `old_stacks` exists for `program_id`, store the old stack.
+        // Note: If `old_stack` is `None`, it means that we are adding a new program to the process.
+        let old_stack = self.process.stacks.write().insert(program_id, stack);
+        let mut old_stacks = self.process.old_stacks.write();
+        if !old_stacks.contains_key(&program_id) {
+            old_stacks.insert(program_id, old_stack);
+        }
+    }
+
+    /// Commits the staged stacks to the process.
+    /// This finalizes the addition of the new stacks and clears the old stacks.
+    #[inline]
+    pub fn commit_stacks(&self) {
+        // Clear the old stacks.
+        self.process.old_stacks.write().clear();
+    }
+
+    /// Reverts the staged stacks, restoring the previous state of the process.
+    /// This will remove the new stacks and restore the old stacks.
+    #[inline]
+    pub fn revert_stacks(&self) {
+        // Restore the old stacks.
+        for (program_id, stack) in self.process.old_stacks.write().drain(..) {
+            // If the stack is `None`, remove the program from the process.
+            // Otherwise, insert the old stack back into the process.
+            if let Some(stack) = stack {
+                self.process.stacks.write().insert(program_id, stack);
+            } else {
+                self.process.stacks.write().shift_remove(&program_id);
+            }
+        }
+    }
+
+    /// Adds a new program to the process, verifying that it is a valid addition.
+    /// If the program exists, then the existing stack is replaced and discarded.
+    /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
+    #[inline]
+    pub fn add_program(&self, program: &Program<N>) -> Result<()> {
+        // Initialize the 'credits.aleo' program ID.
+        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
+        // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
+        if program.id() != &credits_program_id {
+            self.add_stack(Stack::new(self.process, program)?);
+        }
+        Ok(())
+    }
+
+    /// Adds a new program with the given edition to the process, verifying that it is a valid addition.
+    /// If the program exists, then the existing stack is replaced and discarded.
+    /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
+    #[inline]
+    pub fn add_program_with_edition(&self, program: &Program<N>, edition: u16) -> Result<()> {
+        // Initialize the 'credits.aleo' program ID.
+        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
+        // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
+        if program.id() != &credits_program_id {
+            let stack = Stack::new_raw(self.process, program, edition)?;
+            stack.initialize_and_check(self.process)?;
+            self.add_stack(stack);
+        }
+        Ok(())
+    }
+
+    /// Adds a set of programs and editions, in topological order, to the process, deferring validation of the programs until all programs are added.
+    /// If a program exists, then the existing stack is replaced and discarded.
+    /// Either all programs are added or none are.
+    /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
+    #[inline]
+    pub fn add_programs_with_editions(&self, programs: &[(Program<N>, u16)]) -> Result<()> {
+        // Initialize the 'credits.aleo' program ID.
+        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
+        // Defer cleanup of the uncommitted stacks.
+        defer! {
+            self.revert_stacks()
+        }
+        // Initialize raw stacks for each of the programs, skipping `credits.aleo`.
+        for (program, edition) in programs {
+            if program.id() != &credits_program_id {
+                self.stage_stack(Stack::new_raw(self.process, program, *edition)?)
+            }
+        }
+        // For each stack, check and initialize it before adding it to the process.
+        for (program, _) in programs {
+            // Retrieve the stack.
+            let stack = self.process.get_stack(program.id())?;
+            // Initialize and check the stack for well-formedness.
+            stack.initialize_and_check(self.process)?;
+        }
+        // Commit the staged stacks.
+        self.commit_stacks();
+        Ok(())
+    }
+}
+
 impl<N: Network> Process<N> {
     /// Initializes a new process.
     #[inline]
@@ -146,7 +273,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Synthesize credits program keys");
 
         // Add the 'credits.aleo' stack to the process.
-        process.add_stack(stack);
+        process.lock().add_stack(stack);
 
         finish!(timer);
         // Return the process.
@@ -154,71 +281,8 @@ impl<N: Network> Process<N> {
     }
 
     /// Guard the Process against any concurrent reads or writes.
-    #[cfg(feature = "locktick")]
-    pub fn lock(&self) -> LockGuard<MutexGuard<()>> {
-        self.lock.lock()
-    }
-
-    /// Guard the Process against any concurrent reads or writes.
-    #[cfg(not(feature = "locktick"))]
-    pub fn lock(&self) -> MutexGuard<()> {
-        self.lock.lock()
-    }
-
-    /// Adds a new stack to the process.
-    /// If the program already exists, then the existing stack is replaced and the original stack is returned.
-    /// Note. This method assumes that the provided stack is valid.
-    #[inline]
-    pub fn add_stack(&self, stack: Stack<N>) -> Option<Arc<Stack<N>>> {
-        // Get the program ID.
-        let program_id = *stack.program_id();
-        // Arc the stack first to limit the scope of the write lock.
-        let stack = Arc::new(stack);
-        // Insert the stack into the process, replacing the existing stack if it exists.
-        self.stacks.write().insert(program_id, stack)
-    }
-
-    /// Stages a stack to be added to the process.
-    /// The new stack is active, while the old stack is retained in `old_stacks`.
-    /// The `commit_stacks` method must be called to finalize the addition of the new stack.
-    /// The `revert_stacks` method can be called to revert the staged stacks.
-    #[inline]
-    pub fn stage_stack(&self, stack: Stack<N>) {
-        // Get the program ID.
-        let program_id = *stack.program_id();
-        // Arc the stack first to limit the scope of the write lock.
-        let stack = Arc::new(stack);
-        // If no entry in `old_stacks` exists for `program_id`, store the old stack.
-        // Note: If `old_stack` is `None`, it means that we are adding a new program to the process.
-        let old_stack = self.stacks.write().insert(program_id, stack);
-        let mut old_stacks = self.old_stacks.write();
-        if !old_stacks.contains_key(&program_id) {
-            old_stacks.insert(program_id, old_stack);
-        }
-    }
-
-    /// Commits the staged stacks to the process.
-    /// This finalizes the addition of the new stacks and clears the old stacks.
-    #[inline]
-    pub fn commit_stacks(&self) {
-        // Clear the old stacks.
-        self.old_stacks.write().clear();
-    }
-
-    /// Reverts the staged stacks, restoring the previous state of the process.
-    /// This will remove the new stacks and restore the old stacks.
-    #[inline]
-    pub fn revert_stacks(&self) {
-        // Restore the old stacks.
-        for (program_id, stack) in self.old_stacks.write().drain(..) {
-            // If the stack is `None`, remove the program from the process.
-            // Otherwise, insert the old stack back into the process.
-            if let Some(stack) = stack {
-                self.stacks.write().insert(program_id, stack);
-            } else {
-                self.stacks.write().shift_remove(&program_id);
-            }
-        }
+    pub fn lock(&self) -> ProcessExclusiveGuard<'_, N> {
+        ProcessExclusiveGuard { process: self, _guard: self.lock.lock() }
     }
 
     /// Ensure that the types referred to in this program's mappings exist.
@@ -296,7 +360,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Load circuit keys");
 
         // Add the stack to the process.
-        process.add_stack(stack);
+        process.lock().add_stack(stack);
 
         finish!(timer, "Process::load");
         // Return the process.
@@ -340,7 +404,7 @@ impl<N: Network> Process<N> {
         lap!(timer, "Load circuit keys");
 
         // Add the stack to the process.
-        process.add_stack(stack);
+        process.lock().add_stack(stack);
 
         finish!(timer, "Process::load_v0");
         // Return the process.
@@ -366,70 +430,10 @@ impl<N: Network> Process<N> {
         let stack = Stack::new(&process, &program)?;
 
         // Add the stack to the process.
-        process.add_stack(stack);
+        process.lock().add_stack(stack);
 
         // Return the process.
         Ok(process)
-    }
-
-    /// Adds a new program to the process, verifying that it is a valid addition.
-    /// If the program exists, then the existing stack is replaced and discarded.
-    /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
-    #[inline]
-    pub fn add_program(&self, program: &Program<N>) -> Result<()> {
-        // Initialize the 'credits.aleo' program ID.
-        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
-        // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
-        if program.id() != &credits_program_id {
-            self.add_stack(Stack::new(self, program)?);
-        }
-        Ok(())
-    }
-
-    /// Adds a new program with the given edition to the process, verifying that it is a valid addition.
-    /// If the program exists, then the existing stack is replaced and discarded.
-    /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
-    #[inline]
-    pub fn add_program_with_edition(&self, program: &Program<N>, edition: u16) -> Result<()> {
-        // Initialize the 'credits.aleo' program ID.
-        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
-        // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
-        if program.id() != &credits_program_id {
-            let stack = Stack::new_raw(self, program, edition)?;
-            stack.initialize_and_check(self)?;
-            self.add_stack(stack);
-        }
-        Ok(())
-    }
-
-    /// Adds a set of programs and editions, in topological order, to the process, deferring validation of the programs until all programs are added.
-    /// If a program exists, then the existing stack is replaced and discarded.
-    /// Either all programs are added or none are.
-    /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
-    #[inline]
-    pub fn add_programs_with_editions(&self, programs: &[(Program<N>, u16)]) -> Result<()> {
-        // Initialize the 'credits.aleo' program ID.
-        let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
-        // Defer cleanup of the uncommitted stacks.
-        defer! {
-            self.revert_stacks()
-        }
-        // Initialize raw stacks for each of the programs, skipping `credits.aleo`.
-        for (program, edition) in programs {
-            if program.id() != &credits_program_id {
-                self.stage_stack(Stack::new_raw(self, program, *edition)?)
-            }
-        }
-        // For each stack, check and initialize it before adding it to the process.
-        for (program, _) in programs {
-            // Retrieve the stack.
-            let stack = self.get_stack(program.id())?;
-            // Initialize and check the stack for well-formedness.
-            stack.initialize_and_check(self)?;
-        }
-        // Commit the staged stacks.
-        self.commit_stacks();
-        Ok(())
     }
 
     /// Returns the universal SRS.
@@ -584,7 +588,7 @@ pub mod test_helpers {
 
         // Add the program to the process if doesn't yet exist.
         if !process.contains_program(program.id()) {
-            process.add_program(program).unwrap();
+            process.lock().add_program(program).unwrap();
         }
 
         // Compute the authorization.
@@ -719,7 +723,7 @@ function compute:
         // Construct a new process.
         let process = Process::load().unwrap();
         // Add the program to the process.
-        process.add_program(program).unwrap();
+        process.lock().add_program(program).unwrap();
         // Return the process.
         process
     }

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -225,6 +225,32 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
         self.commit_stacks();
         Ok(())
     }
+
+    /// Update the `credits.aleo` program in the VM with the latest verifying keys.
+    pub fn update_credits_verifying_keys(&self) -> Result<()> {
+        // Initialize the store for 'credits.aleo'.
+        let credits = Program::<N>::credits()?;
+
+        // Synthesize the 'credits.aleo' verifying keys.
+        for function_name in credits.functions().keys() {
+            // Remove the proving key.
+            self.process.remove_proving_key(credits.id(), function_name)?;
+            // Load the verifying key.
+            let verifying_key = N::get_credits_verifying_key(function_name.to_string())?;
+            // Retrieve the number of public and private variables.
+            // Note: This number does *NOT* include the number of constants. This is safe because
+            // this program is never deployed, as it is a first-class citizen of the protocol.
+            let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
+            // Insert the verifying key.
+            self.process.insert_verifying_key(
+                credits.id(),
+                function_name,
+                VerifyingKey::new(verifying_key.clone(), num_variables),
+            )?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<N: Network> Process<N> {

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -105,8 +105,8 @@ pub struct Process<N: Network> {
     universal_srs: UniversalSRS<N>,
     /// The mapping of program IDs to stacks.
     stacks: Arc<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>>,
-    /// The mapping of program IDs to old stacks.
-    old_stacks: RwLock<IndexMap<ProgramID<N>, Option<Arc<Stack<N>>>>>,
+    /// The mapping of program IDs to new, pending stacks.
+    new_stacks: RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>,
     /// A lock guarding the entire Process in case no concurrent reads or writes
     /// on the object are to be permitted.
     lock: Mutex<()>,
@@ -136,46 +136,34 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
     }
 
     /// Stages a stack to be added to the process.
-    /// The new stack is active, while the old stack is retained in `old_stacks`.
+    /// The new stack is pending in `new_stacks`.
     /// The `commit_stacks` method must be called to finalize the addition of the new stack.
-    /// The `revert_stacks` method can be called to revert the staged stacks.
+    /// The `cancel_staged_stacks` method can be called to revert the staged stacks.
     #[inline]
     pub fn stage_stack(&self, stack: Stack<N>) {
         // Get the program ID.
         let program_id = *stack.program_id();
         // Arc the stack first to limit the scope of the write lock.
         let stack = Arc::new(stack);
-        // If no entry in `old_stacks` exists for `program_id`, store the old stack.
-        // Note: If `old_stack` is `None`, it means that we are adding a new program to the process.
-        let old_stack = self.process.stacks.write().insert(program_id, stack);
-        let mut old_stacks = self.process.old_stacks.write();
-        if !old_stacks.contains_key(&program_id) {
-            old_stacks.insert(program_id, old_stack);
-        }
+        self.process.new_stacks.write().insert(program_id, stack);
     }
 
     /// Commits the staged stacks to the process.
-    /// This finalizes the addition of the new stacks and clears the old stacks.
+    /// This finalizes the addition of the new stacks.
     #[inline]
     pub fn commit_stacks(&self) {
-        // Clear the old stacks.
-        self.process.old_stacks.write().clear();
+        let mut new_stacks = self.process.new_stacks.write();
+        let mut stacks = self.process.stacks.write();
+        // Move the pending new stacks to the current stacks.
+        for (program_id, stack) in new_stacks.drain(..) {
+            stacks.insert(program_id, stack);
+        }
     }
 
-    /// Reverts the staged stacks, restoring the previous state of the process.
-    /// This will remove the new stacks and restore the old stacks.
+    /// Removes the staged stacks.
     #[inline]
-    pub fn revert_stacks(&self) {
-        // Restore the old stacks.
-        for (program_id, stack) in self.process.old_stacks.write().drain(..) {
-            // If the stack is `None`, remove the program from the process.
-            // Otherwise, insert the old stack back into the process.
-            if let Some(stack) = stack {
-                self.process.stacks.write().insert(program_id, stack);
-            } else {
-                self.process.stacks.write().shift_remove(&program_id);
-            }
-        }
+    pub fn cancel_staged_stacks(&self) {
+        self.process.new_stacks.write().clear();
     }
 
     /// Adds a new program to the process, verifying that it is a valid addition.
@@ -218,7 +206,7 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // Defer cleanup of the uncommitted stacks.
         defer! {
-            self.revert_stacks()
+            self.cancel_staged_stacks()
         }
         // Initialize raw stacks for each of the programs, skipping `credits.aleo`.
         for (program, edition) in programs {
@@ -249,7 +237,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            old_stacks: Default::default(),
+            new_stacks: Default::default(),
             lock: Default::default(),
         };
         lap!(timer, "Initialize process");
@@ -332,7 +320,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            old_stacks: Default::default(),
+            new_stacks: Default::default(),
             lock: Default::default(),
         };
         lap!(timer, "Initialize process");
@@ -376,7 +364,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            old_stacks: Default::default(),
+            new_stacks: Default::default(),
             lock: Default::default(),
         };
         lap!(timer, "Initialize process");
@@ -419,7 +407,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            old_stacks: Default::default(),
+            new_stacks: Default::default(),
             lock: Default::default(),
         };
 

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -168,13 +168,14 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
     #[inline]
     pub fn revert_stacks(&self) {
         // Restore the old stacks.
+        let mut stacks = self.process.stacks.write();
         for (program_id, stack) in self.process.old_stacks.write().drain(..) {
             // If the stack is `None`, remove the program from the process.
             // Otherwise, insert the old stack back into the process.
             if let Some(stack) = stack {
-                self.process.stacks.write().insert(program_id, stack);
+                stacks.insert(program_id, stack);
             } else {
-                self.process.stacks.write().shift_remove(&program_id);
+                stacks.shift_remove(&program_id);
             }
         }
     }

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -86,9 +86,13 @@ use aleo_std::prelude::{finish, lap, timer};
 use indexmap::{IndexMap, IndexSet};
 
 #[cfg(feature = "locktick")]
-use locktick::parking_lot::RwLock;
+use locktick::{
+    LockGuard,
+    parking_lot::{Mutex, RwLock},
+};
+use parking_lot::MutexGuard;
 #[cfg(not(feature = "locktick"))]
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -96,14 +100,16 @@ use std::{
 
 // Note: a `Process` and all of its fields are meant to be completely stateless. They have no
 // notion of block height or consensus version.
-#[derive(Clone)]
 pub struct Process<N: Network> {
     /// The universal SRS.
     universal_srs: UniversalSRS<N>,
     /// The mapping of program IDs to stacks.
     stacks: Arc<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>>,
     /// The mapping of program IDs to old stacks.
-    old_stacks: Arc<RwLock<IndexMap<ProgramID<N>, Option<Arc<Stack<N>>>>>>,
+    old_stacks: RwLock<IndexMap<ProgramID<N>, Option<Arc<Stack<N>>>>>,
+    /// A lock guarding the entire Process in case no concurrent reads or writes
+    /// on the object are to be permitted.
+    lock: Mutex<()>,
 }
 
 impl<N: Network> Process<N> {
@@ -113,8 +119,12 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process:setup");
 
         // Initialize the process.
-        let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default(), old_stacks: Default::default() };
+        let process = Self {
+            universal_srs: UniversalSRS::load()?,
+            stacks: Default::default(),
+            old_stacks: Default::default(),
+            lock: Default::default(),
+        };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -143,11 +153,23 @@ impl<N: Network> Process<N> {
         Ok(process)
     }
 
+    /// Guard the Process against any concurrent reads or writes.
+    #[cfg(feature = "locktick")]
+    pub fn lock(&self) -> LockGuard<MutexGuard<()>> {
+        self.lock.lock()
+    }
+
+    /// Guard the Process against any concurrent reads or writes.
+    #[cfg(not(feature = "locktick"))]
+    pub fn lock(&self) -> MutexGuard<()> {
+        self.lock.lock()
+    }
+
     /// Adds a new stack to the process.
     /// If the program already exists, then the existing stack is replaced and the original stack is returned.
     /// Note. This method assumes that the provided stack is valid.
     #[inline]
-    pub fn add_stack(&mut self, stack: Stack<N>) -> Option<Arc<Stack<N>>> {
+    pub fn add_stack(&self, stack: Stack<N>) -> Option<Arc<Stack<N>>> {
         // Get the program ID.
         let program_id = *stack.program_id();
         // Arc the stack first to limit the scope of the write lock.
@@ -243,8 +265,12 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process::load");
 
         // Initialize the process.
-        let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default(), old_stacks: Default::default() };
+        let process = Self {
+            universal_srs: UniversalSRS::load()?,
+            stacks: Default::default(),
+            old_stacks: Default::default(),
+            lock: Default::default(),
+        };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -283,8 +309,12 @@ impl<N: Network> Process<N> {
         let timer = timer!("Process::load_v0");
 
         // Initialize the process.
-        let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default(), old_stacks: Default::default() };
+        let process = Self {
+            universal_srs: UniversalSRS::load()?,
+            stacks: Default::default(),
+            old_stacks: Default::default(),
+            lock: Default::default(),
+        };
         lap!(timer, "Initialize process");
 
         // Initialize the 'credits.aleo' program.
@@ -322,8 +352,12 @@ impl<N: Network> Process<N> {
     #[cfg(feature = "wasm")]
     pub fn load_web() -> Result<Self> {
         // Initialize the process.
-        let mut process =
-            Self { universal_srs: UniversalSRS::load()?, stacks: Default::default(), old_stacks: Default::default() };
+        let process = Self {
+            universal_srs: UniversalSRS::load()?,
+            stacks: Default::default(),
+            old_stacks: Default::default(),
+            lock: Default::default(),
+        };
 
         // Initialize the 'credits.aleo' program.
         let program = Program::credits()?;
@@ -342,7 +376,7 @@ impl<N: Network> Process<N> {
     /// If the program exists, then the existing stack is replaced and discarded.
     /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
     #[inline]
-    pub fn add_program(&mut self, program: &Program<N>) -> Result<()> {
+    pub fn add_program(&self, program: &Program<N>) -> Result<()> {
         // Initialize the 'credits.aleo' program ID.
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
@@ -356,7 +390,7 @@ impl<N: Network> Process<N> {
     /// If the program exists, then the existing stack is replaced and discarded.
     /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
     #[inline]
-    pub fn add_program_with_edition(&mut self, program: &Program<N>, edition: u16) -> Result<()> {
+    pub fn add_program_with_edition(&self, program: &Program<N>, edition: u16) -> Result<()> {
         // Initialize the 'credits.aleo' program ID.
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // If the program is not 'credits.aleo', compute the program stack, and add it to the process.
@@ -373,7 +407,7 @@ impl<N: Network> Process<N> {
     /// Either all programs are added or none are.
     /// Note. This method should **NOT** be used by the on-chain VM to add new program, use `finalize_deployment` or `load_deployment` instead instead.
     #[inline]
-    pub fn add_programs_with_editions(&mut self, programs: &[(Program<N>, u16)]) -> Result<()> {
+    pub fn add_programs_with_editions(&self, programs: &[(Program<N>, u16)]) -> Result<()> {
         // Initialize the 'credits.aleo' program ID.
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // Defer cleanup of the uncommitted stacks.
@@ -683,7 +717,7 @@ function compute:
     /// Initializes a new process with the given program.
     pub(crate) fn sample_process(program: &Program<CurrentNetwork>) -> Process<CurrentNetwork> {
         // Construct a new process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Add the program to the process.
         process.add_program(program).unwrap();
         // Return the process.

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -105,8 +105,8 @@ pub struct Process<N: Network> {
     universal_srs: UniversalSRS<N>,
     /// The mapping of program IDs to stacks.
     stacks: Arc<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>>,
-    /// The mapping of program IDs to new, pending stacks.
-    new_stacks: RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>,
+    /// The mapping of program IDs to old stacks.
+    old_stacks: RwLock<IndexMap<ProgramID<N>, Option<Arc<Stack<N>>>>>,
     /// A lock guarding the entire Process in case no concurrent reads or writes
     /// on the object are to be permitted.
     lock: Mutex<()>,
@@ -136,34 +136,46 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
     }
 
     /// Stages a stack to be added to the process.
-    /// The new stack is pending in `new_stacks`.
+    /// The new stack is active, while the old stack is retained in `old_stacks`.
     /// The `commit_stacks` method must be called to finalize the addition of the new stack.
-    /// The `cancel_staged_stacks` method can be called to revert the staged stacks.
+    /// The `revert_stacks` method can be called to revert the staged stacks.
     #[inline]
     pub fn stage_stack(&self, stack: Stack<N>) {
         // Get the program ID.
         let program_id = *stack.program_id();
         // Arc the stack first to limit the scope of the write lock.
         let stack = Arc::new(stack);
-        self.process.new_stacks.write().insert(program_id, stack);
-    }
-
-    /// Commits the staged stacks to the process.
-    /// This finalizes the addition of the new stacks.
-    #[inline]
-    pub fn commit_stacks(&self) {
-        let mut new_stacks = self.process.new_stacks.write();
-        let mut stacks = self.process.stacks.write();
-        // Move the pending new stacks to the current stacks.
-        for (program_id, stack) in new_stacks.drain(..) {
-            stacks.insert(program_id, stack);
+        // If no entry in `old_stacks` exists for `program_id`, store the old stack.
+        // Note: If `old_stack` is `None`, it means that we are adding a new program to the process.
+        let old_stack = self.process.stacks.write().insert(program_id, stack);
+        let mut old_stacks = self.process.old_stacks.write();
+        if !old_stacks.contains_key(&program_id) {
+            old_stacks.insert(program_id, old_stack);
         }
     }
 
-    /// Removes the staged stacks.
+    /// Commits the staged stacks to the process.
+    /// This finalizes the addition of the new stacks and clears the old stacks.
     #[inline]
-    pub fn cancel_staged_stacks(&self) {
-        self.process.new_stacks.write().clear();
+    pub fn commit_stacks(&self) {
+        // Clear the old stacks.
+        self.process.old_stacks.write().clear();
+    }
+
+    /// Reverts the staged stacks, restoring the previous state of the process.
+    /// This will remove the new stacks and restore the old stacks.
+    #[inline]
+    pub fn revert_stacks(&self) {
+        // Restore the old stacks.
+        for (program_id, stack) in self.process.old_stacks.write().drain(..) {
+            // If the stack is `None`, remove the program from the process.
+            // Otherwise, insert the old stack back into the process.
+            if let Some(stack) = stack {
+                self.process.stacks.write().insert(program_id, stack);
+            } else {
+                self.process.stacks.write().shift_remove(&program_id);
+            }
+        }
     }
 
     /// Adds a new program to the process, verifying that it is a valid addition.
@@ -206,7 +218,7 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
         let credits_program_id = ProgramID::<N>::from_str("credits.aleo")?;
         // Defer cleanup of the uncommitted stacks.
         defer! {
-            self.cancel_staged_stacks()
+            self.revert_stacks()
         }
         // Initialize raw stacks for each of the programs, skipping `credits.aleo`.
         for (program, edition) in programs {
@@ -263,7 +275,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            new_stacks: Default::default(),
+            old_stacks: Default::default(),
             lock: Default::default(),
         };
         lap!(timer, "Initialize process");
@@ -346,7 +358,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            new_stacks: Default::default(),
+            old_stacks: Default::default(),
             lock: Default::default(),
         };
         lap!(timer, "Initialize process");
@@ -390,7 +402,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            new_stacks: Default::default(),
+            old_stacks: Default::default(),
             lock: Default::default(),
         };
         lap!(timer, "Initialize process");
@@ -433,7 +445,7 @@ impl<N: Network> Process<N> {
         let process = Self {
             universal_srs: UniversalSRS::load()?,
             stacks: Default::default(),
-            new_stacks: Default::default(),
+            old_stacks: Default::default(),
             lock: Default::default(),
         };
 

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -107,12 +107,13 @@ pub struct Process<N: Network> {
     stacks: Arc<RwLock<IndexMap<ProgramID<N>, Arc<Stack<N>>>>>,
     /// The mapping of program IDs to old stacks.
     old_stacks: RwLock<IndexMap<ProgramID<N>, Option<Arc<Stack<N>>>>>,
-    /// A lock guarding the entire Process in case no concurrent reads or writes
-    /// on the object are to be permitted.
+    /// A lock used to create instances of `ProcessExclusiveGuard`, which ensures that only
+    /// one of them may ever exist at a time.
     lock: Mutex<()>,
 }
 
-/// A wrapper ensuring exclusive access to the Process for the purposes of add_stacks.
+/// A wrapper ensuring exclusive access to the Process for the purposes of methods which
+/// affect the state of the stacks.
 pub struct ProcessExclusiveGuard<'a, N: Network> {
     process: &'a Process<N>,
     #[cfg(not(feature = "locktick"))]

--- a/synthesizer/process/src/stack/helpers/stack_trait.rs
+++ b/synthesizer/process/src/stack/helpers/stack_trait.rs
@@ -732,7 +732,7 @@ function dynamic_func:
         )
         .unwrap();
         // Add the program to a fresh process (no deployment needed for stack inspection).
-        let mut process = Process::<CurrentNetwork>::load().unwrap();
+        let process = Process::<CurrentNetwork>::load().unwrap();
         process.add_program(&program).unwrap();
         let stack = process.get_stack("dynamic_test.aleo").unwrap();
         // `dynamic_func` contains a `call.dynamic` instruction and must be detected.
@@ -771,7 +771,7 @@ function caller_func:
         )
         .unwrap();
         // Add programs in dependency order: helper first, then caller.
-        let mut process = Process::<CurrentNetwork>::load().unwrap();
+        let process = Process::<CurrentNetwork>::load().unwrap();
         process.add_program(&helper_program).unwrap();
         process.add_program(&caller_program).unwrap();
         let stack = process.get_stack("caller.aleo").unwrap();

--- a/synthesizer/process/src/stack/helpers/stack_trait.rs
+++ b/synthesizer/process/src/stack/helpers/stack_trait.rs
@@ -733,7 +733,7 @@ function dynamic_func:
         .unwrap();
         // Add the program to a fresh process (no deployment needed for stack inspection).
         let process = Process::<CurrentNetwork>::load().unwrap();
-        process.add_program(&program).unwrap();
+        process.lock().add_program(&program).unwrap();
         let stack = process.get_stack("dynamic_test.aleo").unwrap();
         // `dynamic_func` contains a `call.dynamic` instruction and must be detected.
         let function_name = Identifier::from_str("dynamic_func").unwrap();
@@ -772,8 +772,8 @@ function caller_func:
         .unwrap();
         // Add programs in dependency order: helper first, then caller.
         let process = Process::<CurrentNetwork>::load().unwrap();
-        process.add_program(&helper_program).unwrap();
-        process.add_program(&caller_program).unwrap();
+        process.lock().add_program(&helper_program).unwrap();
+        process.lock().add_program(&caller_program).unwrap();
         let stack = process.get_stack("caller.aleo").unwrap();
         // `caller_func` transitively reaches `call.dynamic` via `helper.aleo/dynamic_helper`.
         let function_name = Identifier::from_str("caller_func").unwrap();

--- a/synthesizer/process/src/tests/test_call_graph.rs
+++ b/synthesizer/process/src/tests/test_call_graph.rs
@@ -45,7 +45,7 @@ fn fake_transition(
 /// Builds a `Process` pre-loaded with `credits.aleo` and the given programs.
 /// Programs must be listed in dependency order (dependencies before dependents).
 fn make_process(programs: &[&str]) -> Process<CurrentNetwork> {
-    let mut process = Process::load().unwrap(); // unwrap: always succeeds in tests
+    let process = Process::load().unwrap(); // unwrap: always succeeds in tests
     for src in programs {
         let (rest, program) = Program::<CurrentNetwork>::parse(src).unwrap(); // unwrap: valid test program
         assert!(rest.is_empty(), "Parser did not consume the full program string");

--- a/synthesizer/process/src/tests/test_call_graph.rs
+++ b/synthesizer/process/src/tests/test_call_graph.rs
@@ -49,7 +49,7 @@ fn make_process(programs: &[&str]) -> Process<CurrentNetwork> {
     for src in programs {
         let (rest, program) = Program::<CurrentNetwork>::parse(src).unwrap(); // unwrap: valid test program
         assert!(rest.is_empty(), "Parser did not consume the full program string");
-        process.add_program(&program).unwrap(); // unwrap: valid program in dependency order
+        process.lock().add_program(&program).unwrap(); // unwrap: valid program in dependency order
     }
     process
 }

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -339,7 +339,7 @@ fn execute_function<F: FinalizeStorage<CurrentNetwork>>(
     let block_height = block_height.unwrap_or(1);
 
     // Add an atomic finalize wrapper around the finalize function.
-    process.finalize_execution(sample_finalize_state(block_height), finalize_store, &execution, None)?;
+    process.lock().finalize_execution(sample_finalize_state(block_height), finalize_store, &execution, None)?;
 
     Ok(())
 }

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -2629,7 +2629,7 @@ fn test_process_deploy_credits_program() {
     let empty_process = Process {
         universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(),
         stacks: Default::default(),
-        old_stacks: Default::default(),
+        new_stacks: Default::default(),
         lock: Default::default(),
     };
 

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -2629,7 +2629,7 @@ fn test_process_deploy_credits_program() {
     let empty_process = Process {
         universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(),
         stacks: Default::default(),
-        new_stacks: Default::default(),
+        old_stacks: Default::default(),
         lock: Default::default(),
     };
 

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -1147,7 +1147,7 @@ function transfer:
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program0);
+    let process = crate::test_helpers::sample_process(&program0);
     // Initialize another program.
     let (string, program1) = Program::<CurrentNetwork>::parse(
         r"
@@ -1307,7 +1307,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1425,7 +1425,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1558,7 +1558,7 @@ finalize mint_public:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1693,7 +1693,7 @@ finalize mint_public:
     process.synthesize_key::<CurrentAleo, _>(program0.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1857,7 +1857,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -1956,7 +1956,7 @@ finalize c:
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program0);
+    let process = crate::test_helpers::sample_process(&program0);
 
     // Initialize another program (middle node).
     let (string, program1) = Program::<CurrentNetwork>::parse(
@@ -2151,7 +2151,7 @@ fn test_complex_execution_order() {
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program0);
+    let process = crate::test_helpers::sample_process(&program0);
 
     // Initialize another program (leaf).
     let (string, program1) = Program::<CurrentNetwork>::parse(
@@ -2438,7 +2438,7 @@ finalize compute:
     process.synthesize_key::<CurrentAleo, _>(program.id(), &function_name, rng).unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -2623,6 +2623,7 @@ fn test_process_deploy_credits_program() {
         universal_srs: UniversalSRS::<CurrentNetwork>::load().unwrap(),
         stacks: Default::default(),
         old_stacks: Default::default(),
+        lock: Default::default(),
     };
 
     // Construct the process.
@@ -2680,7 +2681,7 @@ function {function_name}:
     .unwrap();
 
     // Reset the process.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
 
     // Initialize a new block store.
     let block_store = BlockStore::<CurrentNetwork, BlockMemory<_>>::open(StorageMode::new_test(None)).unwrap();
@@ -2756,7 +2757,7 @@ fn test_long_import_chain() {
     .unwrap();
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program);
+    let process = crate::test_helpers::sample_process(&program);
 
     // Add `MAX_PROGRAM_DEPTH` programs to the process.
     for i in 1..=MAX_PROGRAM_DEPTH {
@@ -2801,7 +2802,7 @@ fn test_long_import_chain_with_calls() {
     .unwrap();
 
     // Construct the process.
-    let mut process = crate::test_helpers::sample_process(&program);
+    let process = crate::test_helpers::sample_process(&program);
 
     // Check that the number of calls, up to `Transaction::MAX_TRANSITIONS - 1`, is correct.
     for i in 1..(Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1) {
@@ -2846,7 +2847,7 @@ fn test_long_import_chain_with_calls() {
 #[test]
 fn test_max_imports() {
     // Construct the process.
-    let mut process = Process::<CurrentNetwork>::load().unwrap();
+    let process = Process::<CurrentNetwork>::load().unwrap();
 
     // Add `MAX_IMPORTS` programs to the process.
     for i in 0..CurrentNetwork::MAX_IMPORTS {

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -1170,7 +1170,7 @@ function transfer:
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Add the program to the process.
-    process.add_program(&program1).unwrap();
+    process.lock().add_program(&program1).unwrap();
 
     // Initialize the RNG.
     let rng = &mut TestRng::default();
@@ -1321,9 +1321,10 @@ finalize compute:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1368,7 +1369,7 @@ finalize compute:
     assert_eq!(execution_cost(&process, &execution, ConsensusVersion::V10).unwrap(), expected_execution_cost);
 
     // Now, finalize the execution.
-    process.finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
+    process.lock().finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
 
     // Check that the account balance is now 8.
     let candidate = finalize_store
@@ -1439,9 +1440,10 @@ finalize compute:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1487,7 +1489,7 @@ finalize compute:
     assert_eq!(execution_cost(&process, &execution, ConsensusVersion::V10).unwrap(), expected_execution_cost);
 
     // Now, finalize the execution.
-    process.finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
+    process.lock().finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
 
     // Check that the account balance is now 0.
     let candidate = finalize_store
@@ -1572,9 +1574,10 @@ finalize mint_public:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1624,7 +1627,7 @@ finalize mint_public:
     assert_eq!(execution_cost(&process, &execution, ConsensusVersion::V10).unwrap(), expected_execution_cost);
 
     // Now, finalize the execution.
-    process.finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
+    process.lock().finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
 
     // Check the account balance.
     let candidate = finalize_store
@@ -1707,9 +1710,10 @@ finalize mint_public:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1747,9 +1751,10 @@ finalize init:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(2), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(2), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // TODO (howardwu): Remove this. I call this to synthesize the proving key independent of the assignment from 'execute'.
     //  In general, we should update all tests to utilize a presynthesized proving key, before execution, to test
@@ -1798,7 +1803,7 @@ finalize init:
     assert_eq!(execution_cost(&process, &execution, ConsensusVersion::V10).unwrap(), expected_execution_cost);
 
     // Now, finalize the execution.
-    process.finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
+    process.lock().finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
 
     // Check the account balance.
     let candidate = finalize_store
@@ -1871,9 +1876,10 @@ finalize compute:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -1919,7 +1925,7 @@ finalize compute:
     assert_eq!(execution_cost(&process, &execution, ConsensusVersion::V10).unwrap(), expected_execution_cost);
 
     // Now, finalize the execution.
-    process.finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
+    process.lock().finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
 
     // Check that the account balance is now 8.
     let candidate = finalize_store
@@ -1987,7 +1993,7 @@ finalize b:
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Add the program to the process.
-    process.add_program(&program1).unwrap();
+    process.lock().add_program(&program1).unwrap();
 
     // Initialize another program (root node).
     let (string, program2) = Program::<CurrentNetwork>::parse(
@@ -2019,7 +2025,7 @@ finalize a:
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Add the program to the process.
-    process.add_program(&program2).unwrap();
+    process.lock().add_program(&program2).unwrap();
 
     // Initialize the RNG.
     let rng = &mut TestRng::default();
@@ -2178,7 +2184,7 @@ fn test_complex_execution_order() {
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Add the program to the process.
-    process.add_program(&program1).unwrap();
+    process.lock().add_program(&program1).unwrap();
 
     // Initialize another program (calls zero and one).
     let (string, program2) = Program::<CurrentNetwork>::parse(
@@ -2213,7 +2219,7 @@ fn test_complex_execution_order() {
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Add the program to the process.
-    process.add_program(&program2).unwrap();
+    process.lock().add_program(&program2).unwrap();
 
     // Initialize another program (calls two, one, zero).
     let (string, program3) = Program::<CurrentNetwork>::parse(
@@ -2252,7 +2258,7 @@ fn test_complex_execution_order() {
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Add the program to the process.
-    process.add_program(&program3).unwrap();
+    process.lock().add_program(&program3).unwrap();
 
     // Initialize another program (calls two and three).
     let (string, program4) = Program::<CurrentNetwork>::parse(
@@ -2289,7 +2295,7 @@ fn test_complex_execution_order() {
     assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
     // Add the program to the process.
-    process.add_program(&program4).unwrap();
+    process.lock().add_program(&program4).unwrap();
 
     // Initialize the RNG.
     let rng = &mut TestRng::default();
@@ -2452,9 +2458,10 @@ finalize compute:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2499,7 +2506,7 @@ finalize compute:
     assert_eq!(execution_cost(&process, &execution, ConsensusVersion::V10).unwrap(), expected_execution_cost);
 
     // Now, finalize the execution.
-    process.finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
+    process.lock().finalize_execution(sample_finalize_state(1), &finalize_store, &execution, None).unwrap();
 
     // Check that the struct is stored as expected.
     let candidate = finalize_store
@@ -2695,9 +2702,10 @@ function {function_name}:
     // Compute the fee.
     let fee = sample_fee::<_, CurrentAleo, _, _>(&process, &block_store, &finalize_store, rng);
     // Finalize the deployment.
-    let (stack, _) = process.finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
+    let (stack, _) =
+        process.lock().finalize_deployment(sample_finalize_state(1), &finalize_store, &deployment, &fee).unwrap();
     // Add the stack *manually* to the process.
-    process.add_stack(stack);
+    process.lock().add_stack(stack);
 
     // Initialize a new caller account.
     let caller_private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -2773,7 +2781,7 @@ fn test_long_import_chain() {
         ))
         .unwrap();
         // Add the program to the process.
-        process.add_program(&program).unwrap();
+        process.lock().add_program(&program).unwrap();
     }
 
     // Add the `MAX_PROGRAM_DEPTH + 1` program to the process, which should fail.
@@ -2786,7 +2794,7 @@ fn test_long_import_chain() {
         MAX_PROGRAM_DEPTH + 1
     ))
     .unwrap();
-    let result = process.add_program(&program);
+    let result = process.lock().add_program(&program);
     // Programs may create long import chains as long as number of calls does not exceed the maximum number of transitions.
     assert!(result.is_ok());
 }
@@ -2820,7 +2828,7 @@ fn test_long_import_chain_with_calls() {
         ))
         .unwrap();
         // Add the program to the process.
-        process.add_program(&program).unwrap();
+        process.lock().add_program(&program).unwrap();
         // Check that the number of calls is correct.
         let stack = process.get_stack(program.id()).unwrap();
         let number_of_calls =
@@ -2840,7 +2848,7 @@ fn test_long_import_chain_with_calls() {
         Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 2
     ))
     .unwrap();
-    let result = process.add_program(&program);
+    let result = process.lock().add_program(&program);
     assert!(result.is_err())
 }
 
@@ -2855,7 +2863,7 @@ fn test_max_imports() {
         // Initialize a new program.
         let program = Program::from_str(&format!("program test{i}.aleo; function c:")).unwrap();
         // Add the program to the process.
-        process.add_program(&program).unwrap();
+        process.lock().add_program(&program).unwrap();
     }
 
     // Add a program importing all `MAX_IMPORTS` programs, which should pass.
@@ -2864,7 +2872,7 @@ fn test_max_imports() {
     let program =
         Program::from_str(&format!("{import_string}program test{}.aleo; function c:", CurrentNetwork::MAX_IMPORTS))
             .unwrap();
-    process.add_program(&program).unwrap();
+    process.lock().add_program(&program).unwrap();
 
     // Attempt to construct a program importing `MAX_IMPORTS + 1` programs, which should fail.
     let import_string =

--- a/synthesizer/process/src/tests/test_serializers.rs
+++ b/synthesizer/process/src/tests/test_serializers.rs
@@ -98,7 +98,7 @@ function test_serde_equivalence:
         let rng = &mut TestRng::default();
 
         // Load the process.
-        let mut process = Process::<CurrentNetwork>::load().unwrap();
+        let process = Process::<CurrentNetwork>::load().unwrap();
 
         // Structs are not supported.
         let fail_get_struct = |_: &Identifier<CurrentNetwork>| bail!("structs are not supported");
@@ -192,7 +192,7 @@ fn test_value_size_in_bits() {
     const ITERATIONS: usize = 1000;
 
     // Load a process.
-    let mut process = Process::<CurrentNetwork>::load().unwrap();
+    let process = Process::<CurrentNetwork>::load().unwrap();
 
     // Define a program .
     let program0 = Program::<CurrentNetwork>::from_str(

--- a/synthesizer/process/src/tests/test_serializers.rs
+++ b/synthesizer/process/src/tests/test_serializers.rs
@@ -117,7 +117,7 @@ function test_serde_equivalence:
         let program = construct_program(variant, type_.clone(), bits_type.clone());
 
         // Add the program to the process.
-        process.add_program(&program).unwrap();
+        process.lock().add_program(&program).unwrap();
 
         // Get the stack.
         let stack = process.get_stack(program.id()).unwrap();
@@ -233,7 +233,7 @@ finalize dummy:
     .unwrap();
 
     // Add the program to the process.
-    process.add_program(&program0).unwrap();
+    process.lock().add_program(&program0).unwrap();
 
     // Define a program with data types that we want to test.
     let program1 = Program::<CurrentNetwork>::from_str(
@@ -276,7 +276,7 @@ finalize dummy:
     .unwrap();
 
     // Add the program to the process.
-    process.add_program(&program1).unwrap();
+    process.lock().add_program(&program1).unwrap();
 
     // Get the stack.
     let stack = process.get_stack(program1.id()).unwrap();

--- a/synthesizer/process/src/tests/test_upgrade.rs
+++ b/synthesizer/process/src/tests/test_upgrade.rs
@@ -24,7 +24,7 @@ type CurrentNetwork = MainnetV0;
 
 // A helper function to sample the default process.
 fn sample_process() -> Result<Process<CurrentNetwork>, Error> {
-    let mut process = Process::load()?;
+    let process = Process::load()?;
     // Add the default program to the process.
     let default_program = Program::from_str(
         r"
@@ -42,7 +42,7 @@ constructor:
 #[test]
 fn test_add_simple_program() -> Result<()> {
     // Sample the default process.
-    let mut process = Process::<CurrentNetwork>::load()?;
+    let process = Process::<CurrentNetwork>::load()?;
     // Add a simple program to the process.
     let initial_program = Program::from_str(
         r"
@@ -63,7 +63,7 @@ function foo:
 #[test]
 fn test_upgrade_without_constructor() -> Result<()> {
     // Sample the default process.
-    let mut process = Process::<CurrentNetwork>::load()?;
+    let process = Process::<CurrentNetwork>::load()?;
     // Add a program without a constructor to the process.
     let initial_program = Program::from_str(
         r"
@@ -88,7 +88,7 @@ function bar:
 #[test]
 fn test_upgrade_with_constructor() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -107,7 +107,7 @@ function bar:
 #[test]
 fn test_add_import() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -129,7 +129,7 @@ function foo:
 #[test]
 fn test_add_struct() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -152,7 +152,7 @@ function foo:
 #[test]
 fn test_add_record() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -176,7 +176,7 @@ function foo:
 #[test]
 fn test_add_mapping() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -200,7 +200,7 @@ function foo:
 #[test]
 fn test_add_closure() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -226,7 +226,7 @@ function foo:
 #[test]
 fn test_add_function() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -252,7 +252,7 @@ function foo:
 #[test]
 fn test_modify_function_logic() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -291,7 +291,7 @@ function adder:
 #[test]
 fn test_modify_function_signature() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -327,7 +327,7 @@ function adder:
 #[test]
 fn test_modify_finalize_logic() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -374,7 +374,7 @@ finalize assert_on_chain:
 #[test]
 fn test_modify_finalize_signature() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -418,7 +418,7 @@ finalize assert_on_chain:
 #[test]
 fn test_modify_struct() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -450,7 +450,7 @@ function foo:
 #[test]
 fn test_modify_record() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -484,7 +484,7 @@ function foo:
 #[test]
 fn test_modify_mapping() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -518,7 +518,7 @@ function foo:
 #[test]
 fn test_modify_closure_logic() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -556,7 +556,7 @@ function foo:
 #[test]
 fn test_modify_closure_signature() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -594,7 +594,7 @@ function foo:
 #[test]
 fn test_remove_import() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -623,7 +623,7 @@ function foo:
 #[test]
 fn test_remove_struct() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -653,7 +653,7 @@ function foo:
 #[test]
 fn test_remove_record() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -684,7 +684,7 @@ function foo:
 #[test]
 fn test_remove_mapping() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -715,7 +715,7 @@ function foo:
 #[test]
 fn test_remove_closure() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -748,7 +748,7 @@ function foo:
 #[test]
 fn test_remove_function() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -781,7 +781,7 @@ function foo:
 #[test]
 fn test_add_call_to_non_async_transition() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add a program with a non-async transition.
     let new_program = Program::from_str(
         r"
@@ -835,7 +835,7 @@ function adder:
 #[test]
 fn test_add_call_to_async_transition() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add a program with an async transition.
     let new_program = Program::from_str(
         r"
@@ -896,7 +896,7 @@ finalize adder:
 #[test]
 fn test_add_import_cycle() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
 
     // Add the initial program to the process.
     let initial_program = Program::from_str(
@@ -971,7 +971,7 @@ function adder:
 #[test]
 fn test_constructor_upgrade() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -1015,7 +1015,7 @@ fn test_credits_is_not_upgradable() -> Result<()> {
 #[test]
 fn test_edition_and_checksum_and_program_owner_operands() -> Result<()> {
     // Sample the default process.
-    let mut process = sample_process()?;
+    let process = sample_process()?;
 
     // A helper to sample a test program with an operand in the function.
     let sample_program_with_operand_in_function = |operand: &str| -> Result<Program<CurrentNetwork>> {

--- a/synthesizer/process/src/tests/test_upgrade.rs
+++ b/synthesizer/process/src/tests/test_upgrade.rs
@@ -34,7 +34,7 @@ constructor:
     assert.eq true true;
     ",
     )?;
-    process.add_program(&default_program)?;
+    process.lock().add_program(&default_program)?;
     // Return the process.
     Ok(process)
 }
@@ -51,7 +51,7 @@ function foo:
     ",
     )?;
     // Add the new program to the process.
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Get the program from the process.
     let stack = process.get_stack("test.aleo")?;
     let program = stack.program();
@@ -71,7 +71,7 @@ program test.aleo;
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Attempt to upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -81,7 +81,7 @@ function bar:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -100,7 +100,7 @@ function bar:
     ",
     )?;
     // Verify that the upgrade was successful.
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     Ok(())
 }
 
@@ -118,7 +118,7 @@ constructor:
 function foo:
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("test.aleo")?;
     let program = stack.program();
@@ -141,7 +141,7 @@ struct bar:
 function foo:
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("test.aleo")?;
     let program = stack.program();
@@ -165,7 +165,7 @@ record bar:
 function foo:
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("test.aleo")?;
     let program = stack.program();
@@ -189,7 +189,7 @@ mapping onchain:
 function foo:
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("test.aleo")?;
     let program = stack.program();
@@ -215,7 +215,7 @@ closure sum:
 function foo:
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("test.aleo")?;
     let program = stack.program();
@@ -241,7 +241,7 @@ function adder:
 function foo:
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("test.aleo")?;
     let program = stack.program();
@@ -266,7 +266,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -280,7 +280,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("basic.aleo")?;
     let program = stack.program();
@@ -305,7 +305,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -320,7 +320,7 @@ function adder:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -345,7 +345,7 @@ finalize assert_on_chain:
     assert.eq r0 r1;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -363,7 +363,7 @@ finalize assert_on_chain:
     assert.neq r0 r1;
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("basic.aleo")?;
     let program = stack.program();
@@ -392,7 +392,7 @@ finalize assert_on_chain:
     assert.eq r0 r1;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -411,7 +411,7 @@ finalize assert_on_chain:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -430,7 +430,7 @@ struct bar:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -443,7 +443,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -463,7 +463,7 @@ record bar:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -477,7 +477,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -497,7 +497,7 @@ mapping onchain:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -511,7 +511,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -533,7 +533,7 @@ closure sum:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -549,7 +549,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -571,7 +571,7 @@ closure sum:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -587,7 +587,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -605,7 +605,7 @@ constructor:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -616,7 +616,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -635,7 +635,7 @@ struct bar:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -646,7 +646,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -666,7 +666,7 @@ record bar:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -677,7 +677,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -697,7 +697,7 @@ mapping onchain:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -708,7 +708,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -730,7 +730,7 @@ closure sum:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -741,7 +741,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -763,7 +763,7 @@ function adder:
 function foo:
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -774,7 +774,7 @@ function foo:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -794,7 +794,7 @@ function foo:
     add r0 r1 into r2;
     output r2 as u8.private;",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -809,7 +809,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -824,7 +824,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("basic.aleo")?;
     let program = stack.program();
@@ -854,7 +854,7 @@ finalize foo:
     input r1 as u8.public;
     assert.eq r0 r1;",
     )?;
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     // Add the initial program to the process.
     let initial_program = Program::from_str(
         r"
@@ -869,7 +869,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -889,7 +889,7 @@ finalize adder:
     await r0;",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -911,7 +911,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
 
     // Verify that self-import cycles are not allowed.
     let new_program = Program::from_str(
@@ -927,7 +927,7 @@ function adder:
     output r2 as u8.private;
     ",
     )?;
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
 
     // Add a program dependent on `basic.aleo`.
     let dependent_program = Program::from_str(
@@ -942,7 +942,7 @@ function foo:
     call basic.aleo/adder r0 r1 into r2;
     output r2 as u8.private;",
     )?;
-    process.add_program(&dependent_program)?;
+    process.lock().add_program(&dependent_program)?;
     // Verify that the upgrade was successful.
     let stack = process.get_stack("dependent.aleo")?;
     let program = stack.program();
@@ -964,7 +964,7 @@ function adder:
     ",
     )?;
     // Verify that the upgrade was successful.
-    process.add_program(&new_program)?;
+    process.lock().add_program(&new_program)?;
     Ok(())
 }
 
@@ -981,7 +981,7 @@ constructor:
     assert.eq 1u8 1u8;
     ",
     )?;
-    process.add_program(&initial_program)?;
+    process.lock().add_program(&initial_program)?;
     // Upgrade the program.
     let new_program = Program::from_str(
         r"
@@ -992,7 +992,7 @@ constructor:
     ",
     )?;
     // Verify that the upgrade was not successful.
-    assert!(process.add_program(&new_program).is_err());
+    assert!(process.lock().add_program(&new_program).is_err());
     Ok(())
 }
 
@@ -1053,22 +1053,22 @@ closure foo:
     // Check that the below programs are invalid.
 
     let program = sample_program_with_operand_in_function("edition")?;
-    assert!(process.add_program(&program).is_err());
+    assert!(process.lock().add_program(&program).is_err());
 
     let program = sample_program_with_operand_in_function("checksum")?;
-    assert!(process.add_program(&program).is_err());
+    assert!(process.lock().add_program(&program).is_err());
 
     let program = sample_program_with_operand_in_function("program_owner")?;
-    assert!(process.add_program(&program).is_err());
+    assert!(process.lock().add_program(&program).is_err());
 
     let program = sample_program_with_operand_in_closure("edition")?;
-    assert!(process.add_program(&program).is_err());
+    assert!(process.lock().add_program(&program).is_err());
 
     let program = sample_program_with_operand_in_closure("checksum")?;
-    assert!(process.add_program(&program).is_err());
+    assert!(process.lock().add_program(&program).is_err());
 
     let program = sample_program_with_operand_in_closure("program_owner")?;
-    assert!(process.add_program(&program).is_err());
+    assert!(process.lock().add_program(&program).is_err());
 
     Ok(())
 }

--- a/synthesizer/process/src/tests/test_utils.rs
+++ b/synthesizer/process/src/tests/test_utils.rs
@@ -254,7 +254,7 @@ fn execute_function<F: FinalizeStorage<CurrentNetwork>>(
     let block_height = block_height.unwrap_or(1);
 
     // Add an atomic finalize wrapper around the finalize function.
-    process.finalize_execution(sample_finalize_state(block_height), finalize_store, &execution, None)?;
+    process.lock().finalize_execution(sample_finalize_state(block_height), finalize_store, &execution, None)?;
 
     Ok(())
 }

--- a/synthesizer/program/tests/types/equivalence.rs
+++ b/synthesizer/program/tests/types/equivalence.rs
@@ -137,7 +137,7 @@ fn test_external_vs_local_struct_equivalence() -> Result<()> {
         struct Foo: x as u32; y as u32;
         function main:",
     )?;
-    process.add_program(&external_program)?;
+    process.lock().add_program(&external_program)?;
 
     // Local program that imports external
     let local_program = Program::from_str(
@@ -146,7 +146,7 @@ fn test_external_vs_local_struct_equivalence() -> Result<()> {
         struct Foo: x as u32; y as u32;
         function main:",
     )?;
-    process.add_program(&local_program)?;
+    process.lock().add_program(&local_program)?;
 
     // Retrieve the stack for the local program
     let s_local = process.get_stack(local_program.id())?;
@@ -182,7 +182,7 @@ fn test_external_and_array_struct_equivalence() -> Result<()> {
         struct Bar: a as u32; b as u32;
         function main:",
     )?;
-    process.add_program(&external_program)?;
+    process.lock().add_program(&external_program)?;
 
     // ---------- Local program importing external ----------
     let local_program = Program::from_str(
@@ -192,7 +192,7 @@ fn test_external_and_array_struct_equivalence() -> Result<()> {
         struct Baz: f as Foo; g as u32;
         function main:",
     )?;
-    process.add_program(&local_program)?;
+    process.lock().add_program(&local_program)?;
 
     // ---------- Retrieve the stack ----------
     let s_local = process.get_stack(local_program.id())?;

--- a/synthesizer/program/tests/types/equivalence.rs
+++ b/synthesizer/program/tests/types/equivalence.rs
@@ -129,7 +129,7 @@ fn test_cross_program_structs_equivalence() -> Result<()> {
 #[test]
 fn test_external_vs_local_struct_equivalence() -> Result<()> {
     // Create a single process to hold both programs
-    let mut process = Process::<CurrentNetwork>::load()?;
+    let process = Process::<CurrentNetwork>::load()?;
 
     // External program
     let external_program = Program::from_str(
@@ -173,7 +173,7 @@ fn test_external_and_array_struct_equivalence() -> Result<()> {
     use snarkvm_synthesizer_program::types_equivalent;
 
     // ---------- Create a single process ----------
-    let mut process = Process::<CurrentNetwork>::load()?;
+    let process = Process::<CurrentNetwork>::load()?;
 
     // ---------- External program ----------
     let external_program = Program::from_str(

--- a/synthesizer/src/vm/deploy.rs
+++ b/synthesizer/src/vm/deploy.rs
@@ -64,7 +64,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Construct the owner.
         let owner = ProgramOwner::new(private_key, deployment_id, rng)?;
 
-        let (minimum_deployment_cost, _) = deployment_cost(&self.process().read(), &deployment, consensus_version)?;
+        let (minimum_deployment_cost, _) = deployment_cost(&self.process, &deployment, consensus_version)?;
         // Authorize the fee.
         let fee_authorization = match fee_record {
             Some(record) => self.authorize_fee_private(

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -82,8 +82,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             true => {
                 // Compute the minimum execution cost.
                 let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
-                let (minimum_execution_cost, _) =
-                    execution_cost(&self.process().read(), &execution, consensus_version)?;
+                let (minimum_execution_cost, _) = execution_cost(&self.process, &execution, consensus_version)?;
                 // Compute the execution ID.
                 let execution_id = execution.to_execution_id()?;
                 // Authorize the fee.
@@ -191,7 +190,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Determine the consensus version.
         let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
         // Check whether the authorization is for a valid program edition.
-        authorization.check_valid_edition(&self.process.read(), consensus_version)?;
+        authorization.check_valid_edition(&self.process, consensus_version)?;
         // Check whether the authorization is creating valid records.
         authorization.check_valid_records(consensus_version)?;
         // Determine which Varuna version to use.
@@ -249,7 +248,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Determine the consensus version.
         let consensus_version = N::CONSENSUS_VERSION(query.current_block_height()?)?;
         // Check whether the authorization is for a valid program edition.
-        authorization.check_valid_edition(&self.process.read(), consensus_version)?;
+        authorization.check_valid_edition(&self.process, consensus_version)?;
         // Check whether the authorization is creating valid records.
         authorization.check_valid_records(consensus_version)?;
         // Determine which Varuna version to use.
@@ -443,8 +442,8 @@ mod tests {
 
         let query = Query::VM(vm.block_store().clone());
         let (execution, _) = vm.execute_authorization_raw(authorization, &query, rng).unwrap();
-        let (cost, _) = execution_cost(&vm.process().read(), &execution, ConsensusVersion::V2).unwrap();
-        let (old_cost, _) = execution_cost(&vm.process().read(), &execution, ConsensusVersion::V1).unwrap();
+        let (cost, _) = execution_cost(vm.process(), &execution, ConsensusVersion::V2).unwrap();
+        let (old_cost, _) = execution_cost(vm.process(), &execution, ConsensusVersion::V1).unwrap();
 
         assert_eq!(34_060, cost);
         assert_eq!(51_060, old_cost);
@@ -580,7 +579,7 @@ finalize test:
 
         let query = Query::VM(vm.block_store().clone());
         let (execution, _) = vm.execute_authorization_raw(authorization, &query, rng).unwrap();
-        let (cost, _) = execution_cost(&vm.process().read(), &execution, ConsensusVersion::V1).unwrap();
+        let (cost, _) = execution_cost(vm.process(), &execution, ConsensusVersion::V1).unwrap();
         println!("Cost: {cost}");
     }
 
@@ -971,7 +970,7 @@ finalize test:
         assert_eq!(execution.transitions().len(), <CurrentNetwork as Network>::MAX_INPUTS + 1);
 
         // Get the finalize cost of the execution.
-        let (_, (_, finalize_cost)) = execution_cost(&vm.process().read(), &execution, ConsensusVersion::V2).unwrap();
+        let (_, (_, finalize_cost)) = execution_cost(vm.process(), &execution, ConsensusVersion::V2).unwrap();
 
         // Compute the expected cost as the sum of the cost in microcredits of each command in each finalize block of each transition in the execution.
         let mut expected_cost = 0;
@@ -980,7 +979,7 @@ finalize test:
             let program_id = transition.program_id();
             let function_name = transition.function_name();
             // Get the stack.
-            let stack = vm.process().read().get_stack(program_id).unwrap().clone();
+            let stack = vm.process().get_stack(program_id).unwrap().clone();
             // Get the finalize types.
             let finalize_types = stack.get_finalize_types(function_name).unwrap();
             // Get the finalize block of the transition and sum the cost of each command.
@@ -1120,7 +1119,7 @@ constructor:
         assert_eq!(execution.transitions().len(), Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1);
 
         // Get the finalize cost of the execution.
-        let (_, (_, finalize_cost)) = execution_cost(&vm.process().read(), &execution, ConsensusVersion::V2).unwrap();
+        let (_, (_, finalize_cost)) = execution_cost(vm.process(), &execution, ConsensusVersion::V2).unwrap();
 
         // Compute the expected cost as the sum of the cost in microcredits of each command in each finalize block of each transition in the execution.
         let mut expected_cost = 0;
@@ -1129,7 +1128,7 @@ constructor:
             let program_id = transition.program_id();
             let function_name = transition.function_name();
             // Get the stack.
-            let stack = vm.process().read().get_stack(program_id).unwrap().clone();
+            let stack = vm.process().get_stack(program_id).unwrap().clone();
             // Get the finalize types.
             let finalize_types = stack.get_finalize_types(function_name).unwrap();
             // Get the finalize block of the transition and sum the cost of each command.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -335,10 +335,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             /* Perform the atomic finalize over the transactions. */
 
-            // Acquire the write lock on the process.
+            // Acquire a guard on the contents of the process.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
-            // we choose to acquire the write lock for the entire duration of this atomic batch.
-            let process = self.process.write();
+            // we choose to acquire it for the entire duration of this atomic batch.
+            let process = &self.process;
+            let _process_guard = process.lock();
 
             // Revert any unstaged stacks, when the function returns.
             // Note. This function does not call `commit_stacks` so the staged stacks will always be reverted
@@ -684,10 +685,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             /* Perform the atomic finalize over the transactions. */
 
-            // Acquire the write lock on the process.
+            // Acquire a guard on the contents of the process.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
-            // we choose to acquire the write lock for the entire duration of this atomic batch.
-            let process = self.process.write();
+            // we choose to acquire it for the entire duration of this atomic batch.
+            let process = &self.process;
+            let _process_guard = process.lock();
 
             // Revert any unstaged stacks, when the function returns.
             // Note. `commit_stacks` is called at the bottom of this function after successful finalization.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -344,7 +344,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Note. This function does not call `commit_stacks` so the staged stacks will always be reverted
             //  regardless of whether the function succeeds or fails.
             defer! {
-                process.revert_stacks();
+                process.cancel_staged_stacks();
             }
 
             // Initialize a list of the confirmed transactions.
@@ -693,7 +693,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Note. `commit_stacks` is called at the bottom of this function after successful finalization.
             //  The staged stacks are only reverted if the function returns an error.
             defer! {
-                process.revert_stacks();
+                process.cancel_staged_stacks();
             }
 
             // Finalize the transactions.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -338,8 +338,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Acquire a guard on the contents of the process.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
             // we choose to acquire it for the entire duration of this atomic batch.
-            let process = &self.process;
-            let _process_guard = process.lock();
+            let process = self.process.lock();
 
             // Revert any unstaged stacks, when the function returns.
             // Note. This function does not call `commit_stacks` so the staged stacks will always be reverted
@@ -688,8 +687,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Acquire a guard on the contents of the process.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
             // we choose to acquire it for the entire duration of this atomic batch.
-            let process = &self.process;
-            let _process_guard = process.lock();
+            let process = self.process.lock();
 
             // Revert any unstaged stacks, when the function returns.
             // Note. `commit_stacks` is called at the bottom of this function after successful finalization.

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -344,7 +344,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Note. This function does not call `commit_stacks` so the staged stacks will always be reverted
             //  regardless of whether the function succeeds or fails.
             defer! {
-                process.cancel_staged_stacks();
+                process.revert_stacks();
             }
 
             // Initialize a list of the confirmed transactions.
@@ -693,7 +693,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             // Note. `commit_stacks` is called at the bottom of this function after successful finalization.
             //  The staged stacks are only reverted if the function returns an error.
             defer! {
-                process.cancel_staged_stacks();
+                process.revert_stacks();
             }
 
             // Finalize the transactions.

--- a/synthesizer/src/vm/helpers/macros.rs
+++ b/synthesizer/src/vm/helpers/macros.rs
@@ -85,26 +85,26 @@ macro_rules! process {
             console::network::MainnetV0::ID => {
                 // Cast the process.
                 let process = (&$self.process as &dyn std::any::Any)
-                    .downcast_ref::<Arc<RwLock<Process<console::network::MainnetV0>>>>()
+                    .downcast_ref::<Arc<Process<console::network::MainnetV0>>>()
                     .ok_or_else(|| anyhow!("Failed to downcast {}", stringify!($self.process)))?;
                 // Process the logic.
-                $logic!(process.read(), console::network::MainnetV0, circuit::AleoV0)
+                $logic!(process, console::network::MainnetV0, circuit::AleoV0)
             }
             console::network::TestnetV0::ID => {
                 // Cast the process.
                 let process = (&$self.process as &dyn std::any::Any)
-                    .downcast_ref::<Arc<RwLock<Process<console::network::TestnetV0>>>>()
+                    .downcast_ref::<Arc<Process<console::network::TestnetV0>>>()
                     .ok_or_else(|| anyhow!("Failed to downcast {}", stringify!($self.process)))?;
                 // Process the logic.
-                $logic!(process.read(), console::network::TestnetV0, circuit::AleoTestnetV0)
+                $logic!(process, console::network::TestnetV0, circuit::AleoTestnetV0)
             }
             console::network::CanaryV0::ID => {
                 // Cast the process.
                 let process = (&$self.process as &dyn std::any::Any)
-                    .downcast_ref::<Arc<RwLock<Process<console::network::CanaryV0>>>>()
+                    .downcast_ref::<Arc<Process<console::network::CanaryV0>>>()
                     .ok_or_else(|| anyhow!("Failed to downcast {}", stringify!($self.process)))?;
                 // Process the logic.
-                $logic!(process.read(), console::network::CanaryV0, circuit::AleoCanaryV0)
+                $logic!(process, console::network::CanaryV0, circuit::AleoCanaryV0)
             }
             _ => return Err(anyhow!("Unsupported VM configuration for network: {}", N::ID).into()),
         }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -124,7 +124,7 @@ type TransactionCacheKey<N> = (<N as Network>::TransactionID, Vec<U16<N>>);
 #[derive(Clone)]
 pub struct VM<N: Network, C: ConsensusStorage<N>> {
     /// The process.
-    process: Arc<RwLock<Process<N>>>,
+    process: Arc<Process<N>>,
     /// The puzzle.
     puzzle: Puzzle<N>,
     /// The VM store.
@@ -159,7 +159,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let block_store = store.block_store();
 
         #[cfg(not(any(test, feature = "test")))]
-        let mut process = {
+        let process = {
             // Determine the latest block height.
             let latest_block_height = block_store.current_block_height();
             // Determine the consensus version.
@@ -173,7 +173,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         };
         #[cfg(any(test, feature = "test"))]
         // Initialize a new process.
-        let mut process = Process::load()?;
+        let process = Process::load()?;
 
         // Retrieve the list of deployment transaction IDs and their associated block heights.
         let deployment_ids = transaction_store.deployment_transaction_ids().collect::<Vec<_>>();
@@ -227,7 +227,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
         // Construct the VM object.
         let vm = Self {
-            process: Arc::new(RwLock::new(process)),
+            process: Arc::new(process),
             puzzle: Self::new_puzzle()?,
             store,
             partially_verified_transactions: Arc::new(RwLock::new(LruCache::new(
@@ -253,13 +253,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Returns `true` if a program with the given program ID exists.
     #[inline]
     pub fn contains_program(&self, program_id: &ProgramID<N>) -> bool {
-        self.process.read().contains_program(program_id)
+        self.process.contains_program(program_id)
     }
 
     /// Returns the process.
     #[inline]
-    pub fn process(&self) -> Arc<RwLock<Process<N>>> {
-        self.process.clone()
+    pub fn process(&self) -> &Arc<Process<N>> {
+        &self.process
     }
 
     /// Returns the puzzle.
@@ -577,8 +577,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Initialize the store for 'credits.aleo'.
         let credits = Program::<N>::credits()?;
 
-        // Acquire the process lock.
-        let process = self.process.write();
+        // Acquire the process.
+        let process = &self.process;
 
         // Synthesize the 'credits.aleo' verifying keys.
         for function_name in credits.functions().keys() {
@@ -3130,7 +3130,7 @@ function check:
         assert!(vm.contains_program(&ProgramID::from_str("grandparent_program.aleo").unwrap()));
 
         // Initialize the process.
-        let mut process = Process::<CurrentNetwork>::load().unwrap();
+        let process = Process::<CurrentNetwork>::load().unwrap();
 
         // Load the child and parent program
         process.add_program(&child_program_1).unwrap();
@@ -3285,7 +3285,7 @@ function adder:
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_1.fee_amount().unwrap(), 2483025);
         // Add the first program to the off-chain VM.
-        off_chain_vm.process().write().add_program(&program_1).unwrap();
+        off_chain_vm.process().add_program(&program_1).unwrap();
         // Deploy the second program.
         let deployment_2 = off_chain_vm.deploy(&private_key_2, &program_2, None, 0, None, rng).unwrap();
         // Check that the account has enough to pay for the deployment.
@@ -3300,7 +3300,7 @@ function adder:
         vm.add_next_block(&block).unwrap();
 
         // Check that only `child_program.aleo` is in the VM.
-        assert!(vm.process().read().contains_program(&ProgramID::from_str("child_program.aleo").unwrap()));
+        assert!(vm.process().contains_program(&ProgramID::from_str("child_program.aleo").unwrap()));
     }
 
     #[cfg(feature = "test")]
@@ -3403,7 +3403,7 @@ function adder:
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment.fee_amount().unwrap(), 2483025);
         // Add the program to the off-chain VM.
-        off_chain_vm.process().write().add_program(&program).unwrap();
+        off_chain_vm.process().add_program(&program).unwrap();
         // Execute the program.
         let transaction = off_chain_vm
             .execute(
@@ -3430,7 +3430,7 @@ function adder:
         vm.add_next_block(&block).unwrap();
 
         // Check that the program was deployed.
-        assert!(vm.process().read().contains_program(&ProgramID::from_str("adder_program.aleo").unwrap()));
+        assert!(vm.process().contains_program(&ProgramID::from_str("adder_program.aleo").unwrap()));
     }
 
     #[cfg(feature = "test")]
@@ -3519,7 +3519,7 @@ constructor:
         // vm.add_next_block(&block).unwrap();
 
         // // Check that the program was deployed.
-        // assert!(vm.process().read().contains_program(&ProgramID::from_str("strings_0.aleo").unwrap()));
+        // assert!(vm.process().contains_program(&ProgramID::from_str("strings_0.aleo").unwrap()));
 
         // let hello_literal = Literal::String(StringType::new("hello"));
         // let hello_friend_literal = Literal::String(StringType::new("hello_friend"));
@@ -3597,6 +3597,6 @@ constructor:
         // vm.add_next_block(&block).unwrap();
 
         // // Check that the program was notdeployed.
-        // assert!(!vm.process().read().contains_program(&ProgramID::from_str("strings_1.aleo").unwrap()));
+        // assert!(!vm.process().contains_program(&ProgramID::from_str("strings_1.aleo").unwrap()));
     }
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -3133,10 +3133,10 @@ function check:
         let process = Process::<CurrentNetwork>::load().unwrap();
 
         // Load the child and parent program
-        process.add_program(&child_program_1).unwrap();
-        process.add_program(&child_program_2).unwrap();
-        process.add_program(&parent_program).unwrap();
-        process.add_program(&grandparent_program).unwrap();
+        process.lock().add_program(&child_program_1).unwrap();
+        process.lock().add_program(&child_program_2).unwrap();
+        process.lock().add_program(&parent_program).unwrap();
+        process.lock().add_program(&grandparent_program).unwrap();
 
         // Specify the function name on the parent program
         let function_name = Identifier::<CurrentNetwork>::from_str("check").unwrap();
@@ -3285,7 +3285,7 @@ function adder:
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment_1.fee_amount().unwrap(), 2483025);
         // Add the first program to the off-chain VM.
-        off_chain_vm.process().add_program(&program_1).unwrap();
+        off_chain_vm.process().lock().add_program(&program_1).unwrap();
         // Deploy the second program.
         let deployment_2 = off_chain_vm.deploy(&private_key_2, &program_2, None, 0, None, rng).unwrap();
         // Check that the account has enough to pay for the deployment.
@@ -3403,7 +3403,7 @@ function adder:
         // Check that the account has enough to pay for the deployment.
         assert_eq!(*deployment.fee_amount().unwrap(), 2483025);
         // Add the program to the off-chain VM.
-        off_chain_vm.process().add_program(&program).unwrap();
+        off_chain_vm.process().lock().add_program(&program).unwrap();
         // Execute the program.
         let transaction = off_chain_vm
             .execute(

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -93,7 +93,6 @@ use snarkvm_synthesizer_program::{
     Program,
     StackTrait as _,
 };
-use snarkvm_synthesizer_snark::VerifyingKey;
 use snarkvm_utilities::try_vm_runtime;
 
 use aleo_std::prelude::{finish, lap, timer};
@@ -526,7 +525,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             Ok(_ratified_finalize_operations) => {
                 // If the block advances to `ConsensusVersion::V8`, updated the VKs used for the credits program.
                 if N::CONSENSUS_HEIGHT(ConsensusVersion::V8).unwrap_or_default() == block.height() {
-                    self.update_credits_verifying_keys()?;
+                    self.process.lock().update_credits_verifying_keys()?;
                 }
                 // Unpause the atomic writes, executing the ones queued from block insertion and finalization.
                 #[cfg(feature = "rocks")]
@@ -568,37 +567,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 Err(finalize_error)
             }
         }
-    }
-}
-
-impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
-    /// Update the `credits.aleo` program in the VM with the latest verifying keys.
-    fn update_credits_verifying_keys(&self) -> Result<()> {
-        // Initialize the store for 'credits.aleo'.
-        let credits = Program::<N>::credits()?;
-
-        // Acquire the process.
-        let process = &self.process;
-
-        // Synthesize the 'credits.aleo' verifying keys.
-        for function_name in credits.functions().keys() {
-            // Remove the proving key.
-            process.remove_proving_key(credits.id(), function_name)?;
-            // Load the verifying key.
-            let verifying_key = N::get_credits_verifying_key(function_name.to_string())?;
-            // Retrieve the number of public and private variables.
-            // Note: This number does *NOT* include the number of constants. This is safe because
-            // this program is never deployed, as it is a first-class citizen of the protocol.
-            let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
-            // Insert the verifying key.
-            process.insert_verifying_key(
-                credits.id(),
-                function_name,
-                VerifyingKey::new(verifying_key.clone(), num_variables),
-            )?;
-        }
-
-        Ok(())
     }
 }
 

--- a/synthesizer/src/vm/tests/test_v14/amendments.rs
+++ b/synthesizer/src/vm/tests/test_v14/amendments.rs
@@ -32,7 +32,7 @@ fn create_v3_deployment_transaction<C: ConsensusStorage<CurrentNetwork>, R: Rng 
     rng: &mut R,
 ) -> Result<Transaction<CurrentNetwork>> {
     // Create a deployment for the program.
-    let mut v3_deployment = vm.process().read().deploy::<CurrentAleo, _>(program, rng)?;
+    let mut v3_deployment = vm.process().deploy::<CurrentAleo, _>(program, rng)?;
 
     // Set the V3 deployment fields (amendment: checksum but no owner).
     // Translation VKs are retained if the program has records.
@@ -48,7 +48,7 @@ fn create_v3_deployment_transaction<C: ConsensusStorage<CurrentNetwork>, R: Rng 
 
     // Compute the deployment cost.
     let consensus_version = CurrentNetwork::CONSENSUS_VERSION(vm.block_store().current_block_height())?;
-    let (minimum_cost, _) = deployment_cost(&vm.process().read(), &v3_deployment, consensus_version)?;
+    let (minimum_cost, _) = deployment_cost(vm.process(), &v3_deployment, consensus_version)?;
 
     // Authorize and execute the fee.
     let fee_authorization = vm.authorize_fee_public(private_key, minimum_cost, 0, deployment_id, rng)?;
@@ -110,7 +110,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Verify the program is deployed with edition 0.
-    let stack = vm.process().read().get_stack("amendment_test.aleo")?;
+    let stack = vm.process().get_stack("amendment_test.aleo")?;
     assert_eq!(*stack.program_edition(), 0);
 
     // Create a V3 deployment (amendment).
@@ -147,7 +147,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Verify the edition hasn't changed (V3 doesn't change edition).
-    let stack = vm.process().read().get_stack("amendment_test.aleo")?;
+    let stack = vm.process().get_stack("amendment_test.aleo")?;
     assert_eq!(*stack.program_edition(), 0, "Edition should remain 0 after an amendment");
 
     Ok(())
@@ -207,7 +207,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Verify the program was deployed without translation VKs.
-    let stack = vm.process().read().get_stack("vk_test.aleo")?;
+    let stack = vm.process().get_stack("vk_test.aleo")?;
     assert!(
         stack.get_verifying_key(&Identifier::from_str("token")?).is_err(),
         "V2 deployment at V9 should NOT have translation VKs"
@@ -236,7 +236,7 @@ constructor:
     }
 
     // Get the deployed program.
-    let stack = vm.process().read().get_stack("vk_test.aleo")?;
+    let stack = vm.process().get_stack("vk_test.aleo")?;
     let deployed_program = stack.program().clone();
 
     // First amendment: Adds translation VKs - should succeed.
@@ -246,7 +246,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Verify the translation VK was added by the amendment.
-    let stack = vm.process().read().get_stack("vk_test.aleo")?;
+    let stack = vm.process().get_stack("vk_test.aleo")?;
     assert!(
         stack.get_verifying_key(&Identifier::from_str("token")?).is_ok(),
         "Amendment should have added translation VKs"
@@ -329,7 +329,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Get the deployed program info.
-    let stack = vm.process().read().get_stack("validation_test.aleo")?;
+    let stack = vm.process().get_stack("validation_test.aleo")?;
     let deployed_program = stack.program().clone();
 
     // Advance the VM to V14 height.
@@ -342,7 +342,7 @@ constructor:
     // Test 1: An amendment with wrong checksum should be rejected by the VM.
     // Note: Raw setters bypass construction validation, so the transaction is created,
     // but the VM will reject it during check_transaction because the checksum doesn't match.
-    let mut wrong_checksum_deployment = vm.process().read().deploy::<CurrentAleo, _>(&deployed_program, rng)?;
+    let mut wrong_checksum_deployment = vm.process().deploy::<CurrentAleo, _>(&deployed_program, rng)?;
     wrong_checksum_deployment.set_edition_raw(0);
     wrong_checksum_deployment.set_program_checksum_raw(Some([0u8; 32].map(U8::new))); // Wrong checksum
     wrong_checksum_deployment.set_program_owner_raw(None);
@@ -350,7 +350,7 @@ constructor:
     let deployment_id = wrong_checksum_deployment.to_deployment_id()?;
     let owner = ProgramOwner::new(&caller_private_key, deployment_id, rng)?;
     let consensus_version = CurrentNetwork::CONSENSUS_VERSION(vm.block_store().current_block_height())?;
-    let (minimum_cost, _) = deployment_cost(&vm.process().read(), &wrong_checksum_deployment, consensus_version)?;
+    let (minimum_cost, _) = deployment_cost(vm.process(), &wrong_checksum_deployment, consensus_version)?;
     let fee_authorization = vm.authorize_fee_public(&caller_private_key, minimum_cost, 0, deployment_id, rng)?;
     let fee = vm.execute_fee_authorization(fee_authorization, None, rng)?;
     let wrong_checksum_tx = Transaction::from_deployment(owner, wrong_checksum_deployment, fee)?;
@@ -377,14 +377,14 @@ constructor:
 ",
     )?;
 
-    let mut nonexistent_deployment = vm.process().read().deploy::<CurrentAleo, _>(&nonexistent_program, rng)?;
+    let mut nonexistent_deployment = vm.process().deploy::<CurrentAleo, _>(&nonexistent_program, rng)?;
     nonexistent_deployment.set_edition_raw(0);
     nonexistent_deployment.set_program_checksum_raw(Some(nonexistent_program.to_checksum()));
     nonexistent_deployment.set_program_owner_raw(None);
 
     let deployment_id = nonexistent_deployment.to_deployment_id()?;
     let owner = ProgramOwner::new(&caller_private_key, deployment_id, rng)?;
-    let (minimum_cost, _) = deployment_cost(&vm.process().read(), &nonexistent_deployment, consensus_version)?;
+    let (minimum_cost, _) = deployment_cost(vm.process(), &nonexistent_deployment, consensus_version)?;
     let fee_authorization = vm.authorize_fee_public(&caller_private_key, minimum_cost, 0, deployment_id, rng)?;
     let fee = vm.execute_fee_authorization(fee_authorization, None, rng)?;
     let nonexistent_tx = Transaction::from_deployment(owner, nonexistent_deployment, fee)?;
@@ -470,7 +470,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Get the deployed program info.
-    let stack = vm.process().read().get_stack("permissionless_test.aleo")?;
+    let stack = vm.process().get_stack("permissionless_test.aleo")?;
     let deployed_program = stack.program().clone();
     let original_program_owner = *stack.program_owner();
 
@@ -491,7 +491,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Verify the program owner hasn't changed.
-    let stack = vm.process().read().get_stack("permissionless_test.aleo")?;
+    let stack = vm.process().get_stack("permissionless_test.aleo")?;
     assert_eq!(
         *stack.program_owner(),
         original_program_owner,
@@ -519,7 +519,7 @@ fn test_credits_cannot_be_amended() -> Result<()> {
     let credits_program = Program::credits()?;
 
     // Attempt to create a V3 deployment for credits.aleo - this should fail.
-    let result = vm.process().read().deploy::<CurrentAleo, _>(&credits_program, rng);
+    let result = vm.process().deploy::<CurrentAleo, _>(&credits_program, rng);
 
     // Verify that creating a deployment for credits.aleo fails.
     assert!(result.is_err(), "Creating a deployment for credits.aleo should fail");
@@ -640,8 +640,7 @@ fn test_dynamic_call_after_amendment() {
     let token_name = Identifier::<CurrentNetwork>::from_str("token").unwrap();
 
     {
-        let process = verifier_vm.process();
-        let vm_process = process.read();
+        let vm_process = verifier_vm.process();
         let stack = vm_process.get_stack(legacy_program_id).unwrap();
         assert_eq!(*stack.program_edition(), 0, "Verifier should have edition 0 before amendment");
         assert!(
@@ -737,7 +736,7 @@ fn test_dynamic_call_after_amendment() {
     // --- Amend verifier VM (V3 amendment adds translation keys) ---
 
     // Create a V3 amendment on verifier VM to add translation keys.
-    let stack = verifier_vm.process().read().get_stack("legacy_token_amend.aleo").unwrap();
+    let stack = verifier_vm.process().get_stack("legacy_token_amend.aleo").unwrap();
     let deployed_program = stack.program().clone();
     let edition = *stack.program_edition();
     drop(stack);
@@ -748,8 +747,7 @@ fn test_dynamic_call_after_amendment() {
 
     // Verify the verifier VM now HAS translation keys after amendment, and edition is unchanged.
     {
-        let process = verifier_vm.process();
-        let vm_process = process.read();
+        let vm_process = verifier_vm.process();
         let stack = vm_process.get_stack(legacy_program_id).unwrap();
         assert_eq!(*stack.program_edition(), 0, "Edition should remain 0 after amendment");
         assert!(

--- a/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
+++ b/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
@@ -869,7 +869,7 @@ fn test_complex_dynamic_graph_construction_internal(
     // 6 -> []
     // 7 -> []
 
-    let graph = vm.process().read().construct_call_graph(transitions.into_iter()).unwrap();
+    let graph = vm.process().construct_call_graph(transitions.into_iter()).unwrap();
     assert_eq!(graph[tids[9]], &[*tids[2], *tids[8]]);
     assert_eq!(graph[tids[8]], &[*tids[5], *tids[6], *tids[7]]);
     assert_eq!(graph[tids[5]], &[*tids[3], *tids[4]]);
@@ -2156,8 +2156,7 @@ fn test_dynamic_call_to_pre_v14_program() {
     let token_name = Identifier::<CurrentNetwork>::from_str("token").unwrap();
 
     {
-        let process = verifier_vm.process();
-        let vm_process = process.read();
+        let vm_process = verifier_vm.process();
         let stack = vm_process.get_stack(legacy_program_id).unwrap();
         assert_eq!(*stack.program_edition(), 0, "Verifier should have edition 0 before upgrade");
         assert!(
@@ -2250,8 +2249,7 @@ fn test_dynamic_call_to_pre_v14_program() {
 
     // Verify the verifier VM now HAS translation keys after upgrade, and the edition incremented.
     {
-        let process = verifier_vm.process();
-        let vm_process = process.read();
+        let vm_process = verifier_vm.process();
         let stack = vm_process.get_stack(legacy_program_id).unwrap();
         assert_eq!(*stack.program_edition(), 1, "Verifier should have edition 1 after upgrade");
         assert!(

--- a/synthesizer/src/vm/tests/test_v14/compare_calls_to_credits.rs
+++ b/synthesizer/src/vm/tests/test_v14/compare_calls_to_credits.rs
@@ -91,13 +91,12 @@ fn get_deployment_costs(
     dynamic_deployment: &Deployment<CurrentNetwork>,
     consensus_version: ConsensusVersion,
 ) -> (DeploymentCosts, DeploymentCosts) {
-    let process_guard = vm.process();
-    let process = process_guard.read();
+    let process = vm.process();
 
     let (static_total, (static_storage, static_synthesis, _, _)) =
-        deployment_cost(&*process, static_deployment, consensus_version).unwrap();
+        deployment_cost(process, static_deployment, consensus_version).unwrap();
     let (dynamic_total, (dynamic_storage, dynamic_synthesis, _, _)) =
-        deployment_cost(&*process, dynamic_deployment, consensus_version).unwrap();
+        deployment_cost(process, dynamic_deployment, consensus_version).unwrap();
 
     ((static_total, static_storage, static_synthesis), (dynamic_total, dynamic_storage, dynamic_synthesis))
 }
@@ -139,16 +138,15 @@ fn get_execution_costs(
     dynamic_tx: &Transaction<CurrentNetwork>,
     consensus_version: ConsensusVersion,
 ) -> (ExecutionCosts, ExecutionCosts) {
-    let process_guard = vm.process();
-    let process = process_guard.read();
+    let process = vm.process();
 
     let static_exec = static_tx.execution().unwrap();
     let dynamic_exec = dynamic_tx.execution().unwrap();
 
     let (static_total, (static_storage, static_finalize)) =
-        execution_cost(&*process, static_exec, consensus_version).unwrap();
+        execution_cost(process, static_exec, consensus_version).unwrap();
     let (dynamic_total, (dynamic_storage, dynamic_finalize)) =
-        execution_cost(&*process, dynamic_exec, consensus_version).unwrap();
+        execution_cost(process, dynamic_exec, consensus_version).unwrap();
 
     ((static_total, static_storage, static_finalize), (dynamic_total, dynamic_storage, dynamic_finalize))
 }

--- a/synthesizer/src/vm/tests/test_v14/mod.rs
+++ b/synthesizer/src/vm/tests/test_v14/mod.rs
@@ -191,16 +191,15 @@ pub(crate) fn add_and_test_with_costs(
     if let Some(inputs) = inputs {
         for (transaction, inputs) in transactions.iter().zip_eq(inputs) {
             if let Some(execution) = transaction.execution() {
-                let actual_cost = execution_cost(&vm.process().read(), execution, ConsensusVersion::V14).unwrap();
+                let actual_cost = execution_cost(vm.process(), execution, ConsensusVersion::V14).unwrap();
                 let authorization = Authorization::from_unchecked((vec![], execution.transitions().cloned().collect()));
                 let estimated_cost_authorization =
-                    execution_cost_for_authorization(&vm.process().read(), &authorization, ConsensusVersion::V14)
-                        .unwrap();
+                    execution_cost_for_authorization(vm.process(), &authorization, ConsensusVersion::V14).unwrap();
                 assert_eq!(actual_cost, estimated_cost_authorization);
 
                 let root_transition = execution.transitions().last().unwrap();
                 let estimated_cost_request = execution_cost_for_call::<CurrentAleo, _>(
-                    &vm.process().read(),
+                    vm.process(),
                     *caller_address,
                     *root_transition.program_id(),
                     *root_transition.function_name(),

--- a/synthesizer/src/vm/tests/test_v14/snark_verify.rs
+++ b/synthesizer/src/vm/tests/test_v14/snark_verify.rs
@@ -17,7 +17,7 @@ use super::*;
 
 use circuit::{Circuit, Environment};
 use console::algorithms::U8;
-use snarkvm_synthesizer_snark::{ProvingKey, UniversalSRS};
+use snarkvm_synthesizer_snark::{ProvingKey, UniversalSRS, VerifyingKey};
 
 use std::sync::OnceLock;
 

--- a/synthesizer/src/vm/tests/test_v14/translation.rs
+++ b/synthesizer/src/vm/tests/test_v14/translation.rs
@@ -1465,7 +1465,7 @@ fn test_differing_keys() {
     // Displaying the keys associated to each translation circuit for easier
     // identification with snark-print
     for program_name in ["program_a.aleo", "program_b.aleo"] {
-        let stack = vm.process().read().get_stack(program_name).unwrap();
+        let stack = vm.process().get_stack(program_name).unwrap();
         println!("{program_name} translation keys:");
         for record_name in ["record_a", "record_b"] {
             let record_identifier = Identifier::<CurrentNetwork>::from_str(record_name).unwrap();

--- a/synthesizer/src/vm/tests/test_v8.rs
+++ b/synthesizer/src/vm/tests/test_v8.rs
@@ -415,7 +415,7 @@ function dummy:
     vm.add_next_block(&block)?;
 
     // Check the edition of the deployed program.
-    let edition = *vm.process().read().get_stack("test_deploy_and_redeploy.aleo")?.program_edition();
+    let edition = *vm.process().get_stack("test_deploy_and_redeploy.aleo")?.program_edition();
     assert_eq!(edition, 0);
 
     // Attempt to execute the program immediately after deployment.
@@ -443,7 +443,7 @@ function dummy:
         Some(address),
     )?;
     // Note: This needs to be recalculated since the new deployment contains a checksum and owner.
-    let (base_fee_amount, _) = deployment_cost_v1(&vm.process.read(), &deployment)?;
+    let (base_fee_amount, _) = deployment_cost_v1(vm.process(), &deployment)?;
     let fee_authorization = vm.authorize_fee_public(
         &other_private_key,
         base_fee_amount,

--- a/synthesizer/src/vm/tests/test_v9.rs
+++ b/synthesizer/src/vm/tests/test_v9.rs
@@ -170,7 +170,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Check that the program is deployed.
-    let stack = vm.process().read().get_stack("adder.aleo")?;
+    let stack = vm.process().get_stack("adder.aleo")?;
     assert_eq!(stack.program_id(), &ProgramID::from_str("adder.aleo")?);
     assert_eq!(*stack.program_edition(), 0);
 
@@ -239,7 +239,7 @@ constructor:
     vm.add_next_block(&block)?;
 
     // Check that the program is upgraded.
-    let stack = vm.process().read().get_stack("adder.aleo")?;
+    let stack = vm.process().get_stack("adder.aleo")?;
     assert_eq!(stack.program_id(), &ProgramID::from_str("adder.aleo")?);
     assert_eq!(*stack.program_edition(), 1);
 
@@ -333,11 +333,11 @@ constructor:
 
     // Using the off-chain VM, generate a sequence of deployments.
     let deployment_v0_pass = off_chain_vm.deploy(&caller_private_key, &program_v0, None, 0, None, rng)?;
-    off_chain_vm.process().write().add_program(&program_v0)?;
+    off_chain_vm.process().add_program(&program_v0)?;
     let deployment_v1_fail = off_chain_vm.deploy(&caller_private_key, &program_v1, None, 0, None, rng)?;
     let deployment_v1_pass = off_chain_vm.deploy(&caller_private_key, &program_v1, None, 0, None, rng)?;
     let deployment_v2_as_v1_fail = off_chain_vm.deploy(&caller_private_key, &program_v2_as_v1, None, 0, None, rng)?;
-    off_chain_vm.process().write().add_program(&program_v1)?;
+    off_chain_vm.process().add_program(&program_v1)?;
     let deployment_v2_fail = off_chain_vm.deploy(&caller_private_key, &program_v2, None, 0, None, rng)?;
     let deployment_v2_pass = off_chain_vm.deploy(&caller_private_key, &program_v2, None, 0, None, rng)?;
 
@@ -363,7 +363,7 @@ constructor:
     assert_eq!(block.transactions().num_rejected(), 0);
     assert_eq!(block.aborted_transaction_ids().len(), 0);
     on_chain_vm.add_next_block(&block)?;
-    let stack = on_chain_vm.process().read().get_stack("basic.aleo")?;
+    let stack = on_chain_vm.process().get_stack("basic.aleo")?;
     assert_eq!(*stack.program_edition(), 0);
 
     // This deployment should fail because it does not increment the edition.
@@ -379,7 +379,7 @@ constructor:
     assert_eq!(block.transactions().num_rejected(), 0);
     assert_eq!(block.aborted_transaction_ids().len(), 0);
     on_chain_vm.add_next_block(&block)?;
-    let stack = on_chain_vm.process().read().get_stack("basic.aleo")?;
+    let stack = on_chain_vm.process().get_stack("basic.aleo")?;
     assert_eq!(*stack.program_edition(), 1);
 
     // This deployment should fail because it attempt to redeploy at the same edition.
@@ -395,7 +395,7 @@ constructor:
     assert_eq!(block.transactions().num_rejected(), 0);
     assert_eq!(block.aborted_transaction_ids().len(), 0);
     on_chain_vm.add_next_block(&block)?;
-    let stack = on_chain_vm.process().read().get_stack("basic.aleo")?;
+    let stack = on_chain_vm.process().get_stack("basic.aleo")?;
     assert_eq!(*stack.program_edition(), 2);
 
     Ok(())
@@ -2062,13 +2062,13 @@ constructor:
     vm.add_next_block(&block).unwrap();
 
     // Check the owners of the programs.
-    let stack = vm.process().read().get_stack("credits.aleo").unwrap();
+    let stack = vm.process().get_stack("credits.aleo").unwrap();
     assert!(stack.program_owner().is_none());
 
-    let stack = vm.process().read().get_stack("test_program_0.aleo").unwrap();
+    let stack = vm.process().get_stack("test_program_0.aleo").unwrap();
     assert!(stack.program_owner().is_none());
 
-    let stack = vm.process().read().get_stack("test_program_1.aleo").unwrap();
+    let stack = vm.process().get_stack("test_program_1.aleo").unwrap();
     assert!(stack.program_owner().is_some());
     assert_eq!(stack.program_owner().unwrap(), caller_address);
 }
@@ -2435,7 +2435,7 @@ constructor:
     // Initialize a new VM.
     let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V9).unwrap(), rng);
     // Add the programs to the VM.
-    vm.process().write().add_programs_with_editions(&[(program_a_v1, 1), (program_b_v0, 0)]).unwrap();
+    vm.process().add_programs_with_editions(&[(program_a_v1, 1), (program_b_v0, 0)]).unwrap();
 
     // Check that the programs can be executed.
     let execution_foo = vm
@@ -2675,8 +2675,7 @@ finalize set_first:
     vm.add_next_block(&block).unwrap();
 
     // Check that the program was upgraded.
-    let edition =
-        *vm.process().read().get_stack(ProgramID::from_str("test_one.aleo").unwrap()).unwrap().program_edition();
+    let edition = *vm.process().get_stack(ProgramID::from_str("test_one.aleo").unwrap()).unwrap().program_edition();
     assert_eq!(edition, 1);
 
     // Verify that the first execution was successful.
@@ -2724,8 +2723,7 @@ finalize set_first:
     vm.add_next_block(&block).unwrap();
 
     // Check that the program was upgraded.
-    let edition =
-        *vm.process().read().get_stack(ProgramID::from_str("test_one.aleo").unwrap()).unwrap().program_edition();
+    let edition = *vm.process().get_stack(ProgramID::from_str("test_one.aleo").unwrap()).unwrap().program_edition();
     assert_eq!(edition, 2);
 
     // Now add an old execution that was made before the upgrade.
@@ -2863,7 +2861,7 @@ function baz:
 
     // Generate the deployments.
     // Note that we are attempting to upgrade twice with consecutive editions.
-    let mut process = Process::load().unwrap();
+    let process = Process::load().unwrap();
     process.add_program(&program_v0).unwrap();
     let mut deployment_v1 = process.deploy::<CurrentAleo, _>(&program_v1, rng).unwrap();
     deployment_v1.set_program_checksum_raw(Some(deployment_v1.program().to_checksum()));
@@ -3321,10 +3319,10 @@ constructor:
     // Check that all programs are present in the process.
     for i in 0..(Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1) {
         let program_id = ProgramID::from_str(&format!("parent_program_{i}.aleo")).unwrap();
-        assert!(vm.process().read().get_stack(program_id).is_ok(), "Program parent_program_{i}.aleo should exist.");
+        assert!(vm.process().get_stack(program_id).is_ok(), "Program parent_program_{i}.aleo should exist.");
     }
     assert!(
-        vm.process().read().get_stack(ProgramID::from_str("parent_program_negative.aleo").unwrap()).is_ok(),
+        vm.process().get_stack(ProgramID::from_str("parent_program_negative.aleo").unwrap()).is_ok(),
         "Program parent_program_negative.aleo should exist."
     );
 
@@ -3554,11 +3552,11 @@ constructor:
 
     // Check that the parent program exists in the process.
     let parent_program_id = ProgramID::from_str("parent_program.aleo").unwrap();
-    assert!(vm.process().read().get_stack(parent_program_id).is_ok(), "Program parent_program.aleo should exist.");
+    assert!(vm.process().get_stack(parent_program_id).is_ok(), "Program parent_program.aleo should exist.");
 
     // Check that the child program exists in the process.
     let child_program_id = ProgramID::from_str("child_program.aleo").unwrap();
-    assert!(vm.process().read().get_stack(child_program_id).is_ok(), "Program child_program.aleo should exist.");
+    assert!(vm.process().get_stack(child_program_id).is_ok(), "Program child_program.aleo should exist.");
 
     // Execute the child program to verify it still works.
     let execution = vm

--- a/synthesizer/src/vm/tests/test_v9.rs
+++ b/synthesizer/src/vm/tests/test_v9.rs
@@ -333,11 +333,11 @@ constructor:
 
     // Using the off-chain VM, generate a sequence of deployments.
     let deployment_v0_pass = off_chain_vm.deploy(&caller_private_key, &program_v0, None, 0, None, rng)?;
-    off_chain_vm.process().add_program(&program_v0)?;
+    off_chain_vm.process().lock().add_program(&program_v0)?;
     let deployment_v1_fail = off_chain_vm.deploy(&caller_private_key, &program_v1, None, 0, None, rng)?;
     let deployment_v1_pass = off_chain_vm.deploy(&caller_private_key, &program_v1, None, 0, None, rng)?;
     let deployment_v2_as_v1_fail = off_chain_vm.deploy(&caller_private_key, &program_v2_as_v1, None, 0, None, rng)?;
-    off_chain_vm.process().add_program(&program_v1)?;
+    off_chain_vm.process().lock().add_program(&program_v1)?;
     let deployment_v2_fail = off_chain_vm.deploy(&caller_private_key, &program_v2, None, 0, None, rng)?;
     let deployment_v2_pass = off_chain_vm.deploy(&caller_private_key, &program_v2, None, 0, None, rng)?;
 
@@ -2435,7 +2435,7 @@ constructor:
     // Initialize a new VM.
     let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V9).unwrap(), rng);
     // Add the programs to the VM.
-    vm.process().add_programs_with_editions(&[(program_a_v1, 1), (program_b_v0, 0)]).unwrap();
+    vm.process().lock().add_programs_with_editions(&[(program_a_v1, 1), (program_b_v0, 0)]).unwrap();
 
     // Check that the programs can be executed.
     let execution_foo = vm
@@ -2862,12 +2862,12 @@ function baz:
     // Generate the deployments.
     // Note that we are attempting to upgrade twice with consecutive editions.
     let process = Process::load().unwrap();
-    process.add_program(&program_v0).unwrap();
+    process.lock().add_program(&program_v0).unwrap();
     let mut deployment_v1 = process.deploy::<CurrentAleo, _>(&program_v1, rng).unwrap();
     deployment_v1.set_program_checksum_raw(Some(deployment_v1.program().to_checksum()));
     deployment_v1.set_program_owner_raw(Some(Address::try_from(&private_key_1).unwrap()));
     assert_eq!(deployment_v1.edition(), 1);
-    process.add_program(&program_v1).unwrap();
+    process.lock().add_program(&program_v1).unwrap();
     let mut deployment_v2 = process.deploy::<CurrentAleo, _>(&program_v2, rng).unwrap();
     deployment_v2.set_program_checksum_raw(Some(deployment_v2.program().to_checksum()));
     deployment_v2.set_program_owner_raw(Some(Address::try_from(&private_key_2).unwrap()));

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -151,7 +151,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let mut program_editions = Vec::with_capacity(Transaction::<N>::MAX_TRANSITIONS);
         for transition in transaction.transitions() {
             // Get the stack.
-            let stack = self.process.read().get_stack(transition.program_id())?;
+            let stack = self.process.get_stack(transition.program_id())?;
             // Get the program ID.
             let program_id = *stack.program_id();
             // Get the program edition.
@@ -268,12 +268,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
                     // Returns the external record that `locator` references.
                     let get_external_record = |locator: &Locator<N>| {
-                        let external_stack = self.process.read().get_stack(locator.program_id())?;
+                        let external_stack = self.process.get_stack(locator.program_id())?;
                         external_stack.program().get_record(locator.resource()).cloned()
                     };
                     // Returns the external function that `locator` references.
                     let get_external_function = |locator: &Locator<N>| {
-                        let external_stack = self.process.read().get_stack(locator.program_id())?;
+                        let external_stack = self.process.get_stack(locator.program_id())?;
                         external_stack.program().get_function(locator.resource())
                     };
                     // Returns the *external* finalize logic that `locator` references.
@@ -281,7 +281,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         if program.id() == locator.program_id() {
                             anyhow::bail!("external finalize logic refers to the current program")
                         }
-                        let external_stack = self.process.read().get_stack(locator.program_id())?;
+                        let external_stack = self.process.get_stack(locator.program_id())?;
                         external_stack
                             .program()
                             .get_function_ref(locator.resource())?
@@ -313,7 +313,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         "Invalid deployment transaction '{id}' - program uses syntax that is not allowed before `ConsensusVersion::V14`"
                     );
                     // Check that all future argument bit sizes do not exceed the maximum allowed size of u16::MAX.
-                    let stack = Stack::new(&self.process().read(), deployment.program())?;
+                    let stack = Stack::new(&self.process, deployment.program())?;
                     check_future_argument_bit_size(deployment.program(), &stack, u16::MAX as usize)?;
                     // Before V14, record verifying keys are not allowed.
                     let num_functions = deployment.num_functions();
@@ -364,7 +364,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     );
                 }
                 if consensus_version >= ConsensusVersion::V13 {
-                    self.process.read().mapping_types_exist(deployment.program())?;
+                    self.process.mapping_types_exist(deployment.program())?;
                 }
                 if consensus_version >= ConsensusVersion::V14 {
                     let num_functions = deployment.num_functions();
@@ -445,7 +445,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     );
 
                     // Get the existing program.
-                    let stack = self.process().read().get_stack(deployment.program_id())?;
+                    let stack = self.process.get_stack(deployment.program_id())?;
                     let existing_program = stack.program();
 
                     // Ensure the existing program matches the deployment program.
@@ -537,7 +537,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                             );
                             // Get the existing program.
                             // It should be the case that the stored program matches the process program.
-                            let stack = self.process().read().get_stack(deployment.program_id())?;
+                            let stack = self.process.get_stack(deployment.program_id())?;
                             let existing_program = stack.program();
                             // Check that the new edition increments the old edition by 1.
                             let old_edition = *stack.program_edition();
@@ -627,7 +627,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 let total_writes = transaction
                     .transitions()
                     .map(|t| -> Result<u16> {
-                        let stack = self.process.read().get_stack(t.program_id())?;
+                        let stack = self.process.get_stack(t.program_id())?;
                         let program = stack.program();
                         Ok(program
                             .get_function(t.function_name())?
@@ -677,8 +677,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 // Ensure the rejected ID is not present.
                 ensure!(rejected_id.is_none(), "Transaction '{id}' should not have a rejected ID (deployment)");
                 // Compute the minimum deployment cost.
-                let (minimum_cost, cost_details) =
-                    deployment_cost(&self.process().read(), deployment, consensus_version)?;
+                let (minimum_cost, cost_details) = deployment_cost(&self.process, deployment, consensus_version)?;
                 // Ensure the compute cost does not exceed the transaction spend limit.
                 // Comparison logic before ConsensusVersion::V10 has been pruned to simplify the code.
                 if consensus_version >= ConsensusVersion::V10 {
@@ -709,8 +708,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     // If the fee is required, then check that the base fee amount is satisfied.
                     if is_fee_required {
                         // Compute the minimum execution cost.
-                        let (minimum_cost, cost_details) =
-                            execution_cost(&self.process().read(), execution, consensus_version)?;
+                        let (minimum_cost, cost_details) = execution_cost(&self.process, execution, consensus_version)?;
                         // Ensure the compute cost does not exceed the transaction spend limit.
                         // Comparison logic before ConsensusVersion::V10 has been pruned to simplify the code.
                         if consensus_version >= ConsensusVersion::V10 {
@@ -829,9 +827,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Verify the execution proof, if it has not been partially-verified before.
         let verification = match is_partially_verified {
             true => Ok(()),
-            false => {
-                self.process.read().verify_execution(consensus_version, varuna_version, inclusion_version, execution)
-            }
+            false => self.process.verify_execution(consensus_version, varuna_version, inclusion_version, execution),
         };
         lap!(timer, "Verify the execution");
 
@@ -887,7 +883,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Verify the fee, if it has not been partially-verified before.
         let verification = match is_partially_verified {
             true => Ok(()),
-            false => self.process.read().verify_fee(
+            false => self.process.verify_fee(
                 consensus_version,
                 varuna_version,
                 inclusion_version,
@@ -964,9 +960,7 @@ mod tests {
         // Get the program editions.
         let program_editions = transaction
             .transitions()
-            .map(|transition| {
-                vm.process().read().get_stack(transition.program_id()).map(|stack| stack.program_edition())
-            })
+            .map(|transition| vm.process().get_stack(transition.program_id()).map(|stack| stack.program_edition()))
             .collect::<Result<Vec<_>>>()
             .unwrap();
         // Return the cache key.

--- a/synthesizer/tests/test_process_execute.rs
+++ b/synthesizer/tests/test_process_execute.rs
@@ -60,7 +60,7 @@ fn run_test(process: &Process<CurrentNetwork>, test: &ProgramTest) -> serde_yaml
 
     // Add the programs into the process.
     for program in test.programs() {
-        if let Err(err) = process.add_program(program) {
+        if let Err(err) = process.lock().add_program(program) {
             output
                 .get_mut(serde_yaml::Value::String("errors".to_string()))
                 .unwrap()

--- a/synthesizer/tests/test_process_execute.rs
+++ b/synthesizer/tests/test_process_execute.rs
@@ -31,13 +31,13 @@ use std::panic::AssertUnwindSafe;
 fn test_process_execute() {
     // Load the tests.
     let tests = load_tests::<_, ProgramTest>("./tests/process/execute", "./expectations/process/execute");
-    // Initialize a process.
-    let process = Process::<CurrentNetwork>::load().unwrap();
 
     // Run each test and compare it against its corresponding expectation.
     tests.par_iter().for_each(|test| {
+        // Initialize a process.
+        let process = Process::<CurrentNetwork>::load().unwrap();
         // Run the test.
-        let output = run_test(process.clone(), test);
+        let output = run_test(&process, test);
         // Check against the expected output.
         let res = test.check(&output);
         if let Err(err) = &res {
@@ -50,7 +50,7 @@ fn test_process_execute() {
 }
 
 // A helper function to run the test and extract the outputs as YAML, to be compared against the expectation.
-fn run_test(process: Process<CurrentNetwork>, test: &ProgramTest) -> serde_yaml::Mapping {
+fn run_test(process: &Process<CurrentNetwork>, test: &ProgramTest) -> serde_yaml::Mapping {
     // Initialize the output.
     let mut output = serde_yaml::Mapping::new();
     output.insert(
@@ -59,7 +59,6 @@ fn run_test(process: Process<CurrentNetwork>, test: &ProgramTest) -> serde_yaml:
     );
 
     // Add the programs into the process.
-    let mut process = process.clone();
     for program in test.programs() {
         if let Err(err) = process.add_program(program) {
             output

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -252,15 +252,15 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
 
             // Test cost computation given the Authorization and the request
             if consensus_version >= ConsensusVersion::V4 {
-                let actual_cost = execution_cost(&vm.process().read(), execution, consensus_version).unwrap();
+                let actual_cost = execution_cost(vm.process(), execution, consensus_version).unwrap();
 
                 let authorization = Authorization::from_unchecked((vec![], execution.transitions().cloned().collect()));
                 let expected_cost_given_authorization =
-                    execution_cost_for_authorization(&vm.process().read(), &authorization, consensus_version).unwrap();
+                    execution_cost_for_authorization(vm.process(), &authorization, consensus_version).unwrap();
                 assert_eq!(actual_cost, expected_cost_given_authorization);
 
                 let expected_cost_given_call = execution_cost_for_call::<CurrentAleo, _>(
-                    &vm.process().read(),
+                    vm.process(),
                     address,
                     program_id,
                     function_name,

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -228,7 +228,7 @@ function compute:
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
         // Construct the process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Add the program to the process.
         process.add_program(&program).unwrap();
 

--- a/vm/file/prover.rs
+++ b/vm/file/prover.rs
@@ -230,7 +230,7 @@ function compute:
         // Construct the process.
         let process = Process::load().unwrap();
         // Add the program to the process.
-        process.add_program(&program).unwrap();
+        process.lock().add_program(&program).unwrap();
 
         // Prepare the function name.
         let function_name = Identifier::from_str("compute").unwrap();

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -228,7 +228,7 @@ function compute:
         assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
 
         // Construct the process.
-        let mut process = Process::load().unwrap();
+        let process = Process::load().unwrap();
         // Add the program to the process.
         process.add_program(&program).unwrap();
 

--- a/vm/file/verifier.rs
+++ b/vm/file/verifier.rs
@@ -230,7 +230,7 @@ function compute:
         // Construct the process.
         let process = Process::load().unwrap();
         // Add the program to the process.
-        process.add_program(&program).unwrap();
+        process.lock().add_program(&program).unwrap();
 
         // Prepare the function name.
         let function_name = Identifier::from_str("compute").unwrap();

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -152,7 +152,7 @@ impl<N: Network> Package<N> {
     /// Returns a new process for the package.
     pub fn get_process(&self) -> Result<Process<N>> {
         // Load the default process.
-        let mut process = Process::load()?;
+        let process = Process::load()?;
         // Get the imported programs.
         let imports_directory = self.imports_directory();
         let mut programs = self

--- a/vm/package/mod.rs
+++ b/vm/package/mod.rs
@@ -194,7 +194,7 @@ impl<N: Network> Package<N> {
             .collect::<Vec<_>>();
 
         // Load the programs.
-        process.add_programs_with_editions(&programs_and_editions)?;
+        process.lock().add_programs_with_editions(&programs_and_editions)?;
 
         Ok(process)
     }


### PR DESCRIPTION
This PR is in response to https://github.com/ProvableHQ/snarkVM/issues/3193.

The current setup around the `Process` is unfortunate; its contents are either immutable or they are locked, but the `Process` itself is in an `RwLock`, and has some `&mut` methods. This is confusing, and might lead to complicated issues like the one in the link above.

While I initially considered just relaxing 2 instances of write guards to read guards, in the end I elected to remove the `RwLock` from the `Process`, and introduce an internal lock that can be used to maintain the current desired behavior of the write guards (blocking concurrent reads and writes from elsewhere), but with reduced (future) risk of deadlocks.

Note: since finalization and block insertion happen completely sequentially in a dedicated thread, the newly introduced lock is not a safeguard against concurrent use between them, but against any future use which may happen outside of those operations, but rely on the `Process` not being partially modified etc.