### PR TITLE
[Feat] Introduce `commit.*.raw` instructions

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -54,7 +54,7 @@ pub enum ConsensusVersion {
     ///      Introduces `aleo::GENERATOR`, `aleo::GENERATOR_POWERS`, `snark.verify` opcodes,
     ///      and dynamic dispatch, and identifier literal types.
     V14 = 14,
-    /// V15: Introduces the record-existence check and raw commit instruction variants.
+    /// V15: Introduces the record-existence check and `commit.*.raw` instruction variants.
     V15 = 15,
 }
 

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -54,7 +54,7 @@ pub enum ConsensusVersion {
     ///      Introduces `aleo::GENERATOR`, `aleo::GENERATOR_POWERS`, `snark.verify` opcodes,
     ///      and dynamic dispatch, and identifier literal types.
     V14 = 14,
-    /// V15: Introduces the record-existence check.
+    /// V15: Introduces the record-existence check and raw commit instruction variants.
     V15 = 15,
 }
 

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -542,6 +542,24 @@ pub fn cost_per_command<N: Network>(
         Command::Instruction(Instruction::CommitPED128(commit)) => {
             cost_in_size(stack, finalize_types, commit.operands(), HASH_PER_BYTE_COST, HASH_BASE_COST)
         }
+        Command::Instruction(Instruction::CommitBHP256Raw(commit)) => {
+            cost_in_size(stack, finalize_types, commit.operands(), HASH_BHP_PER_BYTE_COST, HASH_BHP_BASE_COST)
+        }
+        Command::Instruction(Instruction::CommitBHP512Raw(commit)) => {
+            cost_in_size(stack, finalize_types, commit.operands(), HASH_BHP_PER_BYTE_COST, HASH_BHP_BASE_COST)
+        }
+        Command::Instruction(Instruction::CommitBHP768Raw(commit)) => {
+            cost_in_size(stack, finalize_types, commit.operands(), HASH_BHP_PER_BYTE_COST, HASH_BHP_BASE_COST)
+        }
+        Command::Instruction(Instruction::CommitBHP1024Raw(commit)) => {
+            cost_in_size(stack, finalize_types, commit.operands(), HASH_BHP_PER_BYTE_COST, HASH_BHP_BASE_COST)
+        }
+        Command::Instruction(Instruction::CommitPED64Raw(commit)) => {
+            cost_in_size(stack, finalize_types, commit.operands(), HASH_PER_BYTE_COST, HASH_BASE_COST)
+        }
+        Command::Instruction(Instruction::CommitPED128Raw(commit)) => {
+            cost_in_size(stack, finalize_types, commit.operands(), HASH_PER_BYTE_COST, HASH_BASE_COST)
+        }
         Command::Instruction(Instruction::DeserializeBits(deserialize)) => {
             Ok(plaintext_size_in_bytes(stack, &PlaintextType::Array(deserialize.operand_type().clone()))?
                 .saturating_mul(CAST_PER_BYTE_COST)

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -686,6 +686,30 @@ impl<N: Network> RegisterTypes<N> {
                 matches!(instruction, Instruction::CommitPED128(..)),
                 "Instruction '{instruction}' is not for opcode '{opcode}'."
             ),
+            "commit.bhp256.raw" => ensure!(
+                matches!(instruction, Instruction::CommitBHP256Raw(..)),
+                "Instruction '{instruction}' is not for opcode '{opcode}'."
+            ),
+            "commit.bhp512.raw" => ensure!(
+                matches!(instruction, Instruction::CommitBHP512Raw(..)),
+                "Instruction '{instruction}' is not for opcode '{opcode}'."
+            ),
+            "commit.bhp768.raw" => ensure!(
+                matches!(instruction, Instruction::CommitBHP768Raw(..)),
+                "Instruction '{instruction}' is not for opcode '{opcode}'."
+            ),
+            "commit.bhp1024.raw" => ensure!(
+                matches!(instruction, Instruction::CommitBHP1024Raw(..)),
+                "Instruction '{instruction}' is not for opcode '{opcode}'."
+            ),
+            "commit.ped64.raw" => ensure!(
+                matches!(instruction, Instruction::CommitPED64Raw(..)),
+                "Instruction '{instruction}' is not for opcode '{opcode}'."
+            ),
+            "commit.ped128.raw" => ensure!(
+                matches!(instruction, Instruction::CommitPED128Raw(..)),
+                "Instruction '{instruction}' is not for opcode '{opcode}'."
+            ),
             _ => bail!("Instruction '{instruction}' is not for opcode '{opcode}'."),
         }
         Ok(())

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -1323,6 +1323,36 @@ impl<N: Network> ProgramCore<N> {
         Ok(false)
     }
 
+    /// Returns `true` if a program contains any V15 syntax.
+    /// This includes:
+    /// 1. `commit.*.raw` opcodes (raw commit variants).
+    ///
+    /// This is enforced to be `false` for programs before `ConsensusVersion::V15`.
+    #[inline]
+    pub fn contains_v15_syntax(&self) -> bool {
+        // Helper to check if an opcode is a raw commit variant.
+        let has_op = |opcode: &str| opcode.starts_with("commit.") && opcode.ends_with(".raw");
+
+        // Determine if any function instructions contain the new syntax.
+        let function_contains = cfg_iter!(self.functions())
+            .flat_map(|(_, function)| function.instructions())
+            .any(|instruction| has_op(*instruction.opcode()));
+
+        // Determine if any closure instructions contain the new syntax.
+        let closure_contains = cfg_iter!(self.closures())
+            .flat_map(|(_, closure)| closure.instructions())
+            .any(|instruction| has_op(*instruction.opcode()));
+
+        // Determine if any finalize commands or constructor commands contain the new syntax.
+        let command_contains = cfg_iter!(self.functions())
+            .flat_map(|(_, function)| function.finalize_logic().map(|finalize| finalize.commands()))
+            .flatten()
+            .chain(cfg_iter!(self.constructor).flat_map(|constructor| constructor.commands()))
+            .any(|command| matches!(command, Command::Instruction(instruction) if has_op(*instruction.opcode())));
+
+        function_contains || closure_contains || command_contains
+    }
+
     /// Returns `true` if a program contains any string type.
     /// Before ConsensusVersion::V12, variable-length string sampling when using them as inputs caused deployment synthesis to be inconsistent and abort with probability 63/64.
     /// After ConsensusVersion::V12, string types are disallowed.

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -93,6 +93,18 @@ pub enum Instruction<N: Network> {
     CommitPED64(CommitPED64<N>),
     /// Performs a Pedersen commitment on up to a 128-bit input.
     CommitPED128(CommitPED128<N>),
+    /// Performs a BHP commitment on the input's raw bits in 256-bit chunks.
+    CommitBHP256Raw(CommitBHP256Raw<N>),
+    /// Performs a BHP commitment on the input's raw bits in 512-bit chunks.
+    CommitBHP512Raw(CommitBHP512Raw<N>),
+    /// Performs a BHP commitment on the input's raw bits in 768-bit chunks.
+    CommitBHP768Raw(CommitBHP768Raw<N>),
+    /// Performs a BHP commitment on the input's raw bits in 1024-bit chunks.
+    CommitBHP1024Raw(CommitBHP1024Raw<N>),
+    /// Performs a Pedersen commitment on the input's raw bits up to a 64-bit input.
+    CommitPED64Raw(CommitPED64Raw<N>),
+    /// Performs a Pedersen commitment on the input's raw bits up to a 128-bit input.
+    CommitPED128Raw(CommitPED128Raw<N>),
     /// Deserializes the bits into a value.
     DeserializeBits(DeserializeBits<N>),
     /// Deserializes the raw bits into a value.
@@ -462,6 +474,14 @@ macro_rules! instruction {
             SnarkVerify,
             SnarkVerifyBatch,
 
+            // New opcodes added in `ConsensusVersion::V15`
+            CommitBHP256Raw,
+            CommitBHP512Raw,
+            CommitBHP768Raw,
+            CommitBHP1024Raw,
+            CommitPED64Raw,
+            CommitPED128Raw,
+
             // New opcodes should be added here, with a comment on which consensus version they were added in.
         }}
     };
@@ -685,7 +705,7 @@ mod tests {
         // Sanity check the number of instructions is unchanged.
         // Note that the number of opcodes **MUST NOT** exceed u16::MAX.
         assert_eq!(
-            123,
+            129,
             Instruction::<CurrentNetwork>::OPCODES.len(),
             "Update me if the number of instructions changes."
         );

--- a/synthesizer/program/src/logic/instruction/operation/commit.rs
+++ b/synthesizer/program/src/logic/instruction/operation/commit.rs
@@ -33,8 +33,21 @@ pub type CommitPED64<N> = CommitInstruction<N, { CommitVariant::CommitPED64 as u
 /// Pedersen128 is a collision-resistant function that processes inputs in 128-bit chunks.
 pub type CommitPED128<N> = CommitInstruction<N, { CommitVariant::CommitPED128 as u8 }>;
 
+/// BHP256 commit over raw bits (no type-tagged serialization).
+pub type CommitBHP256Raw<N> = CommitInstruction<N, { CommitVariant::CommitBHP256Raw as u8 }>;
+/// BHP512 commit over raw bits.
+pub type CommitBHP512Raw<N> = CommitInstruction<N, { CommitVariant::CommitBHP512Raw as u8 }>;
+/// BHP768 commit over raw bits.
+pub type CommitBHP768Raw<N> = CommitInstruction<N, { CommitVariant::CommitBHP768Raw as u8 }>;
+/// BHP1024 commit over raw bits.
+pub type CommitBHP1024Raw<N> = CommitInstruction<N, { CommitVariant::CommitBHP1024Raw as u8 }>;
+/// Pedersen64 commit over raw bits.
+pub type CommitPED64Raw<N> = CommitInstruction<N, { CommitVariant::CommitPED64Raw as u8 }>;
+/// Pedersen128 commit over raw bits.
+pub type CommitPED128Raw<N> = CommitInstruction<N, { CommitVariant::CommitPED128Raw as u8 }>;
+
 /// Which commit function to use.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CommitVariant {
     CommitBHP256,
     CommitBHP512,
@@ -42,6 +55,13 @@ pub enum CommitVariant {
     CommitBHP1024,
     CommitPED64,
     CommitPED128,
+    // The variants that commit over raw inputs.
+    CommitBHP256Raw,
+    CommitBHP512Raw,
+    CommitBHP768Raw,
+    CommitBHP1024Raw,
+    CommitPED64Raw,
+    CommitPED128Raw,
 }
 
 impl CommitVariant {
@@ -54,8 +74,20 @@ impl CommitVariant {
             3 => "commit.bhp1024",
             4 => "commit.ped64",
             5 => "commit.ped128",
-            6.. => panic!("Invalid 'commit' instruction opcode"),
+            // The variants that commit over raw inputs.
+            6 => "commit.bhp256.raw",
+            7 => "commit.bhp512.raw",
+            8 => "commit.bhp768.raw",
+            9 => "commit.bhp1024.raw",
+            10 => "commit.ped64.raw",
+            11 => "commit.ped128.raw",
+            12.. => panic!("Invalid 'commit' instruction opcode"),
         }
+    }
+
+    // Returns `true` if the variant commits over raw bits.
+    pub const fn is_raw(variant: u8) -> bool {
+        matches!(variant, 6..=11)
     }
 }
 
@@ -129,16 +161,21 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
 macro_rules! do_commit {
     ($N: ident, $variant: expr, $destination_type: expr, $input: expr, $randomizer: expr, $ty: ty, $q: expr) => {{
         let func = match $variant {
-            0 => $N::commit_to_group_bhp256,
-            1 => $N::commit_to_group_bhp512,
-            2 => $N::commit_to_group_bhp768,
-            3 => $N::commit_to_group_bhp1024,
-            4 => $N::commit_to_group_ped64,
-            5 => $N::commit_to_group_ped128,
-            6.. => bail!("Invalid 'commit' variant: {}", $variant),
+            0 | 6 => $N::commit_to_group_bhp256,
+            1 | 7 => $N::commit_to_group_bhp512,
+            2 | 8 => $N::commit_to_group_bhp768,
+            3 | 9 => $N::commit_to_group_bhp1024,
+            4 | 10 => $N::commit_to_group_ped64,
+            5 | 11 => $N::commit_to_group_ped128,
+            12.. => bail!("Invalid 'commit' variant: {}", $variant),
         };
 
-        let literal_output: $ty = $q(func(&$input.to_bits_le(), $randomizer))?.into();
+        let bits = match CommitVariant::is_raw($variant) {
+            true => $input.to_bits_raw_le(),
+            false => $input.to_bits_le(),
+        };
+
+        let literal_output: $ty = $q(func(&bits, $randomizer))?.into();
         literal_output.cast_lossy($destination_type)?
     }};
 }
@@ -196,7 +233,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
         stack: &impl StackTrait<N>,
         registers: &mut impl RegistersCircuit<N, A>,
     ) -> Result<()> {
-        use circuit::traits::ToBits;
+        use circuit::traits::{ToBits, ToBitsRaw};
 
         // Ensure the number of operands is correct.
         if self.operands.len() != 2 {
@@ -251,8 +288,8 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
         // TODO (howardwu): If the operation is Pedersen, check that it is within the number of bits.
 
         match VARIANT {
-            0..=5 => Ok(vec![RegisterType::Plaintext(PlaintextType::Literal(self.destination_type))]),
-            6.. => bail!("Invalid 'commit' variant: {VARIANT}"),
+            0..=11 => Ok(vec![RegisterType::Plaintext(PlaintextType::Literal(self.destination_type))]),
+            12.. => bail!("Invalid 'commit' variant: {VARIANT}"),
         }
     }
 }
@@ -396,5 +433,47 @@ mod tests {
             assert_eq!(commit.destination, Register::Locator(2), "The destination register is incorrect");
             assert_eq!(commit.destination_type, *destination_type, "The destination type is incorrect");
         }
+    }
+
+    #[test]
+    fn test_parse_raw() {
+        for destination_type in valid_destination_types() {
+            let instruction = format!("commit.bhp256.raw r0 r1 into r2 as {destination_type}");
+            let (string, commit) = CommitBHP256Raw::<CurrentNetwork>::parse(&instruction).unwrap();
+            assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+            assert_eq!(commit.operands.len(), 2, "The number of operands is incorrect");
+            assert_eq!(commit.operands[0], Operand::Register(Register::Locator(0)), "The first operand is incorrect");
+            assert_eq!(commit.operands[1], Operand::Register(Register::Locator(1)), "The second operand is incorrect");
+            assert_eq!(commit.destination, Register::Locator(2), "The destination register is incorrect");
+            assert_eq!(commit.destination_type, *destination_type, "The destination type is incorrect");
+        }
+    }
+
+    #[test]
+    fn test_raw_differs_from_standard() {
+        use console::{
+            program::{Literal, Plaintext, Value},
+            types::{Field, Scalar},
+        };
+
+        type N = CurrentNetwork;
+
+        // Use a non-trivial field literal (not zero) so the bits actually differ between
+        // to_bits_le (type-tagged) and to_bits_raw_le (untagged).
+        let input_field = Field::<N>::one();
+        let randomizer = Scalar::<N>::one();
+        let value = Value::Plaintext(Plaintext::from(Literal::Field(input_field)));
+
+        let standard = evaluate_commit(CommitVariant::CommitBHP256, &value, &randomizer, LiteralType::Field).unwrap();
+        let raw = evaluate_commit(CommitVariant::CommitBHP256Raw, &value, &randomizer, LiteralType::Field).unwrap();
+
+        assert_ne!(
+            standard, raw,
+            "commit.bhp256 and commit.bhp256.raw must produce different outputs for the same input"
+        );
+
+        // Check that committing on the field element is equivalent to the raw commit via the instruction.
+        let expected_commitment = N::commit_bhp256(&input_field.to_bits_le(), &randomizer).unwrap();
+        assert_eq!(Literal::Field(expected_commitment), raw);
     }
 }

--- a/synthesizer/program/tests/instruction/commit.rs
+++ b/synthesizer/program/tests/instruction/commit.rs
@@ -26,12 +26,18 @@ use console::{
 use snarkvm_synthesizer_process::{Process, Stack};
 use snarkvm_synthesizer_program::{
     CommitBHP256,
+    CommitBHP256Raw,
     CommitBHP512,
+    CommitBHP512Raw,
     CommitBHP768,
+    CommitBHP768Raw,
     CommitBHP1024,
+    CommitBHP1024Raw,
     CommitInstruction,
     CommitPED64,
+    CommitPED64Raw,
     CommitPED128,
+    CommitPED128Raw,
     Opcode,
     Operand,
     Program,
@@ -230,6 +236,11 @@ test_commit!(commit_bhp512, CommitBHP512);
 test_commit!(commit_bhp768, CommitBHP768);
 test_commit!(commit_bhp1024, CommitBHP1024);
 
+test_commit!(commit_bhp256_raw, CommitBHP256Raw);
+test_commit!(commit_bhp512_raw, CommitBHP512Raw);
+test_commit!(commit_bhp768_raw, CommitBHP768Raw);
+test_commit!(commit_bhp1024_raw, CommitBHP1024Raw);
+
 // Note this test must be explicitly written, instead of using the macro, because CommitPED64 and CommitToGroupPED64 fails on certain input types.
 #[test]
 fn test_commit_ped64_is_consistent() {
@@ -332,4 +343,108 @@ fn test_commit_ped128_is_consistent() {
         };
     }
     check_commit!(CommitPED128);
+}
+
+// Note this test must be explicitly written, instead of using the macro, because CommitPED64Raw fails on certain input types.
+#[test]
+fn test_commit_ped64_raw_is_consistent() {
+    // Prepare the rng.
+    let mut rng = TestRng::default();
+
+    // Prepare the test.
+    let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+    let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
+
+    macro_rules! check_commit {
+        ($operation:tt) => {
+            for _ in 0..ITERATIONS {
+                let literals_a = [
+                    Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                    Literal::I8(console::types::I8::rand(&mut rng)),
+                    Literal::I16(console::types::I16::rand(&mut rng)),
+                    Literal::I32(console::types::I32::rand(&mut rng)),
+                    Literal::U8(console::types::U8::rand(&mut rng)),
+                    Literal::U16(console::types::U16::rand(&mut rng)),
+                    Literal::U32(console::types::U32::rand(&mut rng)),
+                ];
+                let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+                for literal_a in &literals_a {
+                    for literal_b in &literals_b {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                for destination_type in valid_destination_types() {
+                                    check_commit(
+                                        |operands, destination, destination_type| {
+                                            $operation::<CurrentNetwork>::new(operands, destination, destination_type)
+                                                .unwrap()
+                                        },
+                                        $operation::<CurrentNetwork>::opcode(),
+                                        literal_a,
+                                        literal_b,
+                                        mode_a,
+                                        mode_b,
+                                        *destination_type,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+    check_commit!(CommitPED64Raw);
+}
+
+// Note this test must be explicitly written, instead of using the macro, because CommitPED128Raw fails on certain input types.
+#[test]
+fn test_commit_ped128_raw_is_consistent() {
+    // Prepare the rng.
+    let mut rng = TestRng::default();
+
+    // Prepare the test.
+    let modes_a = [circuit::Mode::Public, circuit::Mode::Private];
+    let modes_b = [circuit::Mode::Public, circuit::Mode::Private];
+
+    macro_rules! check_commit {
+        ($operation:tt) => {
+            for _ in 0..ITERATIONS {
+                let literals_a = [
+                    Literal::Boolean(console::types::Boolean::rand(&mut rng)),
+                    Literal::I8(console::types::I8::rand(&mut rng)),
+                    Literal::I16(console::types::I16::rand(&mut rng)),
+                    Literal::I32(console::types::I32::rand(&mut rng)),
+                    Literal::I64(console::types::I64::rand(&mut rng)),
+                    Literal::U8(console::types::U8::rand(&mut rng)),
+                    Literal::U16(console::types::U16::rand(&mut rng)),
+                    Literal::U32(console::types::U32::rand(&mut rng)),
+                    Literal::U64(console::types::U64::rand(&mut rng)),
+                ];
+                let literals_b = vec![Literal::Scalar(console::types::Scalar::rand(&mut rng))];
+                for literal_a in &literals_a {
+                    for literal_b in &literals_b {
+                        for mode_a in &modes_a {
+                            for mode_b in &modes_b {
+                                for destination_type in valid_destination_types() {
+                                    check_commit(
+                                        |operands, destination, destination_type| {
+                                            $operation::<CurrentNetwork>::new(operands, destination, destination_type)
+                                                .unwrap()
+                                        },
+                                        $operation::<CurrentNetwork>::opcode(),
+                                        literal_a,
+                                        literal_b,
+                                        mode_a,
+                                        mode_b,
+                                        *destination_type,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+    check_commit!(CommitPED128Raw);
 }

--- a/synthesizer/src/vm/tests/test_v15/commit_raw.rs
+++ b/synthesizer/src/vm/tests/test_v15/commit_raw.rs
@@ -1,0 +1,182 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+use console::{
+    network::Network,
+    prelude::ToBitsRaw,
+    program::{Literal, Plaintext},
+    types::{Scalar, U64},
+};
+
+// A minimal program that uses `commit.bhp256.raw`. Used for version-gate testing.
+const COMMIT_BHP256_RAW_PROGRAM: &str = r"
+program commit_bhp256_raw_test.aleo;
+
+function run:
+    input r0 as field.public;
+    input r1 as scalar.public;
+    commit.bhp256.raw r0 r1 into r2 as field;
+    output r2 as field.public;
+
+constructor:
+    assert.eq true true;
+";
+
+// A program for testing the additive homomorphism property of `commit.ped128.raw`:
+//   commit(a, r1) + commit(b, r2) == expected
+//
+// Both the function body and the finalize block verify this assertion independently.
+// Inputs are u64 values (64 bits) which fit within PED128's 128-bit generator window;
+// note that field inputs (254 bits) would exceed that limit.
+const PED128_RAW_HOMOMORPHISM_PROGRAM: &str = r"
+program test_ped128_raw_homomorphism.aleo;
+
+function check_homomorphism:
+    input r0 as u64.public;
+    input r1 as u64.public;
+    input r2 as scalar.public;
+    input r3 as scalar.public;
+    input r4 as group.public;
+    commit.ped128.raw r0 r2 into r5 as group;
+    commit.ped128.raw r1 r3 into r6 as group;
+    add r5 r6 into r7;
+    assert.eq r7 r4;
+    async check_homomorphism r0 r1 r2 r3 r4 into r8;
+    output r8 as test_ped128_raw_homomorphism.aleo/check_homomorphism.future;
+
+finalize check_homomorphism:
+    input r0 as u64.public;
+    input r1 as u64.public;
+    input r2 as scalar.public;
+    input r3 as scalar.public;
+    input r4 as group.public;
+    commit.ped128.raw r0 r2 into r5 as group;
+    commit.ped128.raw r1 r3 into r6 as group;
+    add r5 r6 into r7;
+    assert.eq r7 r4;
+
+constructor:
+    assert.eq true true;
+";
+
+// Tests that deploying a program with `commit.*.raw` instructions is aborted before
+// `ConsensusVersion::V15` and accepted at `V15`.
+#[test]
+fn test_deploy_commit_raw_before_and_at_v15() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    // Start one block before V15 so that after adding the (rejected) block we are
+    // exactly at V15 and can deploy the same program successfully.
+    let v15_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap();
+    let vm = sample_vm_at_height(v15_height - 1, rng);
+
+    let program = Program::from_str(COMMIT_BHP256_RAW_PROGRAM).unwrap();
+
+    // Deployment before V15 should be aborted.
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0, "Deployment before V15 should not be accepted");
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 1, "Deployment before V15 should be aborted");
+    vm.add_next_block(&block).unwrap();
+
+    // We should now be at V15.
+    assert_eq!(vm.block_store().current_block_height(), v15_height);
+
+    // Deployment at V15 should succeed.
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Deployment at V15 should be accepted");
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+}
+
+// Tests the additive homomorphism property of `commit.ped128.raw`:
+//   commit(a, r1) + commit(b, r2) == commit(a + b, r1 + r2)
+//
+// The expected group value is computed natively and passed into the program. Both
+// the function body and the finalize block independently verify the assertion.
+#[test]
+fn test_ped128_raw_additive_homomorphism() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    // Initialize the VM at V15 so that `commit.ped128.raw` programs can be deployed.
+    let v15_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap();
+    let vm = sample_vm_at_height(v15_height, rng);
+
+    // Deploy the homomorphism test program.
+    let program = Program::from_str(PED128_RAW_HOMOMORPHISM_PROGRAM).unwrap();
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Program deployment should succeed at V15");
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+
+    // Generate random inputs for the homomorphism test. We use u64 values which fit within PED128's 128-bit generator window;
+    let a = U64::new(u32::rand(rng) as u64);
+    let b = U64::new(u32::rand(rng) as u64);
+    let r1: Scalar<CurrentNetwork> = Scalar::rand(rng);
+    let r2: Scalar<CurrentNetwork> = Scalar::rand(rng);
+
+    // Compute commit(a, r1) and commit(b, r2) natively using the raw bit representation.
+    let a_bits = Value::<CurrentNetwork>::Plaintext(Plaintext::from(Literal::U64(a))).to_bits_raw_le();
+    let b_bits = Value::<CurrentNetwork>::Plaintext(Plaintext::from(Literal::U64(b))).to_bits_raw_le();
+    let c1 = CurrentNetwork::commit_to_group_ped128(&a_bits, &r1).unwrap();
+    let c2 = CurrentNetwork::commit_to_group_ped128(&b_bits, &r2).unwrap();
+    let expected = c1 + c2;
+
+    // Verify the homomorphism holds natively before testing it in-program:
+    //   commit(a, r1) + commit(b, r2) == commit(a + b, r1 + r2)
+    let ab_bits = (a + b).to_bits_le();
+    let r_sum = r1 + r2;
+    let c_direct = CurrentNetwork::commit_to_group_ped128(&ab_bits, &r_sum).unwrap();
+    assert_eq!(expected, c_direct, "Additive homomorphism property should hold natively");
+
+    // Execute the program, which asserts the same property in both function and finalize.
+    let execution = vm
+        .execute(
+            &caller_private_key,
+            ("test_ped128_raw_homomorphism.aleo", "check_homomorphism"),
+            [
+                Value::Plaintext(Plaintext::from(Literal::U64(a))),
+                Value::Plaintext(Plaintext::from(Literal::U64(b))),
+                Value::Plaintext(Plaintext::from(Literal::Scalar(r1))),
+                Value::Plaintext(Plaintext::from(Literal::Scalar(r2))),
+                Value::Plaintext(Plaintext::from(Literal::Group(expected))),
+            ]
+            .into_iter(),
+            None,
+            0,
+            None,
+            rng,
+        )
+        .unwrap();
+
+    let block = sample_next_block(&vm, &caller_private_key, &[execution], rng).unwrap();
+    assert_eq!(
+        block.transactions().num_accepted(),
+        1,
+        "Homomorphism assertion should pass in both function and finalize"
+    );
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+}

--- a/synthesizer/src/vm/tests/test_v15/mod.rs
+++ b/synthesizer/src/vm/tests/test_v15/mod.rs
@@ -18,6 +18,8 @@ mod record_existence;
 
 // Tests on the input/output behaviour of closures and related functionality.
 mod closure_records;
+// Tests on the use of `commit_*_raw` instruction variants.
+mod commit_raw;
 
 use super::*;
 

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -322,6 +322,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         "Invalid deployment transaction '{id}' - expected {num_functions} function verifying keys before `ConsensusVersion::V14`"
                     );
                 }
+                if consensus_version < ConsensusVersion::V15 {
+                    ensure!(
+                        !deployment.program().contains_v15_syntax(),
+                        "Invalid deployment transaction '{id}' - program uses syntax that is not allowed before `ConsensusVersion::V15`"
+                    );
+                }
 
                 // Checks required for current and future consensus versions (>= V9).
                 //


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds `.raw` variants of all commit instructions, activated at `ConsensusVersion::V15`. Raw variants commit over the untagged bit representation of the input, skipping the type-tagged serialization used by the standard variants.                                                                        
                                                                                                                                                                                                                                 
  New opcodes:                                                                                                                                                                                                                   
  - `commit.bhp256.raw`                                                                                                                                                                                                        
  - `commit.bhp512.raw`
  - `commit.bhp768.raw`                                                                                                                                                                                                          
  - `commit.bhp1024.raw`
  - `commit.ped64.raw`                                                                                                                                                                                                           
  - `commit.ped128.raw`                                                                                                                                                                                                        

## Test Plan

Unit tests for each raw variant covering parse, evaluate, and execute, and a divergence test confirming that raw and standard variants produce different outputs for the same input.

Integration tests verifying that programs using `commit.*.raw` are rejected before V15 and accepted at V15, and that `commit.ped128.raw` satisfies the Pedersen additive homomorphism property in both the function body and finalize.                                                                                                                                                       
                                                                                                                                                                                                                                 
## Backwards compatibility                                                                                                                                                                                                     

All new opcodes are gated behind `ConsensusVersion::V15`. Deployment of programs containing `commit.*.raw` is rejected before V15 via `Program::contains_v15_syntax()` enforced in `vm/verify.rs`. No existing behavior is affected.