### PR TITLE
Extend dev_skip_checks so vk public inputs don't have to match

### DIFF
--- a/synthesizer/process/src/verify_execution/mod.rs
+++ b/synthesizer/process/src/verify_execution/mod.rs
@@ -289,14 +289,17 @@ impl<N: Network> Process<N> {
         // count. The Varuna verifier pads inputs up to the domain size (the next power of two at
         // least as large as `num_public_inputs`) with zero field elements, so having fewer inputs
         // than the padded count is always valid.
-        for (verifying_key, inputs_list) in &verifier_inputs {
-            let expected = verifying_key.circuit_info.num_public_inputs;
-            for inputs in inputs_list {
-                ensure!(
-                    inputs.len() <= expected,
-                    "Verifier input count mismatch: expected at most {expected} public inputs, found {}",
-                    inputs.len()
-                );
+        #[cfg(not(feature = "dev_skip_checks"))]
+        {
+            for (verifying_key, inputs_list) in &verifier_inputs {
+                let expected = verifying_key.circuit_info.num_public_inputs;
+                for inputs in inputs_list {
+                    ensure!(
+                        inputs.len() <= expected,
+                        "Verifier input count mismatch: expected at most {expected} public inputs, found {}",
+                        inputs.len()
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Motivation

We have a `dev_skip_checks` feature so someone testing deployments won't have to synthesize function and record circuits. In this workflow, the tests uses `leo deploy --skip-deploy-certificate` to use a fixed placeholder verifying key.

We recently added an optimistic check requiring that the public inputs specified by the verifying key and execution match. But this can only be valid if the deployer goes through the effort of synthesizing the circuit.

## Test Plan

Tested manually `leo deploy --skip-deploy-certificate` on an updated https://github.com/ProvableHQ/ARCs/tree/arc20_approvals
