### PR TITLE
Add estimate_execution_cost for fee estimation without private key

### DIFF
--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -15,11 +15,12 @@
 
 use std::collections::HashMap;
 
-use crate::{Authorization, FinalizeTypes, Process, Stack, StackRef, StackTrait};
+use crate::{circuit, Authorization, FinalizeTypes, Process, Stack, StackRef, StackTrait};
 
 use console::{
+    account::PrivateKey,
     prelude::*,
-    program::{FinalizeType, Identifier, LiteralType, PlaintextType},
+    program::{FinalizeType, Identifier, LiteralType, PlaintextType, ProgramID, Value},
 };
 use snarkvm_algorithms::snark::varuna::VarunaVersion;
 use snarkvm_ledger_block::{Deployment, Execution, Transaction};
@@ -139,6 +140,35 @@ pub fn execution_cost_for_authorization<N: Network>(
     ))?;
 
     execution_cost_given_size(process, &reconstructed_execution, execution_size, consensus_version)
+}
+
+/// Estimates the execution cost in microcredits for a given program function and inputs,
+/// without requiring access to the caller's private key.
+///
+/// This is useful when the private key is stored in a hardware wallet or MPC wallet
+/// and cannot be used for arbitrary computations outside of final signing.
+///
+/// Internally, this generates an ephemeral private key to produce a valid `Authorization`
+/// (following the same pattern used by `CheckDeployment`), then delegates to
+/// `execution_cost_for_authorization` for the actual cost computation.
+pub fn estimate_execution_cost<N: Network, A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
+    process: &Process<N>,
+    program_id: impl TryInto<ProgramID<N>>,
+    function_name: impl TryInto<Identifier<N>>,
+    inputs: impl ExactSizeIterator<Item = impl TryInto<Value<N>>>,
+    consensus_version: ConsensusVersion,
+    rng: &mut R,
+) -> Result<(MinimumCost, ExecuteCostDetails)> {
+    // Generate an ephemeral private key for authorization (not used for signing the final transaction).
+    let burner_private_key = PrivateKey::new(rng)?;
+
+    // Authorize the call using the ephemeral key. Use `authorize_unchecked` to skip
+    // circuit satisfiability checks, since we only need the transitions for cost estimation.
+    let authorization =
+        process.authorize_unchecked::<A, R>(&burner_private_key, program_id, function_name, inputs, rng)?;
+
+    // Compute the execution cost from the authorization.
+    execution_cost_for_authorization(process, &authorization, consensus_version)
 }
 
 /// Returns the compute cost for a deployment in microcredits.

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -151,6 +151,13 @@ pub fn execution_cost_for_authorization<N: Network>(
 /// Internally, this generates an ephemeral private key to produce a valid `Authorization`
 /// (following the same pattern used by `CheckDeployment`), then delegates to
 /// `execution_cost_for_authorization` for the actual cost computation.
+///
+/// **Limitation:** This function only supports non-record inputs (plaintext, future, etc.).
+/// Record inputs will be rejected because `Request::sign` validates that records are owned
+/// by the signer, and the ephemeral key will not match the record owner. For programs that
+/// consume records, use `authorize` with the real key and then `execution_cost_for_authorization`.
+///
+/// Requires `consensus_version >= V4`.
 pub fn estimate_execution_cost<N: Network, A: circuit::Aleo<Network = N>, R: Rng + CryptoRng>(
     process: &Process<N>,
     program_id: impl TryInto<ProgramID<N>>,
@@ -159,13 +166,34 @@ pub fn estimate_execution_cost<N: Network, A: circuit::Aleo<Network = N>, R: Rng
     consensus_version: ConsensusVersion,
     rng: &mut R,
 ) -> Result<(MinimumCost, ExecuteCostDetails)> {
+    // Resolve inputs and reject record inputs early with a clear error.
+    let resolved_inputs: Vec<Value<N>> = inputs
+        .enumerate()
+        .map(|(index, input)| {
+            let value = input.try_into().map_err(|_| anyhow!("Failed to parse input #{index}"))?;
+            // Record inputs cannot be used with an ephemeral key because `Request::sign`
+            // validates that the record owner matches the signer.
+            ensure!(
+                !matches!(value, Value::Record(..)),
+                "estimate_execution_cost does not support record inputs (input #{index} is a record). \
+                 Use `authorize` with the real private key followed by `execution_cost_for_authorization` instead."
+            );
+            Ok(value)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
     // Generate an ephemeral private key for authorization (not used for signing the final transaction).
     let burner_private_key = PrivateKey::new(rng)?;
 
     // Authorize the call using the ephemeral key. Use `authorize_unchecked` to skip
     // circuit satisfiability checks, since we only need the transitions for cost estimation.
-    let authorization =
-        process.authorize_unchecked::<A, R>(&burner_private_key, program_id, function_name, inputs, rng)?;
+    let authorization = process.authorize_unchecked::<A, R>(
+        &burner_private_key,
+        program_id,
+        function_name,
+        resolved_inputs.into_iter(),
+        rng,
+    )?;
 
     // Compute the execution cost from the authorization.
     execution_cost_for_authorization(process, &authorization, consensus_version)


### PR DESCRIPTION
## Summary

Adds `estimate_execution_cost` — a utility function that estimates execution cost in microcredits without requiring the caller's private key.

This enables fee estimation for:
- Hardware wallets (Ledger, Trezor) where the private key cannot be extracted
- MPC wallets where key shares are distributed across parties
- Any context where fee preview is needed before committing to a signing operation

## Approach

Generates an ephemeral `PrivateKey` and calls `authorize_unchecked` to produce a valid `Authorization` with transitions. Passes the authorization to the existing `execution_cost_for_authorization` for cost computation.

This follows the same ephemeral-key pattern used by `CheckDeployment` in `stack/deploy.rs` and `synthesize_key` in `stack/helpers/synthesize.rs`.

## Changes

- `synthesizer/process/src/cost.rs` — added `estimate_execution_cost` function
- Updated imports to include `PrivateKey`, `ProgramID`, `Value`, `circuit`

## Validation

```bash
cargo check -p snarkvm-synthesizer-process  # passes
```

Closes #3180