### PR TITLE
feat: varuna performance optimisations

### DIFF
--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
@@ -168,6 +168,15 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let R_size = constraint_domain.size_as_field_element;
         let C_size = variable_domain.size_as_field_element;
 
+        // Precompute (alpha - row[i]) * (beta - col[i]) once and reuse for both b_poly evals
+        // and f inverses, saving K redundant field multiplications per matrix.
+        let cross_products: Vec<F> = row_on_K
+            .evaluations
+            .iter()
+            .zip_eq(&col_on_K.evaluations)
+            .map(|(&r, &c)| (alpha - r) * (beta - c))
+            .collect();
+
         let mut job_pool = snarkvm_utilities::ExecutionPool::with_capacity(2);
         job_pool.add_job(|| {
             let a_poly_time = start_timer!(|| format!("Computing a poly for {label}"));
@@ -182,14 +191,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 
         job_pool.add_job(|| {
             let b_poly_time = start_timer!(|| format!("Computing b poly for {label}"));
-            let alpha_beta = alpha * beta;
             let b_poly = {
-                let evals: Vec<F> = row_on_K
-                    .evaluations
-                    .iter()
-                    .zip_eq(&col_on_K.evaluations)
-                    .map(|(&r, &c)| R_size * C_size * (alpha_beta - beta * r - alpha * c + r * c))
-                    .collect();
+                let evals: Vec<F> = cross_products.iter().map(|&cp| R_size * C_size * cp).collect();
                 EvaluationsOnDomain::from_vec_and_domain(evals, non_zero_domain)
                     .interpolate_with_pc(ifft_precomputation)
             };
@@ -199,8 +202,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let [a_poly, b_poly]: [_; 2] = job_pool.execute_all().try_into().unwrap();
 
         let f_evals_time = start_timer!(|| format!("Computing f evals on K for {label}"));
-        let mut inverses: Vec<_> =
-            row_on_K.evaluations.iter().zip_eq(&col_on_K.evaluations).map(|(r, c)| (alpha - r) * (beta - c)).collect();
+        // Move cross_products directly into inverses — no second pass over row/col needed.
+        let mut inverses = cross_products;
 
         let matrix_sumcheck_constants = v_R_i_alpha_v_C_i_beta * constraint_domain.size_inv * variable_domain.size_inv;
         batch_inversion_and_mul(&mut inverses, &matrix_sumcheck_constants);

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
@@ -167,8 +167,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             (&arithmetization.row, &arithmetization.col, &arithmetization.row_col_val);
         let R_size_C_size = constraint_domain.size_as_field_element * variable_domain.size_as_field_element;
 
-        // Precompute (alpha - row[i]) * (beta - col[i]) once and reuse for both b_poly evals
-        // and f inverses, saving K redundant field multiplications per matrix.
+        // Precompute (alpha - row[i]) * (beta - col[i]) once and reuse for both b_poly
+        // evals and f inverses, saving K redundant field multiplications per
+        // matrix.
         let cross_products: Vec<F> = row_on_K
             .evaluations
             .iter()
@@ -201,7 +202,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let [a_poly, b_poly]: [_; 2] = job_pool.execute_all().try_into().unwrap();
 
         let f_evals_time = start_timer!(|| format!("Computing f evals on K for {label}"));
-        // Move cross_products directly into inverses - no second pass over row/col needed.
+        // Move cross_products directly into inverses - no second pass over row/col
+        // needed.
         let mut inverses = cross_products;
 
         let matrix_sumcheck_constants = v_R_i_alpha_v_C_i_beta * constraint_domain.size_inv * variable_domain.size_inv;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/fourth.rs
@@ -165,8 +165,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
     ) -> Result<(Sum<F>, Lhs<F>, Gpoly<F>, Apoly<F>, Bpoly<F>)> {
         let (row_on_K, col_on_K, row_col_val) =
             (&arithmetization.row, &arithmetization.col, &arithmetization.row_col_val);
-        let R_size = constraint_domain.size_as_field_element;
-        let C_size = variable_domain.size_as_field_element;
+        let R_size_C_size = constraint_domain.size_as_field_element * variable_domain.size_as_field_element;
 
         // Precompute (alpha - row[i]) * (beta - col[i]) once and reuse for both b_poly evals
         // and f inverses, saving K redundant field multiplications per matrix.
@@ -192,7 +191,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         job_pool.add_job(|| {
             let b_poly_time = start_timer!(|| format!("Computing b poly for {label}"));
             let b_poly = {
-                let evals: Vec<F> = cross_products.iter().map(|&cp| R_size * C_size * cp).collect();
+                let evals: Vec<F> = cross_products.iter().map(|&cp| R_size_C_size * cp).collect();
                 EvaluationsOnDomain::from_vec_and_domain(evals, non_zero_domain)
                     .interpolate_with_pc(ifft_precomputation)
             };
@@ -202,7 +201,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let [a_poly, b_poly]: [_; 2] = job_pool.execute_all().try_into().unwrap();
 
         let f_evals_time = start_timer!(|| format!("Computing f evals on K for {label}"));
-        // Move cross_products directly into inverses — no second pass over row/col needed.
+        // Move cross_products directly into inverses - no second pass over row/col needed.
         let mut inverses = cross_products;
 
         let matrix_sumcheck_constants = v_R_i_alpha_v_C_i_beta * constraint_domain.size_inv * variable_domain.size_inv;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -132,11 +132,12 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                             matrix_transpose,
                             *alpha,
                         )?;
-                        let sum = z_m_at_alpha
-                            .evaluate_over_domain_by_ref(circuit_specific_state.variable_domain)
-                            .evaluations
-                            .into_iter()
-                            .sum::<F>();
+                        // sum_{h∈H} p(h) = n*(c_0 + c_n) for deg(p) < 2n: sum_{h∈H} h^k = n iff n|k, else 0,
+                        // and in [0, 2n-2] only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
+                        let n = circuit_specific_state.variable_domain.size_as_field_element;
+                        let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
+                        let c_n = z_m_at_alpha.coeffs.get(circuit_specific_state.variable_domain.size()).copied().unwrap_or_default();
+                        let sum = n * (c_0 + c_n);
                         Ok((circuit, LinevalPrepInstance { z_m_at_alpha, sum }))
                     });
                 }

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -132,7 +132,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                             matrix_transpose,
                             *alpha,
                         )?;
-                        // sum_{h∈H} p(h) = n*(c_0 + c_n) for deg(p) < 2n: sum_{h∈H} h^k = n iff n|k, else 0,
+                        // sum_{h in H} f(h) = n*(c_0 + c_n) for deg(p) < 2n, where c_0 and c_n are the coeffs of f at degree 0 and n, resp.
                         // and in [0, 2n-2] only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
                         let n = circuit_specific_state.variable_domain.size_as_field_element;
                         let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -132,11 +132,16 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                             matrix_transpose,
                             *alpha,
                         )?;
-                        // sum_{h in H} f(h) = n*(c_0 + c_n) for deg(p) < 2n, where c_0 and c_n are the coeffs of f at degree 0 and n, resp.
-                        // and in [0, 2n-2] only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
+                        // sum_{h in H} f(h) = n*(c_0 + c_n) for deg(p) < 2n, where c_0 and c_n are the
+                        // coeffs of f at degree 0 and n, resp. and in [0, 2n-2]
+                        // only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
                         let n = circuit_specific_state.variable_domain.size_as_field_element;
                         let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
-                        let c_n = z_m_at_alpha.coeffs.get(circuit_specific_state.variable_domain.size()).copied().unwrap_or_default();
+                        let c_n = z_m_at_alpha
+                            .coeffs
+                            .get(circuit_specific_state.variable_domain.size())
+                            .copied()
+                            .unwrap_or_default();
                         let sum = n * (c_0 + c_n);
                         Ok((circuit, LinevalPrepInstance { z_m_at_alpha, sum }))
                     });

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -136,21 +136,12 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                         // coeffs of f at degree 0 and n, resp. and in [0, 2n-2]
                         // only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
                         let n = circuit_specific_state.variable_domain.size_as_field_element;
-                        let c_0 = z_m_at_alpha
-                            .coeffs
-                            .first()
-                            .copied()
-                            .ok_or_else(|| anyhow::anyhow!("z_m_at_alpha has no coefficients"))?;
+                        let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
                         let c_n = z_m_at_alpha
                             .coeffs
                             .get(circuit_specific_state.variable_domain.size())
                             .copied()
-                            .ok_or_else(|| {
-                                anyhow::anyhow!(
-                                    "z_m_at_alpha missing coefficient at index {}",
-                                    circuit_specific_state.variable_domain.size()
-                                )
-                            })?;
+                            .unwrap_or_default();
                         let sum = n * (c_0 + c_n);
                         Ok((circuit, LinevalPrepInstance { z_m_at_alpha, sum }))
                     });

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -136,12 +136,21 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                         // coeffs of f at degree 0 and n, resp. and in [0, 2n-2]
                         // only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
                         let n = circuit_specific_state.variable_domain.size_as_field_element;
-                        let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
+                        let c_0 = z_m_at_alpha
+                            .coeffs
+                            .first()
+                            .copied()
+                            .ok_or_else(|| anyhow::anyhow!("z_m_at_alpha has no coefficients"))?;
                         let c_n = z_m_at_alpha
                             .coeffs
                             .get(circuit_specific_state.variable_domain.size())
                             .copied()
-                            .unwrap_or_default();
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "z_m_at_alpha missing coefficient at index {}",
+                                    circuit_specific_state.variable_domain.size()
+                                )
+                            })?;
                         let sum = n * (c_0 + c_n);
                         Ok((circuit, LinevalPrepInstance { z_m_at_alpha, sum }))
                     });

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -393,16 +393,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         // coeffs of f at degree 0 and n, resp. and in [0, 2n-2] only k=0 and
         // k=n are multiples of n. Avoids an O(n log n) FFT.
         let n = variable_domain.size_as_field_element;
-        let c_0 = z_m_at_alpha
-            .coeffs
-            .first()
-            .copied()
-            .ok_or_else(|| anyhow::anyhow!("z_m_at_alpha has no coefficients"))?;
-        let c_n = z_m_at_alpha
-            .coeffs
-            .get(variable_domain.size())
-            .copied()
-            .ok_or_else(|| anyhow::anyhow!("z_m_at_alpha missing coefficient at index {}", variable_domain.size()))?;
+        let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
+        let c_n = z_m_at_alpha.coeffs.get(variable_domain.size()).copied().unwrap_or_default();
         let sum = n * (c_0 + c_n);
 
         let (h_1_i, xg_1_i) =

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -393,8 +393,16 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         // coeffs of f at degree 0 and n, resp. and in [0, 2n-2] only k=0 and
         // k=n are multiples of n. Avoids an O(n log n) FFT.
         let n = variable_domain.size_as_field_element;
-        let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
-        let c_n = z_m_at_alpha.coeffs.get(variable_domain.size()).copied().unwrap_or_default();
+        let c_0 = z_m_at_alpha
+            .coeffs
+            .first()
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("z_m_at_alpha has no coefficients"))?;
+        let c_n = z_m_at_alpha
+            .coeffs
+            .get(variable_domain.size())
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("z_m_at_alpha missing coefficient at index {}", variable_domain.size()))?;
         let sum = n * (c_0 + c_n);
 
         let (h_1_i, xg_1_i) =

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -389,8 +389,9 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         z_m_at_alpha: Option<DensePolynomial<F>>,
     ) -> Result<LinevalInstance<F>> {
         let mut z_m_at_alpha = z_m_at_alpha.ok_or(anyhow::anyhow!(format!("Expected z_{_matrix_label}_at_alpha")))?;
-        // sum_{h in H} f(h) = n*(c_0 + c_n) for deg(p) < 2n, where c_0 and c_n are the coeffs of f at degree 0 and n, resp.
-        // and in [0, 2n-2] only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
+        // sum_{h in H} f(h) = n*(c_0 + c_n) for deg(p) < 2n, where c_0 and c_n are the
+        // coeffs of f at degree 0 and n, resp. and in [0, 2n-2] only k=0 and
+        // k=n are multiples of n. Avoids an O(n log n) FFT.
         let n = variable_domain.size_as_field_element;
         let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
         let c_n = z_m_at_alpha.coeffs.get(variable_domain.size()).copied().unwrap_or_default();

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -389,7 +389,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         z_m_at_alpha: Option<DensePolynomial<F>>,
     ) -> Result<LinevalInstance<F>> {
         let mut z_m_at_alpha = z_m_at_alpha.ok_or(anyhow::anyhow!(format!("Expected z_{_matrix_label}_at_alpha")))?;
-        // sum_{h∈H} p(h) = n*(c_0 + c_n) for deg(p) < 2n: sum_{h∈H} h^k = n iff n|k, else 0,
+        // sum_{h in H} f(h) = n*(c_0 + c_n) for deg(p) < 2n, where c_0 and c_n are the coeffs of f at degree 0 and n, resp.
         // and in [0, 2n-2] only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
         let n = variable_domain.size_as_field_element;
         let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -389,7 +389,12 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         z_m_at_alpha: Option<DensePolynomial<F>>,
     ) -> Result<LinevalInstance<F>> {
         let mut z_m_at_alpha = z_m_at_alpha.ok_or(anyhow::anyhow!(format!("Expected z_{_matrix_label}_at_alpha")))?;
-        let sum = z_m_at_alpha.evaluate_over_domain_by_ref(*variable_domain).evaluations.into_iter().sum::<F>();
+        // sum_{h∈H} p(h) = n*(c_0 + c_n) for deg(p) < 2n: sum_{h∈H} h^k = n iff n|k, else 0,
+        // and in [0, 2n-2] only k=0 and k=n are multiples of n. Avoids an O(n log n) FFT.
+        let n = variable_domain.size_as_field_element;
+        let c_0 = z_m_at_alpha.coeffs.first().copied().unwrap_or_default();
+        let c_n = z_m_at_alpha.coeffs.get(variable_domain.size()).copied().unwrap_or_default();
+        let sum = n * (c_0 + c_n);
 
         let (h_1_i, xg_1_i) =
             apply_randomized_selector(&mut z_m_at_alpha, combiner, max_variable_domain, variable_domain, true)?;

--- a/algorithms/src/snark/varuna/ahp/selectors.rs
+++ b/algorithms/src/snark/varuna/ahp/selectors.rs
@@ -116,6 +116,17 @@ pub(crate) fn apply_randomized_selector<F: PrimeField>(
         // That's what we're computing here.
         let selector_time = start_timer!(|| "Compute selector with remainder witness");
 
+        // Fast path: when src and target domains are equal, the selector polynomial is 1.
+        // The multiplier simplifies to `combiner` (size/size = 1), and the subsequent
+        // mul_by_vanishing_poly(target) + divide_by_vanishing_poly(src) round-trip
+        // cancels exactly since v_target == v_src. This fires on every single-circuit proof.
+        if src_domain.size == target_domain.size {
+            poly.coeffs.iter_mut().for_each(|c| *c *= combiner);
+            let (h_i, xg_i) = poly.divide_by_vanishing_poly(*src_domain)?;
+            end_timer!(selector_time);
+            return Ok((h_i, Some(xg_i)));
+        }
+
         let multiplier = combiner * src_domain.size_as_field_element * target_domain.size_inv;
         poly.coeffs.iter_mut().for_each(|c| *c *= multiplier);
 

--- a/algorithms/src/snark/varuna/ahp/selectors.rs
+++ b/algorithms/src/snark/varuna/ahp/selectors.rs
@@ -116,31 +116,36 @@ pub(crate) fn apply_randomized_selector<F: PrimeField>(
         // That's what we're computing here.
         let selector_time = start_timer!(|| "Compute selector with remainder witness");
 
-        // Fast path: when src and target domains are equal, the selector polynomial is 1.
-        // The multiplier simplifies to `combiner` (size/size = 1), and the subsequent
-        // mul_by_vanishing_poly(target) + divide_by_vanishing_poly(src) round-trip
-        // cancels exactly since v_target == v_src. This fires on every single-circuit proof.
-        if src_domain.size == target_domain.size {
-            poly.coeffs.iter_mut().for_each(|c| *c *= combiner);
-            let (h_i, xg_i) = poly.divide_by_vanishing_poly(*src_domain)?;
-            end_timer!(selector_time);
-            return Ok((h_i, Some(xg_i)));
-        }
+        let multiplier = if src_domain.size == target_domain.size {
+            combiner
+        } else {
+            combiner * src_domain.size_as_field_element * target_domain.size_inv
+        };
 
-        let multiplier = combiner * src_domain.size_as_field_element * target_domain.size_inv;
         poly.coeffs.iter_mut().for_each(|c| *c *= multiplier);
 
-        let (h_i, mut xg_i) = poly.divide_by_vanishing_poly(*src_domain)?;
-        xg_i = xg_i.mul_by_vanishing_poly(*target_domain);
+        let (h_i, xg_i) = poly.divide_by_vanishing_poly(*src_domain)?;
 
-        let (xg_i, remainder) = xg_i.divide_by_vanishing_poly(*src_domain)?;
-        ensure!(
-            remainder.is_zero(),
-            "[Returning remainder witness] Failed to divide by vanishing polynomial - non-zero remainder ({remainder:?})"
-        );
+        // Computing xg_i * s_i with s_i = (v_H / v_H_i) * (H_i.size() /
+        // H.size()) without the last constant, which was already incorporated
+        // into the multiplier. If the two domains are equal, s_i = 1 and we
+        // skip this step.
+        let updated_xg_i = if src_domain.size == target_domain.size {
+            xg_i
+        } else {
+            let xg_i = xg_i.mul_by_vanishing_poly(*target_domain);
+
+            let (xg_i, remainder) = xg_i.divide_by_vanishing_poly(*src_domain)?;
+            ensure!(
+                remainder.is_zero(),
+                "[Returning remainder witness] Failed to divide by vanishing polynomial - non-zero remainder ({remainder:?})"
+            );
+
+            xg_i
+        };
 
         end_timer!(selector_time);
-        Ok((h_i, Some(xg_i)))
+        Ok((h_i, Some(updated_xg_i)))
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

The following performance improvements were applied.

#### 1. Cross-product precomputation in the fourth round (`fourth.rs`)

The expressions `(α − row[i]) · (β − col[i])` were computed independently for the `b_poly` evaluations and the `f` inverses. This hoists the product into a single pass over `row_on_K`/`col_on_K` and reuses the resulting vector for both consumers, eliminating K redundant field multiplications per matrix.

#### 2. Closed-form domain summation (`prepare_third.rs`, `third.rs`)

Computing `∑_{h∈H} p(h)` via `evaluate_over_domain_by_ref` required a full O(n log n) FFT followed by a linear sum. For a polynomial of degree < 2n evaluated over a domain of size n, the identity `∑_{h∈H} h^k = n` iff `n | k` (and 0 otherwise) means the sum collapses to `n · (c₀ + cₙ)`, a constant-time read of two coefficients. Applied in both the third-round preparation and the third-round lineval computation.

#### 3. Equal-domain fast path in `apply_randomized_selector` (`selectors.rs`)

When source and target domains have the same size (true for every single-circuit proof), the selector polynomial is the identity. The existing code would multiply by the vanishing polynomial of the target domain and then divide by the vanishing polynomial of the source domain, an expensive round-trip that cancels exactly. The new fast path detects `src.size == target.size`, scales the polynomial by `combiner` directly, and proceeds to the division, avoiding the unnecessary multiply step entirely.

## Test Plan

### Correctness

```
cargo test -p snarkvm-algorithms -- varuna
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 62 filtered out; finished in 204.07s
```

### Performance

### Benchmark Results (`credits.aleo`)

| Function | Baseline | After | Δ (median) |
|---|---|---|---|
| `transfer_public` | 347.58 ms | 329.90 ms | **−4.9 %** |
| `transfer_private` | 2.9346 s | 2.8005 s | **−4.6 %** |
| `transfer_public_to_private` | 569.13 ms | 533.04 ms | **−6.3 %** |
| `transfer_private_to_public` | 2.9016 s | 2.7622 s | **−4.8 %** |
| `join` | 3.3261 s | 3.1319 s | **−5.8 %** |
| `split` | 2.8807 s | 2.7583 s | **−4.2 %** |

## Documentation
No documentation changes needed.

## Backwards compatibility
These changes are fully backwards compatible.
