### PR TITLE
Fix target adjustment tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1273,13 +1273,18 @@ workflows:
       - utilities-derives
       - wasm
 
+  # Jobs specific to this branch to run
+  custom-workflow:
+    when: pipeline.git.branch == "fix_target_adjustment_tests"
+    jobs:
+      - ledger-block
+
   # Run additional but unlikely to fail checks on merges only
   merge-workflow:
     when: pipeline.git.branch == "staging"
       or pipeline.git.branch == "canary"
       or pipeline.git.branch == "testnet"
       or pipeline.git.branch == "mainnet"
-      or pipeline.git.branch == "make_parameter_downloads_more_robust"
     jobs:
       - check-unused-dependencies # This can be cleaned up before releases
       - check-cargo-semver-checks # This can be cleaned up before releases

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -2124,7 +2124,7 @@ mod tests {
         }
 
         // A larger anchor time shrinks the drift-to-anchor ratio (15/35 < 15/25),
-        // so more blocks are needed to double the target.
-        assert!(num_blocks_v15 > num_blocks_v1);
+        // so less blocks are needed to double the target.
+        assert!(num_blocks_v15 < num_blocks_v1);
     }
 }


### PR DESCRIPTION
## Motivation

One test failed in the `merge-workflow`. The fix is consistent with my understanding of the impacts of the new anchor time: halvings will be reached slower but doublings will be reached faster.

And if I recall correctly, @ljedrz ' simulations indicated that with fast blocktimes, the target will not keep increasing but will settle on some higher steady state. @raychu86 is this in line with your expectations?