### PR TITLE
[Chore] Update `bech32` and `sha2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,21 +419,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -463,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -663,9 +657,18 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpubits"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -909,9 +912,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.17"
+version = "0.17.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
+checksum = "54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96"
 dependencies = [
  "der",
  "digest 0.11.2",
@@ -929,9 +932,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.31"
+version = "0.14.0-rc.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
+checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1466,9 +1469,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "subtle",
  "typenum",
@@ -1650,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1729,27 +1732,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote 1.0.45",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1783,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1813,7 +1821,7 @@ dependencies = [
  "cpubits",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2633,9 +2641,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2783,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2811,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2821,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -3051,12 +3059,23 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
 
@@ -3090,6 +3109,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_moving_average"
@@ -3170,7 +3205,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "snarkvm-algorithms-cuda",
  "snarkvm-curves",
@@ -3251,7 +3286,7 @@ dependencies = [
  "nom",
  "num-traits",
  "serial_test",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "snarkvm-algorithms",
  "snarkvm-circuit",
@@ -3962,7 +3997,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4860,9 +4895,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4873,9 +4908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4883,9 +4918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -4893,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4906,18 +4941,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.68"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+checksum = "29826f9d9ecaa314c480d376b276d1c790e6cb6a4681fab8532da69cbabf977d"
 dependencies = [
  "async-trait",
  "cast",
@@ -4937,9 +4972,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.68"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+checksum = "c610311887f9e6599a546d278d12d69dfd3a3e92639b2129e4b11ad6cf1961d6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -4948,9 +4983,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+checksum = "60238e5b4b1b295701d6f9a66d2a126fe19990348f5fb9dae3b623a370119d94"
 
 [[package]]
 name = "wasm-encoder"
@@ -4988,9 +5023,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5084,15 +5119,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5125,21 +5151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5177,12 +5188,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5195,12 +5200,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5210,12 +5209,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5243,12 +5236,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5258,12 +5245,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5279,12 +5260,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5294,12 +5269,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,9 +909,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.16"
+version = "0.17.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
+checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
 dependencies = [
  "der",
  "digest 0.11.2",
@@ -929,9 +929,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.29"
+version = "0.14.0-rc.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84043d573efd4ac9d2d125817979a379204bf7e328b25a4a30487e8d100e618"
+checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.8"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2c6c227649d5ec80eaae541f1736232641a0bcdb3062a52b34edb42054158"
+checksum = "1b382cbfd43caf55991a93850ce538aa1aa67bb264af367d22dfe7937c4e997d"
 dependencies = [
  "cpubits",
  "ecdsa",
@@ -1836,9 +1836,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2155,9 +2155,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -2187,9 +2187,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2783,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2848,9 +2848,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4321,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
+checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
 dependencies = [
  "env_logger",
  "test-log-macros",
@@ -4331,14 +4331,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-log-macros"
-version = "0.2.19"
+name = "test-log-core"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn 2.0.117",
+ "test-log-core",
 ]
 
 [[package]]
@@ -4664,9 +4674,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -4832,11 +4842,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4845,7 +4855,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5311,6 +5321,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,7 +4016,6 @@ name = "snarkvm-slipstream-plugin-interface"
 version = "4.6.0"
 dependencies = [
  "anyhow",
- "tracing",
 ]
 
 [[package]]
@@ -4026,12 +4025,9 @@ dependencies = [
  "anyhow",
  "json5",
  "libloading",
- "locktick",
- "parking_lot",
  "serde_json",
  "snarkvm-slipstream-plugin-interface",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -263,9 +263,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bincode"
@@ -320,9 +320,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -463,8 +463,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "cpufeatures",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -669,15 +669,6 @@ checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -768,7 +759,7 @@ dependencies = [
  "ctutils",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -790,7 +781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -938,16 +929,16 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.30"
+version = "0.14.0-rc.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
+checksum = "e84043d573efd4ac9d2d125817979a379204bf7e328b25a4a30487e8d100e618"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common 0.2.1",
  "digest 0.11.2",
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -1329,7 +1320,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1506,15 +1497,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1793,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1823,7 +1813,7 @@ dependencies = [
  "cpubits",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -1846,9 +1836,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -1953,9 +1943,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2165,11 +2155,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2197,9 +2187,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -2299,9 +2289,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2388,9 +2378,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
@@ -2435,7 +2425,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -2490,9 +2480,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2500,13 +2490,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2526,7 +2516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2540,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -2551,7 +2541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2569,14 +2559,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60aa6af80be32871323012e02e6e65f8a7cc7890931ae421d217ad8fe0df2ccf"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2598,7 +2588,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2750,7 +2740,7 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2760,7 +2750,7 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -2771,7 +2761,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2784,7 +2774,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2793,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2858,9 +2848,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2948,7 +2938,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3061,23 +3051,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest 0.11.2",
 ]
 
@@ -3103,7 +3082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest 0.11.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3149,7 +3128,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "dotenvy",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rusty-hook",
  "serde_json",
  "snarkvm",
@@ -3186,12 +3165,12 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "snarkvm-algorithms-cuda",
  "snarkvm-curves",
@@ -3272,7 +3251,7 @@ dependencies = [
  "nom",
  "num-traits",
  "serial_test",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "snarkvm-algorithms",
  "snarkvm-circuit",
@@ -3305,7 +3284,7 @@ name = "snarkvm-circuit-program"
 version = "4.6.0"
 dependencies = [
  "anyhow",
- "rand 0.10.0",
+ "rand 0.10.1",
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3401,7 +3380,7 @@ dependencies = [
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
 dependencies = [
- "rand 0.10.0",
+ "rand 0.10.1",
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
  "snarkvm-circuit-types-field",
@@ -3499,7 +3478,7 @@ dependencies = [
  "itertools 0.14.0",
  "nom",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -3631,7 +3610,7 @@ version = "4.6.0"
 dependencies = [
  "bincode",
  "criterion",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustc_version",
  "serde",
  "snarkvm-fields",
@@ -3648,7 +3627,7 @@ dependencies = [
  "criterion",
  "itertools 0.14.0",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "snarkvm-curves",
@@ -3670,7 +3649,7 @@ dependencies = [
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "serde_json",
@@ -3700,7 +3679,7 @@ version = "4.6.0"
 dependencies = [
  "anyhow",
  "bincode",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-authority",
@@ -3745,7 +3724,7 @@ dependencies = [
  "indexmap 2.14.0",
  "parking_lot",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rand_distr",
  "rayon",
@@ -3861,7 +3840,7 @@ dependencies = [
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "serde_json",
@@ -3882,7 +3861,7 @@ dependencies = [
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "snarkvm-circuit",
@@ -3980,10 +3959,10 @@ dependencies = [
  "locktick",
  "parking_lot",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "reqwest",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4036,7 +4015,7 @@ dependencies = [
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde_json",
  "serde_yaml",
@@ -4087,7 +4066,7 @@ dependencies = [
  "itertools 0.14.0",
  "locktick",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "serde_json",
@@ -4116,7 +4095,7 @@ dependencies = [
  "indexmap 2.14.0",
  "k256",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "serde_json",
@@ -4166,7 +4145,7 @@ dependencies = [
  "criterion",
  "num-bigint",
  "num_cpus",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_xorshift 0.5.0",
  "rayon",
  "serde",
@@ -4509,9 +4488,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4571,7 +4550,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -4871,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4884,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4894,9 +4873,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -4904,9 +4883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4917,18 +4896,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
 dependencies = [
  "async-trait",
  "cast",
@@ -4948,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -4959,9 +4938,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"
@@ -4991,7 +4970,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -4999,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5019,18 +4998,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5382,7 +5361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,7 +534,7 @@ version = "1.0"
 version = "2.0"
 
 [workspace.dependencies.sha2]
-version = "0.10"
+version = "0.11"
 default-features = false
 
 [workspace.dependencies.smallvec]

--- a/console/account/src/signature/parse.rs
+++ b/console/account/src/signature/parse.rs
@@ -40,7 +40,9 @@ impl<N: Network> FromStr for Signature<N> {
     /// Reads in the signature string.
     fn from_str(signature: &str) -> Result<Self, Self::Err> {
         // Decode the signature string from bech32m.
-        let (hrp, data) = bech32::decode(signature)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(signature)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != SIGNATURE_PREFIX {
             bail!("Failed to decode signature: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -63,7 +65,7 @@ impl<N: Network> Display for Signature<N> {
         // Convert the signature to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(SIGNATURE_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(SIGNATURE_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/console/account/src/signature/parse.rs
+++ b/console/account/src/signature/parse.rs
@@ -40,16 +40,14 @@ impl<N: Network> FromStr for Signature<N> {
     /// Reads in the signature string.
     fn from_str(signature: &str) -> Result<Self, Self::Err> {
         // Decode the signature string from bech32m.
-        let (hrp, data, variant) = bech32::decode(signature)?;
-        if hrp != SIGNATURE_PREFIX {
+        let (hrp, data) = bech32::decode(signature)?;
+        if hrp.as_str() != SIGNATURE_PREFIX {
             bail!("Failed to decode signature: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode signature: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found an signature that is not bech32m encoded: {signature}");
         }
-        // Decode the signature data from u5 to u8, and into the signature.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the signature data into the signature.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -65,8 +63,8 @@ impl<N: Network> Display for Signature<N> {
         // Convert the signature to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(SIGNATURE_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(SIGNATURE_PREFIX), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/console/network/environment/Cargo.toml
+++ b/console/network/environment/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 workspace = true
 
 [dependencies.bech32]
-version = "0.9"
+version = "0.11"
 
 [dependencies.itertools]
 workspace = true

--- a/console/network/environment/src/helpers/mod.rs
+++ b/console/network/environment/src/helpers/mod.rs
@@ -21,3 +21,21 @@ pub use sanitizer::Sanitizer;
 
 pub mod variable_length;
 pub use variable_length::{read_variable_length_integer, variable_length_integer};
+
+/// A bech32m checksum with no hard length limit.
+///
+/// bech32 0.11 caps [`bech32::Bech32m`] at 1023 characters, but Aleo types such as
+/// ciphertexts, state paths, and snark keys can legitimately exceed this. This type
+/// uses identical generator coefficients and target residue as `Bech32m`, so encoded
+/// strings are valid bech32m and round-trip correctly with any standard decoder that
+/// does not enforce a maximum length.
+pub enum LongBech32m {}
+
+impl bech32::primitives::checksum::Checksum for LongBech32m {
+    type MidstateRepr = u32;
+
+    const CHECKSUM_LENGTH: usize = 6;
+    const CODE_LENGTH: usize = usize::MAX;
+    const GENERATOR_SH: [u32; 5] = [0x3b6a_57b2, 0x2650_8e6d, 0x1ea1_19fa, 0x3d42_33dd, 0x2a14_62b3];
+    const TARGET_RESIDUE: u32 = 0x2bc830a3;
+}

--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -134,7 +134,7 @@ pub mod prelude {
     };
 
     pub use anyhow::{Error, Result, anyhow, bail, ensure};
-    pub use bech32::{self, FromBase32, ToBase32};
+    pub use bech32;
     pub use itertools::Itertools;
     pub use nom::{
         Err,

--- a/console/network/src/helpers/id.rs
+++ b/console/network/src/helpers/id.rs
@@ -126,7 +126,9 @@ impl<F: FieldTrait, const PREFIX: u16> FromStr for AleoID<F, PREFIX> {
             bail!("Invalid byte size for a bech32m hash: {} bytes", string.len())
         }
 
-        let (hrp, data) = bech32::decode(string)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(string)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_bytes() != PREFIX.to_le_bytes() {
             bail!("Invalid prefix for a bech32m hash: {hrp}")
         };
@@ -140,7 +142,7 @@ impl<F: FieldTrait, const PREFIX: u16> FromStr for AleoID<F, PREFIX> {
 impl<F: FieldTrait, const PREFIX: u16> Display for AleoID<F, PREFIX> {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        bech32::encode_to_fmt::<bech32::Bech32m, _>(
+        bech32::encode_to_fmt::<LongBech32m, _>(
             f,
             bech32::Hrp::parse_unchecked(&Self::prefix()),
             &self.0.to_bytes_le().expect("Failed to write data as bytes"),

--- a/console/network/src/helpers/id.rs
+++ b/console/network/src/helpers/id.rs
@@ -16,7 +16,6 @@
 use crate::prelude::*;
 
 use anyhow::Result;
-use bech32::{self, FromBase32, ToBase32};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::borrow::Borrow;
 
@@ -127,30 +126,26 @@ impl<F: FieldTrait, const PREFIX: u16> FromStr for AleoID<F, PREFIX> {
             bail!("Invalid byte size for a bech32m hash: {} bytes", string.len())
         }
 
-        let (hrp, data, variant) = bech32::decode(string)?;
+        let (hrp, data) = bech32::decode(string)?;
         if hrp.as_bytes() != PREFIX.to_le_bytes() {
             bail!("Invalid prefix for a bech32m hash: {hrp}")
         };
         if data.is_empty() {
             bail!("Bech32m hash data is empty")
         }
-        if variant != bech32::Variant::Bech32m {
-            bail!("Hash is not a bech32m hash")
-        }
-        Ok(Self::read_le(&*Vec::from_base32(&data)?)?)
+        Ok(Self::read_le(&*data)?)
     }
 }
 
 impl<F: FieldTrait, const PREFIX: u16> Display for AleoID<F, PREFIX> {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        bech32::encode_to_fmt(
+        bech32::encode_to_fmt::<bech32::Bech32m, _>(
             f,
-            &Self::prefix(),
-            self.0.to_bytes_le().expect("Failed to write data as bytes").to_base32(),
-            bech32::Variant::Bech32m,
+            bech32::Hrp::parse_unchecked(&Self::prefix()),
+            &self.0.to_bytes_le().expect("Failed to write data as bytes"),
         )
-        .expect("Failed to encode in bech32m")
+        .map_err(|_| fmt::Error)
     }
 }
 

--- a/console/network/src/helpers/object.rs
+++ b/console/network/src/helpers/object.rs
@@ -96,7 +96,9 @@ impl<T: Clone + Debug + ToBytes + FromBytes + PartialEq + Eq + Sync + Send, cons
     /// Reads in a bech32m string.
     #[inline]
     fn from_str(string: &str) -> Result<Self, Self::Err> {
-        let (hrp, data) = bech32::decode(string)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(string)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_bytes() != PREFIX.to_le_bytes() {
             bail!("Invalid prefix for a bech32m hash: {hrp}")
         };
@@ -112,7 +114,7 @@ impl<T: Clone + Debug + ToBytes + FromBytes + PartialEq + Eq + Sync + Send, cons
 {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        bech32::encode_to_fmt::<bech32::Bech32m, _>(
+        bech32::encode_to_fmt::<LongBech32m, _>(
             f,
             bech32::Hrp::parse_unchecked(&Self::prefix()),
             &self.0.to_bytes_le().expect("Failed to write data as bytes"),

--- a/console/network/src/helpers/object.rs
+++ b/console/network/src/helpers/object.rs
@@ -16,7 +16,6 @@
 use crate::prelude::*;
 
 use anyhow::Result;
-use bech32::{self, FromBase32, ToBase32};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::borrow::Borrow;
 
@@ -97,17 +96,14 @@ impl<T: Clone + Debug + ToBytes + FromBytes + PartialEq + Eq + Sync + Send, cons
     /// Reads in a bech32m string.
     #[inline]
     fn from_str(string: &str) -> Result<Self, Self::Err> {
-        let (hrp, data, variant) = bech32::decode(string)?;
+        let (hrp, data) = bech32::decode(string)?;
         if hrp.as_bytes() != PREFIX.to_le_bytes() {
             bail!("Invalid prefix for a bech32m hash: {hrp}")
         };
         if data.is_empty() {
             bail!("Bech32m hash data is empty")
         }
-        if variant != bech32::Variant::Bech32m {
-            bail!("Hash is not a bech32m hash")
-        }
-        Ok(Self::read_le(&*Vec::from_base32(&data)?)?)
+        Ok(Self::read_le(&*data)?)
     }
 }
 
@@ -116,13 +112,12 @@ impl<T: Clone + Debug + ToBytes + FromBytes + PartialEq + Eq + Sync + Send, cons
 {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        bech32::encode_to_fmt(
+        bech32::encode_to_fmt::<bech32::Bech32m, _>(
             f,
-            &Self::prefix(),
-            self.0.to_bytes_le().expect("Failed to write data as bytes").to_base32(),
-            bech32::Variant::Bech32m,
+            bech32::Hrp::parse_unchecked(&Self::prefix()),
+            &self.0.to_bytes_le().expect("Failed to write data as bytes"),
         )
-        .expect("Failed to encode in bech32m")
+        .map_err(|_| fmt::Error)
     }
 }
 

--- a/console/program/src/data/ciphertext/parse.rs
+++ b/console/program/src/data/ciphertext/parse.rs
@@ -40,7 +40,9 @@ impl<N: Network> FromStr for Ciphertext<N> {
     /// Reads in the ciphertext string.
     fn from_str(ciphertext: &str) -> Result<Self, Self::Err> {
         // Decode the ciphertext string from bech32m.
-        let (hrp, data) = bech32::decode(ciphertext)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(ciphertext)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != CIPHERTEXT_PREFIX {
             bail!("Failed to decode ciphertext: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -63,7 +65,7 @@ impl<N: Network> Display for Ciphertext<N> {
         // Convert the ciphertext to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(CIPHERTEXT_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(CIPHERTEXT_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/console/program/src/data/ciphertext/parse.rs
+++ b/console/program/src/data/ciphertext/parse.rs
@@ -40,16 +40,14 @@ impl<N: Network> FromStr for Ciphertext<N> {
     /// Reads in the ciphertext string.
     fn from_str(ciphertext: &str) -> Result<Self, Self::Err> {
         // Decode the ciphertext string from bech32m.
-        let (hrp, data, variant) = bech32::decode(ciphertext)?;
-        if hrp != CIPHERTEXT_PREFIX {
+        let (hrp, data) = bech32::decode(ciphertext)?;
+        if hrp.as_str() != CIPHERTEXT_PREFIX {
             bail!("Failed to decode ciphertext: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode ciphertext: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found an ciphertext that is not bech32m encoded: {ciphertext}");
         }
-        // Decode the ciphertext data from u5 to u8, and into the ciphertext.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the ciphertext data into the ciphertext.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -65,8 +63,8 @@ impl<N: Network> Display for Ciphertext<N> {
         // Convert the ciphertext to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(CIPHERTEXT_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(CIPHERTEXT_PREFIX), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/console/program/src/data/record/parse_ciphertext.rs
+++ b/console/program/src/data/record/parse_ciphertext.rs
@@ -40,16 +40,14 @@ impl<N: Network> FromStr for Record<N, Ciphertext<N>> {
     /// Reads in the ciphertext string.
     fn from_str(ciphertext: &str) -> Result<Self, Self::Err> {
         // Decode the ciphertext string from bech32m.
-        let (hrp, data, variant) = bech32::decode(ciphertext)?;
-        if hrp != RECORD_CIPHERTEXT_PREFIX {
+        let (hrp, data) = bech32::decode(ciphertext)?;
+        if hrp.as_str() != RECORD_CIPHERTEXT_PREFIX {
             bail!("Failed to decode record ciphertext: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode record ciphertext: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found a record ciphertext that is not bech32m encoded: {ciphertext}");
         }
-        // Decode the record ciphertext data from u5 to u8, and into the record ciphertext.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the record ciphertext data into the record ciphertext.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -65,7 +63,7 @@ impl<N: Network> Display for Record<N, Ciphertext<N>> {
         // Convert the ciphertext to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode(RECORD_CIPHERTEXT_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m)
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(RECORD_CIPHERTEXT_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/console/program/src/data/record/parse_ciphertext.rs
+++ b/console/program/src/data/record/parse_ciphertext.rs
@@ -40,7 +40,9 @@ impl<N: Network> FromStr for Record<N, Ciphertext<N>> {
     /// Reads in the ciphertext string.
     fn from_str(ciphertext: &str) -> Result<Self, Self::Err> {
         // Decode the ciphertext string from bech32m.
-        let (hrp, data) = bech32::decode(ciphertext)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(ciphertext)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != RECORD_CIPHERTEXT_PREFIX {
             bail!("Failed to decode record ciphertext: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -63,7 +65,7 @@ impl<N: Network> Display for Record<N, Ciphertext<N>> {
         // Convert the ciphertext to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(RECORD_CIPHERTEXT_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(RECORD_CIPHERTEXT_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/console/program/src/state_path/parse.rs
+++ b/console/program/src/state_path/parse.rs
@@ -40,16 +40,14 @@ impl<N: Network> FromStr for StatePath<N> {
     /// Reads in the state path string.
     fn from_str(state_path: &str) -> Result<Self, Self::Err> {
         // Decode the state path string from bech32m.
-        let (hrp, data, variant) = bech32::decode(state_path)?;
-        if hrp != STATE_PATH_PREFIX {
+        let (hrp, data) = bech32::decode(state_path)?;
+        if hrp.as_str() != STATE_PATH_PREFIX {
             bail!("Failed to decode state path: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode state path: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found an state path that is not bech32m encoded: {state_path}");
         }
-        // Decode the state path data from u5 to u8, and into the state path.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the state path data into the state path.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -65,8 +63,8 @@ impl<N: Network> Display for StatePath<N> {
         // Convert the state path to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(STATE_PATH_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(STATE_PATH_PREFIX), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/console/program/src/state_path/parse.rs
+++ b/console/program/src/state_path/parse.rs
@@ -40,7 +40,9 @@ impl<N: Network> FromStr for StatePath<N> {
     /// Reads in the state path string.
     fn from_str(state_path: &str) -> Result<Self, Self::Err> {
         // Decode the state path string from bech32m.
-        let (hrp, data) = bech32::decode(state_path)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(state_path)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != STATE_PATH_PREFIX {
             bail!("Failed to decode state path: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -63,7 +65,7 @@ impl<N: Network> Display for StatePath<N> {
         // Convert the state path to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(STATE_PATH_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(STATE_PATH_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/console/types/address/src/parse.rs
+++ b/console/types/address/src/parse.rs
@@ -44,7 +44,9 @@ impl<E: Environment> FromStr for Address<E> {
             bail!("Invalid account address length: found {}, expected 63", address.len())
         }
         // Decode the address string from bech32m.
-        let (hrp, data) = bech32::decode(address)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(address)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != ADDRESS_PREFIX {
             bail!("Failed to decode address: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -67,7 +69,7 @@ impl<E: Environment> Display for Address<E> {
         // Convert the address to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(ADDRESS_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(ADDRESS_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/console/types/address/src/parse.rs
+++ b/console/types/address/src/parse.rs
@@ -44,16 +44,14 @@ impl<E: Environment> FromStr for Address<E> {
             bail!("Invalid account address length: found {}, expected 63", address.len())
         }
         // Decode the address string from bech32m.
-        let (hrp, data, variant) = bech32::decode(address)?;
-        if hrp != ADDRESS_PREFIX {
+        let (hrp, data) = bech32::decode(address)?;
+        if hrp.as_str() != ADDRESS_PREFIX {
             bail!("Failed to decode address: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode address: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found an address that is not bech32m encoded: {address}");
         }
-        // Decode the address data from u5 to u8, and into an account address.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the address data into an account address.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -69,8 +67,8 @@ impl<E: Environment> Display for Address<E> {
         // Convert the address to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(ADDRESS_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(ADDRESS_PREFIX), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/ledger/narwhal/data/src/lib.rs
+++ b/ledger/narwhal/data/src/lib.rs
@@ -188,8 +188,9 @@ impl<T: FromBytes + ToBytes + Serialize + Send + 'static> Serialize for Data<T> 
                         data.serialize_field("type", "buffer")?;
 
                         // Encode to bech32m.
-                        let buffer = bech32::encode(PREFIX, buffer.to_vec().to_base32(), bech32::Variant::Bech32m)
-                            .map_err(|_| S::Error::custom("Failed to encode data into bech32m"))?;
+                        let buffer =
+                            bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PREFIX), buffer.as_ref())
+                                .map_err(|_| S::Error::custom("Failed to encode data into bech32m"))?;
 
                         // Add the bech32m string.
                         data.serialize_field("data", &buffer)?;
@@ -221,17 +222,14 @@ impl<'de, T: FromBytes + ToBytes + DeserializeOwned + Send + 'static> Deserializ
                         let encoding: String = DeserializeExt::take_from_value::<D>(&mut data, "data")?;
 
                         // Decode from bech32m.
-                        let (hrp, data, variant) = bech32::decode(&encoding).map_err(de::Error::custom)?;
-                        if hrp != PREFIX {
+                        let (hrp, data) = bech32::decode(&encoding).map_err(de::Error::custom)?;
+                        if hrp.as_str() != PREFIX {
                             return Err(de::Error::custom(error(format!("Invalid data HRP - {hrp}"))));
                         };
                         if data.is_empty() {
                             return Err(de::Error::custom(error("Invalid bech32m data (empty)")));
                         }
-                        if variant != bech32::Variant::Bech32m {
-                            return Err(de::Error::custom(error("Invalid data - variant is not bech32m")));
-                        }
-                        Ok(Self::Buffer(Bytes::from(Vec::from_base32(&data).map_err(de::Error::custom)?)))
+                        Ok(Self::Buffer(Bytes::from(data)))
                     }
                     _ => Err(de::Error::custom(error(format!("Invalid data type - {type_}")))),
                 }

--- a/ledger/narwhal/data/src/lib.rs
+++ b/ledger/narwhal/data/src/lib.rs
@@ -189,7 +189,7 @@ impl<T: FromBytes + ToBytes + Serialize + Send + 'static> Serialize for Data<T> 
 
                         // Encode to bech32m.
                         let buffer =
-                            bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PREFIX), buffer.as_ref())
+                            bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(PREFIX), buffer.as_ref())
                                 .map_err(|_| S::Error::custom("Failed to encode data into bech32m"))?;
 
                         // Add the bech32m string.
@@ -222,7 +222,10 @@ impl<'de, T: FromBytes + ToBytes + DeserializeOwned + Send + 'static> Deserializ
                         let encoding: String = DeserializeExt::take_from_value::<D>(&mut data, "data")?;
 
                         // Decode from bech32m.
-                        let (hrp, data) = bech32::decode(&encoding).map_err(de::Error::custom)?;
+                        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(&encoding)
+                            .map_err(de::Error::custom)?;
+                        let hrp = checked.hrp();
+                        let data: Vec<u8> = checked.byte_iter().collect();
                         if hrp.as_str() != PREFIX {
                             return Err(de::Error::custom(error(format!("Invalid data HRP - {hrp}"))));
                         };

--- a/ledger/puzzle/src/solution_id/string.rs
+++ b/ledger/puzzle/src/solution_id/string.rs
@@ -23,16 +23,14 @@ impl<N: Network> FromStr for SolutionID<N> {
     /// Reads in the solution ID string.
     fn from_str(solution_id: &str) -> Result<Self, Self::Err> {
         // Decode the solution ID string from bech32m.
-        let (hrp, data, variant) = bech32::decode(solution_id)?;
-        if hrp != SOLUTION_ID_PREFIX {
+        let (hrp, data) = bech32::decode(solution_id)?;
+        if hrp.as_str() != SOLUTION_ID_PREFIX {
             bail!("Failed to decode solution ID: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode solution ID: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found a solution ID that is not bech32m encoded: {solution_id}");
         }
-        // Decode the solution ID data from u5 to u8, and into the solution ID.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the solution ID data into the solution ID.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -48,8 +46,8 @@ impl<N: Network> Display for SolutionID<N> {
         // Convert the solution ID to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(SOLUTION_ID_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(SOLUTION_ID_PREFIX), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/ledger/puzzle/src/solution_id/string.rs
+++ b/ledger/puzzle/src/solution_id/string.rs
@@ -23,7 +23,9 @@ impl<N: Network> FromStr for SolutionID<N> {
     /// Reads in the solution ID string.
     fn from_str(solution_id: &str) -> Result<Self, Self::Err> {
         // Decode the solution ID string from bech32m.
-        let (hrp, data) = bech32::decode(solution_id)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(solution_id)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != SOLUTION_ID_PREFIX {
             bail!("Failed to decode solution ID: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -46,7 +48,7 @@ impl<N: Network> Display for SolutionID<N> {
         // Convert the solution ID to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(SOLUTION_ID_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(SOLUTION_ID_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/plugins/slipstream_plugin_interface/Cargo.toml
+++ b/plugins/slipstream_plugin_interface/Cargo.toml
@@ -10,6 +10,3 @@ edition = "2024"
 
 [dependencies.anyhow]
 workspace = true
-
-[dependencies.tracing]
-workspace = true

--- a/plugins/slipstream_plugin_manager/Cargo.toml
+++ b/plugins/slipstream_plugin_manager/Cargo.toml
@@ -28,17 +28,3 @@ version = "0.8"
 
 [dependencies.json5]
 version = "0.4"
-
-[features]
-locktick = ["dep:locktick"]
-
-[dependencies.locktick]
-workspace = true
-optional = true
-
-[dependencies.parking_lot]
-workspace = true
-
-[dependencies.tokio]
-version = "1"
-features = [ "sync" ]

--- a/synthesizer/snark/src/certificate/parse.rs
+++ b/synthesizer/snark/src/certificate/parse.rs
@@ -40,7 +40,9 @@ impl<N: Network> FromStr for Certificate<N> {
     /// Reads in the certificate string.
     fn from_str(certificate: &str) -> Result<Self, Self::Err> {
         // Decode the certificate string from bech32m.
-        let (hrp, data) = bech32::decode(certificate)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(certificate)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != VK_CERTIFICATE_PREFIX {
             bail!("Failed to decode certificate: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -63,7 +65,7 @@ impl<N: Network> Display for Certificate<N> {
         // Convert the certificate to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(VK_CERTIFICATE_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(VK_CERTIFICATE_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/synthesizer/snark/src/certificate/parse.rs
+++ b/synthesizer/snark/src/certificate/parse.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 
-static PROOF_PREFIX: &str = "certificate";
+static VK_CERTIFICATE_PREFIX: &str = "certificate";
 
 impl<N: Network> Parser for Certificate<N> {
     /// Parses a string into an certificate.
@@ -23,7 +23,7 @@ impl<N: Network> Parser for Certificate<N> {
     fn parse(string: &str) -> ParserResult<Self> {
         // Prepare a parser for the Aleo certificate.
         let parse_certificate = recognize(pair(
-            pair(tag(PROOF_PREFIX), tag("1")),
+            pair(tag(VK_CERTIFICATE_PREFIX), tag("1")),
             many1(terminated(one_of("qpzry9x8gf2tvdw0s3jn54khce6mua7l"), many0(char('_')))),
         ));
 
@@ -41,7 +41,7 @@ impl<N: Network> FromStr for Certificate<N> {
     fn from_str(certificate: &str) -> Result<Self, Self::Err> {
         // Decode the certificate string from bech32m.
         let (hrp, data) = bech32::decode(certificate)?;
-        if hrp.as_str() != PROOF_PREFIX {
+        if hrp.as_str() != VK_CERTIFICATE_PREFIX {
             bail!("Failed to decode certificate: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode certificate: data field is empty")
@@ -63,7 +63,7 @@ impl<N: Network> Display for Certificate<N> {
         // Convert the certificate to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PROOF_PREFIX), &bytes)
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(VK_CERTIFICATE_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn test_parse() -> Result<()> {
         // Ensure type and empty value fails.
-        assert!(Certificate::<CurrentNetwork>::parse(&format!("{PROOF_PREFIX}1")).is_err());
+        assert!(Certificate::<CurrentNetwork>::parse(&format!("{VK_CERTIFICATE_PREFIX}1")).is_err());
         assert!(Certificate::<CurrentNetwork>::parse("").is_err());
 
         // Sample the certificate.
@@ -90,7 +90,7 @@ mod tests {
         let expected = format!("{certificate}");
         let (remainder, candidate) = Certificate::<CurrentNetwork>::parse(&expected).unwrap();
         assert_eq!(format!("{expected}"), candidate.to_string());
-        assert_eq!(PROOF_PREFIX, candidate.to_string().split('1').next().unwrap());
+        assert_eq!(VK_CERTIFICATE_PREFIX, candidate.to_string().split('1').next().unwrap());
         assert_eq!("", remainder);
         Ok(())
     }
@@ -103,7 +103,7 @@ mod tests {
         // Check the string representation.
         let candidate = format!("{expected}");
         assert_eq!(expected, Certificate::from_str(&candidate)?);
-        assert_eq!(PROOF_PREFIX, candidate.split('1').next().unwrap());
+        assert_eq!(VK_CERTIFICATE_PREFIX, candidate.split('1').next().unwrap());
 
         Ok(())
     }
@@ -115,7 +115,7 @@ mod tests {
 
         let candidate = expected.to_string();
         assert_eq!(format!("{expected}"), candidate);
-        assert_eq!(PROOF_PREFIX, candidate.split('1').next().unwrap());
+        assert_eq!(VK_CERTIFICATE_PREFIX, candidate.split('1').next().unwrap());
 
         let candidate_recovered = Certificate::<CurrentNetwork>::from_str(&candidate)?;
         assert_eq!(expected, candidate_recovered);

--- a/synthesizer/snark/src/certificate/parse.rs
+++ b/synthesizer/snark/src/certificate/parse.rs
@@ -40,16 +40,14 @@ impl<N: Network> FromStr for Certificate<N> {
     /// Reads in the certificate string.
     fn from_str(certificate: &str) -> Result<Self, Self::Err> {
         // Decode the certificate string from bech32m.
-        let (hrp, data, variant) = bech32::decode(certificate)?;
-        if hrp != PROOF_PREFIX {
+        let (hrp, data) = bech32::decode(certificate)?;
+        if hrp.as_str() != PROOF_PREFIX {
             bail!("Failed to decode certificate: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode certificate: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found an certificate that is not bech32m encoded: {certificate}");
         }
-        // Decode the certificate data from u5 to u8, and into the certificate.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the certificate data into the certificate.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -65,8 +63,8 @@ impl<N: Network> Display for Certificate<N> {
         // Convert the certificate to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(PROOF_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PROOF_PREFIX), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/synthesizer/snark/src/proof/parse.rs
+++ b/synthesizer/snark/src/proof/parse.rs
@@ -38,16 +38,14 @@ impl<N: Network> FromStr for Proof<N> {
     /// Reads in the proof string.
     fn from_str(proof: &str) -> Result<Self, Self::Err> {
         // Decode the proof string from bech32m.
-        let (hrp, data, variant) = bech32::decode(proof)?;
-        if hrp != PROOF_PREFIX {
+        let (hrp, data) = bech32::decode(proof)?;
+        if hrp.as_str() != PROOF_PREFIX {
             bail!("Failed to decode proof: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode proof: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found an proof that is not bech32m encoded: {proof}");
         }
-        // Decode the proof data from u5 to u8, and into the proof.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the proof data into the proof.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -63,8 +61,8 @@ impl<N: Network> Display for Proof<N> {
         // Convert the proof to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(PROOF_PREFIX, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PROOF_PREFIX), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/synthesizer/snark/src/proof/parse.rs
+++ b/synthesizer/snark/src/proof/parse.rs
@@ -38,7 +38,9 @@ impl<N: Network> FromStr for Proof<N> {
     /// Reads in the proof string.
     fn from_str(proof: &str) -> Result<Self, Self::Err> {
         // Decode the proof string from bech32m.
-        let (hrp, data) = bech32::decode(proof)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(proof)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != PROOF_PREFIX {
             bail!("Failed to decode proof: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -61,7 +63,7 @@ impl<N: Network> Display for Proof<N> {
         // Convert the proof to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PROOF_PREFIX), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(PROOF_PREFIX), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)

--- a/synthesizer/snark/src/proving_key/parse.rs
+++ b/synthesizer/snark/src/proving_key/parse.rs
@@ -38,16 +38,14 @@ impl<N: Network> FromStr for ProvingKey<N> {
     /// Reads in the proving key string.
     fn from_str(key: &str) -> Result<Self, Self::Err> {
         // Decode the proving key string from bech32m.
-        let (hrp, data, variant) = bech32::decode(key)?;
-        if hrp != PROVING_KEY {
+        let (hrp, data) = bech32::decode(key)?;
+        if hrp.as_str() != PROVING_KEY {
             bail!("Failed to decode proving key: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode proving key: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found a proving key that is not bech32m encoded: {key}");
         }
-        // Decode the proving key data from u5 to u8, and into the proving key.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the proving key data into the proving key.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -63,8 +61,8 @@ impl<N: Network> Display for ProvingKey<N> {
         // Convert the proving key to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(PROVING_KEY, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PROVING_KEY), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/synthesizer/snark/src/proving_key/parse.rs
+++ b/synthesizer/snark/src/proving_key/parse.rs
@@ -38,7 +38,9 @@ impl<N: Network> FromStr for ProvingKey<N> {
     /// Reads in the proving key string.
     fn from_str(key: &str) -> Result<Self, Self::Err> {
         // Decode the proving key string from bech32m.
-        let (hrp, data) = bech32::decode(key)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(key)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != PROVING_KEY {
             bail!("Failed to decode proving key: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -61,8 +63,8 @@ impl<N: Network> Display for ProvingKey<N> {
         // Convert the proving key to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(PROVING_KEY), &bytes)
-            .map_err(|_| fmt::Error)?;
+        let string =
+            bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(PROVING_KEY), &bytes).map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/synthesizer/snark/src/verifying_key/parse.rs
+++ b/synthesizer/snark/src/verifying_key/parse.rs
@@ -38,16 +38,14 @@ impl<N: Network> FromStr for VerifyingKey<N> {
     /// Reads in the verifying key string.
     fn from_str(key: &str) -> Result<Self, Self::Err> {
         // Decode the verifying key string from bech32m.
-        let (hrp, data, variant) = bech32::decode(key)?;
-        if hrp != VERIFYING_KEY {
+        let (hrp, data) = bech32::decode(key)?;
+        if hrp.as_str() != VERIFYING_KEY {
             bail!("Failed to decode verifying key: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
             bail!("Failed to decode verifying key: data field is empty")
-        } else if variant != bech32::Variant::Bech32m {
-            bail!("Found a verifying key that is not bech32m encoded: {key}");
         }
-        // Decode the verifying key data from u5 to u8, and into the verifying key.
-        Ok(Self::read_le(&Vec::from_base32(&data)?[..])?)
+        // Decode the verifying key data into the verifying key.
+        Ok(Self::read_le(&data[..])?)
     }
 }
 
@@ -63,8 +61,8 @@ impl<N: Network> Display for VerifyingKey<N> {
         // Convert the verifying key to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string =
-            bech32::encode(VERIFYING_KEY, bytes.to_base32(), bech32::Variant::Bech32m).map_err(|_| fmt::Error)?;
+        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(VERIFYING_KEY), &bytes)
+            .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)
     }

--- a/synthesizer/snark/src/verifying_key/parse.rs
+++ b/synthesizer/snark/src/verifying_key/parse.rs
@@ -38,7 +38,9 @@ impl<N: Network> FromStr for VerifyingKey<N> {
     /// Reads in the verifying key string.
     fn from_str(key: &str) -> Result<Self, Self::Err> {
         // Decode the verifying key string from bech32m.
-        let (hrp, data) = bech32::decode(key)?;
+        let checked = bech32::primitives::decode::CheckedHrpstring::new::<LongBech32m>(key)?;
+        let hrp = checked.hrp();
+        let data: Vec<u8> = checked.byte_iter().collect();
         if hrp.as_str() != VERIFYING_KEY {
             bail!("Failed to decode verifying key: '{hrp}' is an invalid prefix")
         } else if data.is_empty() {
@@ -61,7 +63,7 @@ impl<N: Network> Display for VerifyingKey<N> {
         // Convert the verifying key to bytes.
         let bytes = self.to_bytes_le().map_err(|_| fmt::Error)?;
         // Encode the bytes into bech32m.
-        let string = bech32::encode::<bech32::Bech32m>(bech32::Hrp::parse_unchecked(VERIFYING_KEY), &bytes)
+        let string = bech32::encode::<LongBech32m>(bech32::Hrp::parse_unchecked(VERIFYING_KEY), &bytes)
             .map_err(|_| fmt::Error)?;
         // Output the string.
         Display::fmt(&string, f)


### PR DESCRIPTION
This PR fixes the following `cargo audit` errors. Simply running `cargo update` was not sufficient, and I needed to update `sha2` and `bech32`.

```
Crate:     rand
Version:   0.10.0
Warning:   unsound
Title:     Rand is unsound with a custom logger using `rand::rng()`
Date:      2026-04-09
ID:        RUSTSEC-2026-0097
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097

Crate:     rand
Version:   0.9.2
Warning:   unsound
Title:     Rand is unsound with a custom logger using `rand::rng()`
Date:      2026-04-09
ID:        RUSTSEC-2026-0097
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097

Crate:     rustls-webpki
Version:   0.103.11
Title:     Name constraints were accepted for certificates asserting a wildcard name
Date:      2026-04-14
ID:        RUSTSEC-2026-0099
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099

Crate:     rustls-webpki
Version:   0.103.11
Title:     Name constraints for URI names were incorrectly accepted
Date:      2026-04-14
ID:        RUSTSEC-2026-0098
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
```
