### PR TITLE
[Fix] Restore past deterministic Rng behavior

### DIFF
--- a/ledger/puzzle/epoch/src/merkle/mod.rs
+++ b/ledger/puzzle/epoch/src/merkle/mod.rs
@@ -19,10 +19,11 @@ use console::{
     types::Field,
 };
 use snarkvm_ledger_puzzle::PuzzleTrait;
+use snarkvm_utilities::rand::gen_range_inclusive_legacy;
 
 use anyhow::Result;
 use core::marker::PhantomData;
-use rand::{RngExt, SeedableRng};
+use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 
 #[cfg(not(feature = "serial"))]
@@ -73,7 +74,9 @@ impl<N: Network> MerklePuzzle<N> {
         // Seed a random number generator from the epoch hash.
         let mut epoch_rng = ChaChaRng::seed_from_u64(seed);
         // Sample a random number of leaves.
-        Ok(epoch_rng.random_range(MIN_NUMBER_OF_LEAVES..=MAX_NUMBER_OF_LEAVES))
+        let num_leaves = gen_range_inclusive_legacy(MIN_NUMBER_OF_LEAVES, MAX_NUMBER_OF_LEAVES, &mut epoch_rng);
+
+        Ok(num_leaves)
     }
 }
 
@@ -91,6 +94,7 @@ mod tests {
         let puzzle = MerklePuzzle::<CurrentNetwork>::new();
         // Sample the number of leaves.
         let num_leaves = puzzle.num_leaves(epoch_hash).unwrap();
+        assert_eq!(num_leaves, 102436);
         // Ensure the number of leaves is within the expected range.
         assert!((MIN_NUMBER_OF_LEAVES..=MAX_NUMBER_OF_LEAVES).contains(&num_leaves));
     }

--- a/ledger/puzzle/epoch/src/synthesis/helpers/mod.rs
+++ b/ledger/puzzle/epoch/src/synthesis/helpers/mod.rs
@@ -37,10 +37,11 @@ use console::{
     program::LiteralType,
 };
 use snarkvm_synthesizer_program::Instruction;
+use snarkvm_utilities::choose_weighted_legacy;
 
 use anyhow::Result;
 use indexmap::IndexSet;
-use rand::{SeedableRng, prelude::*};
+use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use std::{collections::HashMap, str::FromStr};
 
@@ -74,7 +75,7 @@ pub(crate) fn sample_instructions<N: Network>(
         }
 
         // Initialize the instruction and selected literals.
-        let (sequence, _) = instruction_set_weights.choose_weighted(&mut rng, |(_, weight)| *weight).cloned().unwrap();
+        let sequence = choose_weighted_legacy(&instruction_set_weights, |(_, weight)| *weight, &mut rng).0.clone();
 
         // Initialize a cache for the ephemeral registers.
         // This is a mapping from the locator to the one assigned to it in the instruction sequence.
@@ -341,6 +342,8 @@ pub(crate) mod tests {
 
     use console::{prelude::TestRng, program::Identifier};
     use snarkvm_synthesizer_program::Program;
+
+    use rand::RngExt;
 
     type CurrentNetwork = console::network::MainnetV0;
 

--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -176,7 +176,10 @@ impl Drop for TestRng {
 }
 
 /// This impl is Lemire's method with approximate zone. It reproduces rand 0.8's
-/// `rng.gen_range(low..=high)` for `usize` on 64-bit. It mustn't be modified.
+/// `rng.gen_range(low..=high)` for `usize` on 64-bit. It mustn't be modified
+/// to maintain backwards compatibility. It is a direct reimplementation of
+/// `sample_single_inclusive` for a concrete type (`usize`) an inlined widening multiply
+/// from https://github.com/rust-random/rand/blob/937320c/src/distributions/uniform.rs.
 pub fn gen_range_inclusive_legacy(low: usize, high: usize, rng: &mut impl Rng) -> usize {
     debug_assert!(low <= high);
 
@@ -198,7 +201,9 @@ pub fn gen_range_inclusive_legacy(low: usize, high: usize, rng: &mut impl Rng) -
 }
 
 /// This impl reproduces rand 0.8's `slice.choose_weighted(rng, weight_fn)` for u16 weights.
-/// It mustn't be modified.
+/// It mustn't be modified to maintain backwards compatibility. It is a direct, "collapsed"
+/// reimplementation of `WeightedIndex::new(weights).sample(rng)` specifically for `u16` weights
+/// from https://github.com/rust-random/rand/blob/937320c/src/distributions/weighted_index.rs.
 pub fn choose_weighted_legacy<'a, T, R: Rng>(slice: &'a [T], weight_fn: impl Fn(&T) -> u16, rng: &mut R) -> &'a T {
     // WeightedIndex::new.
     let mut cumulative: Vec<u16> = Vec::with_capacity(slice.len());

--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -174,3 +174,25 @@ impl Drop for TestRng {
         println!("Called TestRng with seed {} {} times", self.seed, self.calls);
     }
 }
+
+/// This impl is Lemire's method with approximate zone. It reproduces rand 0.8's
+/// `rng.gen_range(low..=high)` for `usize` on 64-bit. It mustn't be modified.
+pub fn gen_range_inclusive_legacy(low: usize, high: usize, rng: &mut impl Rng) -> usize {
+    debug_assert!(low <= high);
+
+    let range = high.wrapping_sub(low).wrapping_add(1);
+
+    // Approximate zone: conservative but avoids division.
+    let zone = (range << range.leading_zeros()).wrapping_sub(1);
+
+    loop {
+        let v = rng.next_u64() as usize;
+        // Widening multiply: v * range as u128, split into (hi, lo).
+        let wide = (v as u128) * (range as u128);
+        let hi = (wide >> 64) as usize;
+        let lo = wide as usize;
+        if lo <= zone {
+            return low.wrapping_add(hi);
+        }
+    }
+}

--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -196,3 +196,37 @@ pub fn gen_range_inclusive_legacy(low: usize, high: usize, rng: &mut impl Rng) -
         }
     }
 }
+
+/// This impl reproduces rand 0.8's `slice.choose_weighted(rng, weight_fn)` for u16 weights.
+/// It mustn't be modified.
+pub fn choose_weighted_legacy<'a, T, R: Rng>(slice: &'a [T], weight_fn: impl Fn(&T) -> u16, rng: &mut R) -> &'a T {
+    // WeightedIndex::new.
+    let mut cumulative: Vec<u16> = Vec::with_capacity(slice.len());
+    let mut total: u16 = 0;
+    for item in slice {
+        total = total.checked_add(weight_fn(item)).unwrap();
+        cumulative.push(total);
+    }
+    assert!(total > 0);
+
+    // Uniform::new(0u16, total) -> new_inclusive(0, total - 1)
+    // range as u16, then promoted to u32 for zone math.
+    let range = total as u32;
+    let ints_to_reject = (u32::MAX - range + 1) % range;
+    let zone = u32::MAX - ints_to_reject;
+
+    // Uniform::sample (exact Lemire, u32 sample space).
+    let chosen: u16 = loop {
+        let v = rng.next_u32();
+        let wide = (v as u64) * (range as u64);
+        let hi = (wide >> 32) as u32;
+        let lo = wide as u32;
+        if lo <= zone {
+            break hi as u16;
+        }
+    };
+
+    // Binary search (partition_point).
+    let idx = cumulative.partition_point(|w| *w <= chosen);
+    &slice[idx]
+}

--- a/utilities/src/rand.rs
+++ b/utilities/src/rand.rs
@@ -184,6 +184,10 @@ pub fn gen_range_inclusive_legacy(low: usize, high: usize, rng: &mut impl Rng) -
     debug_assert!(low <= high);
 
     let range = high.wrapping_sub(low).wrapping_add(1);
+    // The range is 0..=usize::MAX.
+    if range == 0 {
+        return rng.random::<u64>() as usize;
+    }
 
     // Approximate zone: conservative but avoids division.
     let zone = (range << range.leading_zeros()).wrapping_sub(1);
@@ -206,11 +210,13 @@ pub fn gen_range_inclusive_legacy(low: usize, high: usize, rng: &mut impl Rng) -
 /// from https://github.com/rust-random/rand/blob/937320c/src/distributions/weighted_index.rs.
 pub fn choose_weighted_legacy<'a, T, R: Rng>(slice: &'a [T], weight_fn: impl Fn(&T) -> u16, rng: &mut R) -> &'a T {
     // WeightedIndex::new.
-    let mut cumulative: Vec<u16> = Vec::with_capacity(slice.len());
-    let mut total: u16 = 0;
-    for item in slice {
-        total = total.checked_add(weight_fn(item)).unwrap();
+    let mut iter = slice.iter();
+    let first = iter.next().unwrap();
+    let mut total: u16 = weight_fn(first);
+    let mut cumulative: Vec<u16> = Vec::with_capacity(slice.len() - 1);
+    for item in iter {
         cumulative.push(total);
+        total += weight_fn(item);
     }
     assert!(total > 0);
 


### PR DESCRIPTION
The [rand update PR](https://github.com/ProvableHQ/snarkVM/pull/3191) resulted in some (at least) past proof targets to not match the expected values, leading to sync issues. This was tracked down to 2 functions whose behavior has slightly changed due to reproducibility-breaking optimizations (which were documented in the `0.9` update, but didn't list all the affected method names).

The solution was to vendor the past implementations for the affected methods.

With these changes, I've been able to sync with the mainnet past the height of 300k (which is beyond the first problematic block height 259573).

Fixes https://github.com/ProvableHQ/snarkOS/issues/4209.