### PR TITLE
[Logs] Extra block tree caching info

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -251,11 +251,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         lap!(timer, "Initialize genesis");
 
         // Ensure that the greatest stored height matches that of the block tree.
+        let tree_derived_block_height = ledger.vm().block_store().current_block_height();
         ensure!(
-            latest_height == ledger.vm().block_store().current_block_height(),
-            "The stored height is different than the one in the block tree; \
-            please ensure that the cached block tree is valid or delete the \
-            'block_tree' file from the ledger folder"
+            latest_height == tree_derived_block_height,
+            "The stored height ({latest_height}) is different than the one in \
+            the block tree ({tree_derived_block_height}); please ensure that \
+            the cached block tree is valid or delete the 'block_tree' file from \
+            the ledger folder"
         );
 
         // Verify that the root of the cached block tree matches the one in the storage.

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1235,7 +1235,7 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         path.push("block_tree");
 
         // Create the target file.
-        let file = fs::File::create(path)?;
+        let file = fs::File::create(&path)?;
         // The block tree can become quite large, so use a BufWriter in order to
         // not have to keep the entire serialized tree in memory, and to reduce
         // the number of syscalls involved with disk writes. 1MiB should provide
@@ -1247,6 +1247,8 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         // to perform chunking and parallel serialization. This may be useful
         // for other applications, so it should be implemented as a common
         // utility.
+
+        tracing::debug!("Cached the current block tree to {}", path.display());
 
         Ok(())
     }


### PR DESCRIPTION
A bit of additional `DEBUG` info related to the caching of the block tree.

CC https://github.com/ProvableHQ/snarkOS/issues/4227