### PR TITLE
Removing `credits.aleo` programID filter from `authorize_request` method

### DIFF
--- a/synthesizer/process/src/stack/authorize.rs
+++ b/synthesizer/process/src/stack/authorize.rs
@@ -190,12 +190,6 @@ impl<N: Network> Stack<N> {
     ) -> Result<Authorization<N>, StackAuthError> {
         let timer = timer!("Stack::authorize_request");
 
-        // Get the program ID.
-        let program_id = *self.program.id();
-        // Ensure the program ID is credits.aleo.
-        if program_id.to_string() != "credits.aleo" {
-            return Err(anyhow!("Program ID must be credits.aleo").into());
-        }
         // Initialize the authorization.
         let authorization = Authorization::new(request.clone());
         // Construct the call stack.


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

SnarkVM panics when a Request is supplied to the `process.authorize_request()` method when the corresponding programID is not `credits.aleo`.  This limits authorization generation for all non-credits transactions generated with MPC protocols since `authorize_reqeust` is the only method in the `authorize` module that does not require a private key as an input.

## Test Plan

Tests will be added to the Provable WASM SDK to check that authorizations will be successfully created from non-credits Request objects.