### PR TITLE
feat: read-only `query` functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -905,8 +905,10 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer
+          # `history` enables the per-key historical update map that the `query` evaluation path
+          # depends on; gating it here ensures the v15 query tests are exercised in CI.
           flags: >
-            --lib --bins --features test
+            --lib --bins --features test,history
             --partition count:1/2
             -- --test-threads 8
           cache_key_suffix: -test1
@@ -919,7 +921,7 @@ jobs:
       - run_test:
           workspace_member: snarkvm-synthesizer
           flags: >
-            --lib --bins --features test
+            --lib --bins --features test,history
             --partition count:2/2
             -- --test-threads 8
           cache_key_suffix: -test2
@@ -933,7 +935,7 @@ jobs:
           timeout: 30m # test_vm_execute_and_finalize can take over 10 minutes in the current setup
           no_output_timeout: 20m
           workspace_member: snarkvm-synthesizer
-          flags: --test '*' --features test,dev-print -- --test-threads=4
+          flags: --test '*' --features test,dev-print,history -- --test-threads=4
           cache_key_suffix: -integration
 
   synthesizer-process:
@@ -942,6 +944,8 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkvm-synthesizer-process
+          # See `synthesizer-test-partition1` for why `history` is enabled.
+          flags: --features history
 
   synthesizer-process-with-rocksdb:
     executor: rust-docker

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -226,6 +226,8 @@ pub trait Network:
     const MAX_RECORDS: usize = 10 * Self::MAX_FUNCTIONS;
     /// The maximum number of closures in a program.
     const MAX_CLOSURES: usize = 2 * Self::MAX_FUNCTIONS;
+    /// The maximum number of query functions in a program.
+    const MAX_QUERIES: usize = 2 * Self::MAX_FUNCTIONS;
     /// The maximum number of operands in an instruction.
     const MAX_OPERANDS: usize = Self::MAX_INPUTS;
     /// The maximum number of instructions in a closure or function.

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -33,7 +33,7 @@ locktick = [
 ]
 async = [ "snarkvm-ledger-query/async", "snarkvm-synthesizer-process/async" ]
 cuda = [ "snarkvm-algorithms/cuda" ]
-history = [ "snarkvm-ledger-store/history" ]
+history = [ "snarkvm-ledger-store/history", "snarkvm-synthesizer-process/history" ]
 history-staking-rewards = [ "snarkvm-ledger-store/history-staking-rewards" ]
 slipstream-plugins = [ "snarkvm-ledger-store/slipstream-plugins" ]
 rocks = [ "snarkvm-ledger-store/rocks" ]

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -44,6 +44,7 @@ wasm = [
   "snarkvm-synthesizer-snark/wasm"
 ]
 test = [ "snarkvm-console/test", "snarkvm-circuit/test" ]
+history = [ "snarkvm-ledger-store/history" ]
 timer = [ "aleo-std/timer" ]
 dev-print = [ "snarkvm-utilities/dev-print" ]
 dev_skip_checks = [ ]

--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -252,6 +252,20 @@ pub fn deployment_cost_v2<N: Network>(
         );
     }
 
+    // Bound each query function's worst-case compute. Queries are off-consensus and have no
+    // dedicated fee component beyond what is already counted in `storage_cost` (their bytes
+    // contribute to `size_in_bytes`). The bound below is purely a deploy-time sanity check
+    // to keep pathological queries from being accepted.
+    for query in deployment.program().queries().values() {
+        let query_cost = query_cost_for_single_query(&stack, query.name(), ConsensusFeeVersion::V3)?;
+        ensure!(
+            query_cost <= N::TRANSACTION_SPEND_LIMIT[1].1,
+            "Query '{}' has a cost '{query_cost}' which exceeds the transaction spend limit '{}'",
+            query.name(),
+            N::TRANSACTION_SPEND_LIMIT[1].1
+        );
+    }
+
     // Compute the namespace cost in microcredits: 10^(10 - num_characters) * 1e6
     let namespace_cost = 10u64
         .checked_pow(10u32.saturating_sub(num_characters))
@@ -991,6 +1005,30 @@ fn finalize_cost_for_single_function_raw<N: Network>(
     }
 
     Ok(finalize_cost)
+}
+
+/// Returns the maximum compute cost (in microcredits) of a single query function's body.
+///
+/// Queries do not run as part of consensus, so this cost is not paid by anyone — it is only
+/// used as a deploy-time sanity bound (mirrors the per-function `TRANSACTION_SPEND_LIMIT`
+/// check) to prevent deploying queries whose worst-case compute is unreasonable.
+fn query_cost_for_single_query<N: Network>(
+    stack: &Stack<N>,
+    query_name: &Identifier<N>,
+    consensus_fee_version: ConsensusFeeVersion,
+) -> Result<u64> {
+    let query = stack.program().get_query_ref(query_name)?;
+
+    // Query types are not cached on the stack today; recompute them here for the cost walk.
+    let query_types = FinalizeTypes::from_query(stack, query)?;
+
+    let mut query_cost = 0u64;
+    for command in query.commands() {
+        query_cost = query_cost
+            .checked_add(cost_per_command(stack, &query_types, command, consensus_fee_version)?)
+            .ok_or(anyhow!("Query cost overflowed"))?;
+    }
+    Ok(query_cost)
 }
 
 /// Returns the total finalize cost for an execution by iterating over all concrete transitions.

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use console::program::{FinalizeType, Future, Register};
-use snarkvm_synthesizer_program::{Await, FinalizeRegistersState, Operand, RegistersTrait};
+use snarkvm_synthesizer_program::{Await, FinalizeRegistersState, FinalizeStoreTrait, Operand, RegistersTrait};
 use snarkvm_utilities::try_vm_runtime;
 
 use std::collections::HashSet;
@@ -576,9 +576,12 @@ fn initialize_finalize_state<N: Network>(
 }
 
 // A helper function to finalize all commands except `await`, updating the finalize operations and the counter.
+//
+// Generic over the store so the query evaluator (which passes either the canonical
+// `FinalizeStore` or a read-only historic adapter) can reuse this dispatch.
 #[inline]
-fn finalize_command_except_await<N: Network>(
-    store: &FinalizeStore<N, impl FinalizeStorage<N>>,
+pub(crate) fn finalize_command_except_await<N: Network>(
+    store: &impl FinalizeStoreTrait<N>,
     stack: &impl StackTrait<N>,
     registers: &mut FinalizeRegisters<N>,
     positions: &HashMap<Identifier<N>, usize>,
@@ -669,7 +672,7 @@ fn setup_await<N: Network>(
 }
 
 // A helper function that returns the index to branch to.
-pub(crate) fn branch_to<N: Network, const VARIANT: u8>(
+fn branch_to<N: Network, const VARIANT: u8>(
     counter: usize,
     branch: &Branch<N, VARIANT>,
     positions: &HashMap<Identifier<N>, usize>,

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -669,7 +669,7 @@ fn setup_await<N: Network>(
 }
 
 // A helper function that returns the index to branch to.
-fn branch_to<N: Network, const VARIANT: u8>(
+pub(crate) fn branch_to<N: Network, const VARIANT: u8>(
     counter: usize,
     branch: &Branch<N, VARIANT>,
     positions: &HashMap<Identifier<N>, usize>,

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -319,7 +319,8 @@ fn finalize_constructor<N: Network, P: FinalizeStorage<N>>(
     let constructor_types = stack.get_constructor_types()?.clone();
 
     // Initialize the finalize registers.
-    let mut registers = FinalizeRegisters::new(state, transition_id, *program_id.name(), constructor_types, nonce);
+    let mut registers =
+        FinalizeRegisters::new(state, Some(transition_id), *program_id.name(), constructor_types, Some(nonce));
 
     // Determine the scope name.
     let scope_name = Identifier::<N>::from_str("constructor")?;
@@ -434,8 +435,13 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
                     // Otherwise, query the call graph for the child transition ID corresponding to the future that is being awaited.
                     let consensus_version = N::CONSENSUS_VERSION(state.block_height())?;
                     let transition_id = if (ConsensusVersion::V1..=ConsensusVersion::V2).contains(&consensus_version) {
-                        // Get the current transition ID.
-                        let transition_id = registers.transition_id();
+                        // Get the current transition ID. The finalize path always initializes
+                        // registers with `Some(transition_id)`; only the query path uses `None`,
+                        // and `await` is forbidden on the query path, so this is unreachable
+                        // there. Treat `None` as a logic error.
+                        let transition_id = registers
+                            .transition_id()
+                            .ok_or_else(|| anyhow!("Cannot resolve a child transition ID without a transition ID"))?;
                         // Get the child transition ID.
                         match call_graph.get(transition_id) {
                             Some(transitions) => match transitions.get(call_counter) {
@@ -557,10 +563,10 @@ fn initialize_finalize_state<N: Network>(
     // Initialize the registers.
     let mut registers = FinalizeRegisters::new(
         state,
-        transition_id,
+        Some(transition_id),
         *future.function_name(),
         stack.get_finalize_types(future.function_name())?.clone(),
-        nonce,
+        Some(nonce),
     );
 
     // Store the inputs. The argument count is guaranteed to match the finalize's declared inputs

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -36,8 +36,10 @@ mod deploy;
 mod evaluate;
 mod execute;
 mod finalize;
+#[cfg(feature = "history")]
 mod query;
-pub use query::evaluate_query;
+#[cfg(feature = "history")]
+pub use query::evaluate_query_at_height;
 mod verify_deployment;
 mod verify_execution;
 mod verify_fee;

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -36,6 +36,8 @@ mod deploy;
 mod evaluate;
 mod execute;
 mod finalize;
+mod query;
+pub use query::evaluate_query;
 mod verify_deployment;
 mod verify_execution;
 mod verify_fee;

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -19,7 +19,7 @@ use console::{
     program::{Identifier, ProgramID, Value},
 };
 use snarkvm_ledger_store::{FinalizeMode, FinalizeStorage, FinalizeStore, atomic_finalize};
-use snarkvm_synthesizer_program::{Command, FinalizeGlobalState, FinalizeStoreTrait, RegistersTrait, StackTrait};
+use snarkvm_synthesizer_program::{FinalizeGlobalState, FinalizeStoreTrait, RegistersTrait, StackTrait};
 
 impl<N: Network> Process<N> {
     /// Evaluates a query function in the program identified by `program_id` and returns its outputs.
@@ -253,14 +253,16 @@ fn evaluate_query_inner<N: Network>(
         registers.store(stack, input_stmt.register(), value)?;
     }
 
-    // Evaluate the commands. Queries cannot await; branches reuse the finalize-side
-    // `branch_to` helper so the two execution paths cannot drift.
+    // Evaluate the commands. Queries reject `await` at construction (`add_command`), so the
+    // dispatch is identical to `Finalize` / `Constructor` — we share `finalize_command_except_await`
+    // directly to avoid drift. `try_vm_runtime!` inside that helper also gives queries panic-catch
+    // protection, which is desirable on the off-consensus / RPC-exposed path.
     //
     // Termination & cost bounds (prototype):
     //   - The loop is bounded by `query.commands().len()`, which is itself bounded by
     //     `N::MAX_COMMANDS` (= `u16::MAX`).
-    //   - `branch_to` permits forward jumps only, so the counter strictly advances and
-    //     no command can re-execute. Termination is guaranteed.
+    //   - `branch_to` (used by the helper) permits forward jumps only, so the counter
+    //     strictly advances and no command can re-execute. Termination is guaranteed.
     //   - Deploy-time, `query_cost_for_single_query` enforces that the worst-case body
     //     cost is `<= TRANSACTION_SPEND_LIMIT`, so a deployed query cannot register an
     //     unboundedly expensive body.
@@ -269,22 +271,24 @@ fn evaluate_query_inner<N: Network>(
     //     to the deploy bound per call. Rate-limiting and indexing are expected to be
     //     handled at the snarkOS RPC layer, not here.
     let mut counter = 0;
+    let mut finalize_operations: Vec<snarkvm_synthesizer_program::FinalizeOperation<N>> = Vec::new();
     while counter < query.commands().len() {
         let command = &query.commands()[counter];
-        match command {
-            Command::Await(_) => bail!("'await' is forbidden in a query function"),
-            Command::BranchEq(branch) => {
-                counter = crate::finalize::branch_to(counter, branch, query.positions(), stack, &registers)?;
-            }
-            Command::BranchNeq(branch) => {
-                counter = crate::finalize::branch_to(counter, branch, query.positions(), stack, &registers)?;
-            }
-            other => {
-                other.finalize(stack, store, &mut registers)?;
-                counter += 1;
-            }
-        }
+        crate::finalize::finalize_command_except_await(
+            store,
+            stack,
+            &mut registers,
+            query.positions(),
+            command,
+            &mut counter,
+            &mut finalize_operations,
+            query.name(),
+        )?;
     }
+    // Defensive: queries reject all write-producing commands at construction, so no finalize
+    // operations should ever be emitted. Catches any future regression that allows a write
+    // through the type-check path.
+    debug_assert!(finalize_operations.is_empty(), "query produced finalize operations: {finalize_operations:?}");
 
     // Load the outputs.
     let mut outputs = Vec::with_capacity(query.outputs().len());

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -79,17 +79,18 @@ pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
         registers.store(stack, input_stmt.register(), value)?;
     }
 
-    // Evaluate the commands. Queries cannot await; branches are inlined.
+    // Evaluate the commands. Queries cannot await; branches reuse the finalize-side
+    // `branch_to` helper so the two execution paths cannot drift.
     let mut counter = 0;
     while counter < query.commands().len() {
         let command = &query.commands()[counter];
         match command {
             Command::Await(_) => bail!("'await' is forbidden in a query function"),
             Command::BranchEq(branch) => {
-                counter = evaluate_branch_eq(counter, branch, query.positions(), stack, &registers)?;
+                counter = crate::finalize::branch_to(counter, branch, query.positions(), stack, &registers)?;
             }
             Command::BranchNeq(branch) => {
-                counter = evaluate_branch_neq(counter, branch, query.positions(), stack, &registers)?;
+                counter = crate::finalize::branch_to(counter, branch, query.positions(), stack, &registers)?;
             }
             other => {
                 other.finalize(stack, store, &mut registers)?;
@@ -104,48 +105,6 @@ pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
         outputs.push(registers.load(stack, output.operand())?);
     }
     Ok(outputs)
-}
-
-fn evaluate_branch_eq<N: Network>(
-    counter: usize,
-    branch: &snarkvm_synthesizer_program::BranchEq<N>,
-    positions: &std::collections::HashMap<Identifier<N>, usize>,
-    stack: &impl StackTrait<N>,
-    registers: &impl RegistersTrait<N>,
-) -> Result<usize> {
-    let first = registers.load(stack, branch.first())?;
-    let second = registers.load(stack, branch.second())?;
-    if first == second {
-        let position = branch.position();
-        match positions.get(position) {
-            Some(index) if *index > counter => Ok(*index),
-            Some(_) => bail!("Cannot branch to an earlier position '{position}'"),
-            None => bail!("The position '{position}' does not exist."),
-        }
-    } else {
-        Ok(counter + 1)
-    }
-}
-
-fn evaluate_branch_neq<N: Network>(
-    counter: usize,
-    branch: &snarkvm_synthesizer_program::BranchNeq<N>,
-    positions: &std::collections::HashMap<Identifier<N>, usize>,
-    stack: &impl StackTrait<N>,
-    registers: &impl RegistersTrait<N>,
-) -> Result<usize> {
-    let first = registers.load(stack, branch.first())?;
-    let second = registers.load(stack, branch.second())?;
-    if first != second {
-        let position = branch.position();
-        match positions.get(position) {
-            Some(index) if *index > counter => Ok(*index),
-            Some(_) => bail!("Cannot branch to an earlier position '{position}'"),
-            None => bail!("The position '{position}' does not exist."),
-        }
-    } else {
-        Ok(counter + 1)
-    }
 }
 
 #[cfg(test)]

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -46,11 +46,15 @@ impl<N: Network> Process<N> {
 
     /// Evaluates a query function against historic finalize-store state at the given block
     /// height. Mirrors [`evaluate_query`], but routes mapping reads through the finalize store's
-    /// historical update map. Available only when snarkVM is built with `--features history`.
+    /// historical update map. The caller (typically `VM::evaluate_query_at_height`) is responsible
+    /// for constructing `state` from the historic block at `height` so query operands reading
+    /// block metadata see the historic block's values. Available only when snarkVM is built
+    /// with `--features history`.
     #[cfg(feature = "history")]
     #[inline]
     pub fn evaluate_query_at_height<P: FinalizeStorage<N>>(
         &self,
+        state: FinalizeGlobalState,
         store: &FinalizeStore<N, P>,
         program_id: impl TryInto<ProgramID<N>>,
         query_name: impl TryInto<Identifier<N>>,
@@ -60,7 +64,7 @@ impl<N: Network> Process<N> {
         let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
         let query_name = query_name.try_into().map_err(|_| anyhow!("Invalid query function name"))?;
         let stack = self.get_stack(program_id)?;
-        evaluate_query_at_height(store, &stack, &query_name, inputs, height)
+        evaluate_query_at_height(state, store, &stack, &query_name, inputs, height)
     }
 }
 
@@ -97,20 +101,22 @@ pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
 
 /// Evaluates a query function against historic finalize-store state at the given block
 /// `height`. Mapping reads route through `FinalizeStore::get_historical_mapping_value`, which
-/// reconstructs the value applicable at `height` from the per-key update log. The returned
-/// `FinalizeGlobalState` has its `block_height` set to `height` so any consensus-version
-/// behavior the query depends on resolves consistently with the historic state.
+/// reconstructs the value applicable at `height` from the per-key update log.
+///
+/// `state` is supplied by the caller — typically `VM::evaluate_query_at_height` constructs it
+/// from the historic block at `height` so query operands reading block metadata
+/// (`block.height`, `block.timestamp`, the random seed) reflect that block.
 ///
 /// Available only when snarkVM is built with `--features history`.
 #[cfg(feature = "history")]
 pub fn evaluate_query_at_height<N: Network, P: FinalizeStorage<N>>(
+    state: FinalizeGlobalState,
     store: &FinalizeStore<N, P>,
     stack: &Stack<N>,
     query_name: &Identifier<N>,
     inputs: Vec<Value<N>>,
     height: u32,
 ) -> Result<Vec<Value<N>>> {
-    let state = FinalizeGlobalState::for_query(height);
     let historic = HistoricFinalizeStore { store, height };
     atomic_finalize!(store, FinalizeMode::DryRun, {
         evaluate_query_inner(state, &historic, stack, query_name, inputs).map_err(|e| e.to_string())
@@ -314,8 +320,12 @@ mod tests {
 
     type CurrentNetwork = MainnetV0;
 
+    /// Builds a synthetic `FinalizeGlobalState` for tests. Production callers go through
+    /// `VM::evaluate_query`, which constructs the state from a real block at the call site.
     fn sample_finalize_state(block_height: u32) -> FinalizeGlobalState {
-        FinalizeGlobalState::for_query(block_height)
+        // Use `from` to avoid the BHP hash done by `new`. The seed is irrelevant for these
+        // tests (no rand.chacha) and the round/timestamp aren't read either.
+        FinalizeGlobalState::from(block_height as u64, block_height, None, [0u8; 32])
     }
 
     #[test]
@@ -577,10 +587,10 @@ query fixed_value:
     }
 
     #[test]
-    fn test_query_rejects_block_timestamp_operand() -> Result<()> {
-        // A query that reads `block.timestamp`. Deployment must fail at type-check time —
-        // queries have no meaningful timestamp, so the runtime would otherwise bail with a
-        // confusing "not available until V12" error on every call.
+    fn test_query_can_read_block_timestamp() -> Result<()> {
+        // Queries get a real `FinalizeGlobalState` from the calling VM (built from the
+        // current/historic block), so `block.timestamp` is a valid operand inside a query body.
+        // Drive it directly here at the process layer with a synthetic state.
         let program = Program::<CurrentNetwork>::from_str(
             r"
 program qy_block_ts.aleo;
@@ -595,13 +605,18 @@ query reads_ts:
         )?;
 
         let process = Process::<CurrentNetwork>::load()?;
-        // `Stack::new` runs `FinalizeTypes::from_query` over every query at construction time,
-        // so the rejection surfaces here.
-        let err = match Stack::new(&process, &program) {
-            Ok(_) => panic!("expected stack construction to reject block.timestamp in a query"),
-            Err(err) => err.to_string(),
-        };
-        assert!(err.contains("block.timestamp"), "unexpected error message: {err}");
+        let stack = Stack::new(&process, &program)?;
+        let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
+
+        // Build a state with a non-trivial timestamp, mimicking what a real VM would supply.
+        let state = FinalizeGlobalState::from(1, 1, Some(1234567890), [0u8; 32]);
+        let outputs = evaluate_query(state, &finalize_store, &stack, &Identifier::from_str("reads_ts")?, vec![])?;
+
+        assert_eq!(outputs.len(), 1);
+        match &outputs[0] {
+            Value::Plaintext(Plaintext::Literal(Literal::I64(v), _)) => assert_eq!(**v, 1234567890),
+            other => panic!("expected i64 plaintext, got: {other}"),
+        }
         Ok(())
     }
 
@@ -669,17 +684,15 @@ query lookup:
         // Sanity: confirmed/current state reflects the LAST write (V2 = 55). Historic queries
         // below must therefore return 11 (not 55) at heights ≤ 4, distinguishing the historic
         // path from any accidental fall-through to current speculative state.
-        let outputs = evaluate_query(
-            FinalizeGlobalState::for_query(5),
-            &finalize_store,
-            &stack,
-            &Identifier::from_str("lookup")?,
-            vec![Value::Plaintext(address_key.clone())],
-        )?;
+        let outputs =
+            evaluate_query(sample_finalize_state(5), &finalize_store, &stack, &Identifier::from_str("lookup")?, vec![
+                Value::Plaintext(address_key.clone()),
+            ])?;
         assert_eq!(extract(outputs), 55, "current state should reflect the most recent write");
 
         // Query at height 1 → V1.
         let outputs = evaluate_query_at_height(
+            sample_finalize_state(1),
             &finalize_store,
             &stack,
             &Identifier::from_str("lookup")?,
@@ -690,6 +703,7 @@ query lookup:
 
         // Query at height 5 → V2.
         let outputs = evaluate_query_at_height(
+            sample_finalize_state(5),
             &finalize_store,
             &stack,
             &Identifier::from_str("lookup")?,
@@ -701,6 +715,7 @@ query lookup:
         // Query at height 3 (between the two updates) → V1, since the binary-search picks
         // the most recent applicable height.
         let outputs = evaluate_query_at_height(
+            sample_finalize_state(3),
             &finalize_store,
             &stack,
             &Identifier::from_str("lookup")?,

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -219,10 +219,11 @@ fn evaluate_query_inner<N: Network>(
     // Compute the register types for the query body.
     let types = FinalizeTypes::from_query(stack, query)?;
 
-    // Queries are read-only and externally-callable: no transition is associated. The block
-    // height inside `state` is the only state-binding; `transition_id` and `nonce` are filled
-    // with defaults by the dedicated constructor (they are unused on a query path).
-    let mut registers = FinalizeRegisters::new_for_query(state, *query.name(), types);
+    // Queries are read-only and externally-callable: no transition is associated. Pass `None`
+    // for `transition_id` and `nonce` — the only consumer (rand.chacha) is rejected by
+    // `add_command`, so any future reader of these fields must handle the `None` case
+    // explicitly (the trait surface makes this a compile-time obligation).
+    let mut registers = FinalizeRegisters::new(state, None, *query.name(), types, None);
 
     // Validate the input arity.
     ensure!(

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -19,7 +19,7 @@ use console::{
     program::{Identifier, ProgramID, Value},
 };
 use snarkvm_ledger_store::{FinalizeMode, FinalizeStorage, FinalizeStore, atomic_finalize};
-use snarkvm_synthesizer_program::{Command, FinalizeGlobalState, RegistersTrait, StackTrait};
+use snarkvm_synthesizer_program::{Command, FinalizeGlobalState, FinalizeStoreTrait, RegistersTrait, StackTrait};
 
 impl<N: Network> Process<N> {
     /// Evaluates a query function in the program identified by `program_id` and returns its outputs.
@@ -42,6 +42,25 @@ impl<N: Network> Process<N> {
         let query_name = query_name.try_into().map_err(|_| anyhow!("Invalid query function name"))?;
         let stack = self.get_stack(program_id)?;
         evaluate_query(state, store, &stack, &query_name, inputs)
+    }
+
+    /// Evaluates a query function against historic finalize-store state at the given block
+    /// height. Mirrors [`evaluate_query`], but routes mapping reads through the finalize store's
+    /// historical update map. Available only when snarkVM is built with `--features history`.
+    #[cfg(feature = "history")]
+    #[inline]
+    pub fn evaluate_query_at_height<P: FinalizeStorage<N>>(
+        &self,
+        store: &FinalizeStore<N, P>,
+        program_id: impl TryInto<ProgramID<N>>,
+        query_name: impl TryInto<Identifier<N>>,
+        inputs: Vec<Value<N>>,
+        height: u32,
+    ) -> Result<Vec<Value<N>>> {
+        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        let query_name = query_name.try_into().map_err(|_| anyhow!("Invalid query function name"))?;
+        let stack = self.get_stack(program_id)?;
+        evaluate_query_at_height(store, &stack, &query_name, inputs, height)
     }
 }
 
@@ -76,11 +95,120 @@ pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
     })
 }
 
+/// Evaluates a query function against historic finalize-store state at the given block
+/// `height`. Mapping reads route through `FinalizeStore::get_historical_mapping_value`, which
+/// reconstructs the value applicable at `height` from the per-key update log. The returned
+/// `FinalizeGlobalState` has its `block_height` set to `height` so any consensus-version
+/// behavior the query depends on resolves consistently with the historic state.
+///
+/// Available only when snarkVM is built with `--features history`.
+#[cfg(feature = "history")]
+pub fn evaluate_query_at_height<N: Network, P: FinalizeStorage<N>>(
+    store: &FinalizeStore<N, P>,
+    stack: &Stack<N>,
+    query_name: &Identifier<N>,
+    inputs: Vec<Value<N>>,
+    height: u32,
+) -> Result<Vec<Value<N>>> {
+    let state = FinalizeGlobalState::for_query(height);
+    let historic = HistoricFinalizeStore { store, height };
+    atomic_finalize!(store, FinalizeMode::DryRun, {
+        evaluate_query_inner(state, &historic, stack, query_name, inputs).map_err(|e| e.to_string())
+    })
+}
+
+/// Read-only `FinalizeStoreTrait` adapter that routes mapping reads through the finalize
+/// store's historical update map at a fixed `height`. Writes bail — they are unreachable on
+/// the query path (queries reject `set` / `remove` at construction), but bailing here
+/// preserves that invariant if the adapter is ever passed to other code.
+#[cfg(feature = "history")]
+struct HistoricFinalizeStore<'a, N: Network, P: FinalizeStorage<N>> {
+    store: &'a FinalizeStore<N, P>,
+    height: u32,
+}
+
+#[cfg(feature = "history")]
+impl<N: Network, P: FinalizeStorage<N>> FinalizeStoreTrait<N> for HistoricFinalizeStore<'_, N, P> {
+    fn contains_mapping_confirmed(
+        &self,
+        program_id: &console::program::ProgramID<N>,
+        mapping_name: &Identifier<N>,
+    ) -> Result<bool> {
+        // Mapping existence is not versioned per height. Delegate to the underlying store:
+        // if the mapping exists now, queries at any height return per-key historic values
+        // (or `None` for keys that had no value at that height).
+        self.store.contains_mapping_confirmed(program_id, mapping_name)
+    }
+
+    fn contains_mapping_speculative(
+        &self,
+        program_id: &console::program::ProgramID<N>,
+        mapping_name: &Identifier<N>,
+    ) -> Result<bool> {
+        self.store.contains_mapping_speculative(program_id, mapping_name)
+    }
+
+    fn contains_key_speculative(
+        &self,
+        program_id: console::program::ProgramID<N>,
+        mapping_name: Identifier<N>,
+        key: &console::program::Plaintext<N>,
+    ) -> Result<bool> {
+        Ok(self.store.get_historical_mapping_value(program_id, mapping_name, key.clone(), self.height)?.is_some())
+    }
+
+    fn get_value_speculative(
+        &self,
+        program_id: console::program::ProgramID<N>,
+        mapping_name: Identifier<N>,
+        key: &console::program::Plaintext<N>,
+    ) -> Result<Option<Value<N>>> {
+        Ok(self
+            .store
+            .get_historical_mapping_value(program_id, mapping_name, key.clone(), self.height)?
+            .map(|cow| cow.into_owned()))
+    }
+
+    fn insert_key_value(
+        &self,
+        _program_id: console::program::ProgramID<N>,
+        _mapping_name: Identifier<N>,
+        _key: console::program::Plaintext<N>,
+        _value: Value<N>,
+    ) -> Result<snarkvm_synthesizer_program::FinalizeOperation<N>> {
+        bail!("Forbidden operation: query path cannot write to the finalize store ('insert_key_value')")
+    }
+
+    fn update_key_value(
+        &self,
+        _program_id: console::program::ProgramID<N>,
+        _mapping_name: Identifier<N>,
+        _key: console::program::Plaintext<N>,
+        _value: Value<N>,
+    ) -> Result<snarkvm_synthesizer_program::FinalizeOperation<N>> {
+        bail!("Forbidden operation: query path cannot write to the finalize store ('update_key_value')")
+    }
+
+    fn remove_key_value(
+        &self,
+        _program_id: console::program::ProgramID<N>,
+        _mapping_name: Identifier<N>,
+        _key: &console::program::Plaintext<N>,
+    ) -> Result<Option<snarkvm_synthesizer_program::FinalizeOperation<N>>> {
+        bail!("Forbidden operation: query path cannot write to the finalize store ('remove_key_value')")
+    }
+}
+
 /// Inner evaluation of a query. The outer wrapper enforces isolation via
 /// `atomic_finalize!(DryRun)` — see [`evaluate_query`] for the rationale.
-fn evaluate_query_inner<N: Network, P: FinalizeStorage<N>>(
+///
+/// Generic over the store so that `evaluate_query` (current state) and
+/// `evaluate_query_at_height` (historic state via the `--history` feature) can share the
+/// loop body. The historic path passes a read-only adapter that routes to
+/// `FinalizeStore::get_historical_mapping_value`.
+fn evaluate_query_inner<N: Network>(
     state: FinalizeGlobalState,
-    store: &FinalizeStore<N, P>,
+    store: &impl FinalizeStoreTrait<N>,
     stack: &Stack<N>,
     query_name: &Identifier<N>,
     inputs: Vec<Value<N>>,
@@ -469,6 +597,113 @@ query reads_ts:
             Err(err) => err.to_string(),
         };
         assert!(err.contains("block.timestamp"), "unexpected error message: {err}");
+        Ok(())
+    }
+
+    /// Drives a value through two updates at different block heights and asserts that
+    /// `evaluate_query_at_height` returns the value applicable at each height.
+    #[cfg(feature = "history")]
+    #[test]
+    fn test_evaluate_query_at_height_returns_historic_value() -> Result<()> {
+        use std::sync::atomic::Ordering;
+
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program qy_history.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query lookup:
+    input r0 as address.public;
+    get balances[r0] into r1;
+    output r1 as u64.public;",
+        )?;
+
+        let process = Process::<CurrentNetwork>::load()?;
+        let stack = Stack::new(&process, &program)?;
+        let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
+
+        let program_id = *program.id();
+        let mapping_name = Identifier::from_str("balances")?;
+        finalize_store.initialize_mapping(program_id, mapping_name)?;
+
+        let mut rng = console::prelude::TestRng::default();
+        let private_key = PrivateKey::<CurrentNetwork>::new(&mut rng)?;
+        let address = console::account::Address::try_from(&private_key)?;
+        let address_key = Plaintext::from(Literal::Address(address));
+
+        // Write V1 at height 1, then V2 at height 5. The historic update map is populated
+        // automatically because the `--features history` build path is enabled.
+        finalize_store.current_block_height().store(1, Ordering::SeqCst);
+        finalize_store.update_key_value(
+            program_id,
+            mapping_name,
+            address_key.clone(),
+            Value::Plaintext(Plaintext::from(Literal::U64(U64::new(11)))),
+        )?;
+        finalize_store.current_block_height().store(5, Ordering::SeqCst);
+        finalize_store.update_key_value(
+            program_id,
+            mapping_name,
+            address_key.clone(),
+            Value::Plaintext(Plaintext::from(Literal::U64(U64::new(55)))),
+        )?;
+
+        // Helper to extract the u64 from a single-output Vec<Value<N>>.
+        let extract = |outputs: Vec<Value<CurrentNetwork>>| match &outputs[0] {
+            Value::Plaintext(Plaintext::Literal(Literal::U64(v), _)) => **v,
+            other => panic!("expected u64, got: {other}"),
+        };
+
+        // Sanity: confirmed/current state reflects the LAST write (V2 = 55). Historic queries
+        // below must therefore return 11 (not 55) at heights ≤ 4, distinguishing the historic
+        // path from any accidental fall-through to current speculative state.
+        let outputs = evaluate_query(
+            FinalizeGlobalState::for_query(5),
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("lookup")?,
+            vec![Value::Plaintext(address_key.clone())],
+        )?;
+        assert_eq!(extract(outputs), 55, "current state should reflect the most recent write");
+
+        // Query at height 1 → V1.
+        let outputs = evaluate_query_at_height(
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("lookup")?,
+            vec![Value::Plaintext(address_key.clone())],
+            1,
+        )?;
+        assert_eq!(extract(outputs), 11, "expected historic value at height 1");
+
+        // Query at height 5 → V2.
+        let outputs = evaluate_query_at_height(
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("lookup")?,
+            vec![Value::Plaintext(address_key.clone())],
+            5,
+        )?;
+        assert_eq!(extract(outputs), 55, "expected historic value at height 5");
+
+        // Query at height 3 (between the two updates) → V1, since the binary-search picks
+        // the most recent applicable height.
+        let outputs = evaluate_query_at_height(
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("lookup")?,
+            vec![Value::Plaintext(address_key)],
+            3,
+        )?;
+        assert_eq!(extract(outputs), 11, "expected applicable historic value at intermediate height 3");
+
         Ok(())
     }
 }

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -26,7 +26,9 @@ impl<N: Network> Process<N> {
     ///
     /// This is the public-facing query API: callers pass a program ID and query function name,
     /// not a `&Stack<N>`. It mirrors the shape of `Process::authorize` / `Process::execute`,
-    /// minus the proof stage.
+    /// minus the proof stage. **No transitions are produced and no finalize-store writes occur** —
+    /// queries are read-only by construction (`add_command` rejects `set` / `remove` / `async` /
+    /// `await` / `call` / `rand.chacha` / record-touching ops).
     #[inline]
     pub fn evaluate_query<P: FinalizeStorage<N>>(
         &self,
@@ -74,6 +76,21 @@ pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
         inputs.len(),
     );
 
+    // Reject non-plaintext inputs up-front. Query input statements are typed
+    // `FinalizeType::Plaintext` at construction, so the per-register store would reject
+    // these as well — but with a generic type-mismatch error. Surfacing the kind here
+    // gives a clearer UX.
+    for (i, value) in inputs.iter().enumerate() {
+        let kind = match value {
+            Value::Plaintext(_) => continue,
+            Value::Record(_) => "record",
+            Value::Future(_) => "future",
+            Value::DynamicRecord(_) => "dynamic record",
+            Value::DynamicFuture(_) => "dynamic future",
+        };
+        bail!("Query '{}' input #{i} must be a plaintext value, got a {kind}", query.name());
+    }
+
     // Store the inputs.
     for (input_stmt, value) in query.inputs().iter().zip(inputs.into_iter()) {
         registers.store(stack, input_stmt.register(), value)?;
@@ -81,6 +98,19 @@ pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
 
     // Evaluate the commands. Queries cannot await; branches reuse the finalize-side
     // `branch_to` helper so the two execution paths cannot drift.
+    //
+    // Termination & cost bounds (prototype):
+    //   - The loop is bounded by `query.commands().len()`, which is itself bounded by
+    //     `N::MAX_COMMANDS` (= `u16::MAX`).
+    //   - `branch_to` permits forward jumps only, so the counter strictly advances and
+    //     no command can re-execute. Termination is guaranteed.
+    //   - Deploy-time, `query_cost_for_single_query` enforces that the worst-case body
+    //     cost is `<= TRANSACTION_SPEND_LIMIT`, so a deployed query cannot register an
+    //     unboundedly expensive body.
+    //   - There is intentionally NO smaller per-call runtime budget below the deploy
+    //     bound. A node serving repeated external query calls can therefore consume up
+    //     to the deploy bound per call. Rate-limiting and indexing are expected to be
+    //     handled at the snarkOS RPC layer, not here.
     let mut counter = 0;
     while counter < query.commands().len() {
         let command = &query.commands()[counter];
@@ -294,6 +324,77 @@ query fetch_balance:
 
         let err = result.expect_err("expected error when mapping is not initialized").to_string();
         assert!(err.contains("does not exist"), "unexpected error message: {err}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_evaluate_query_rejects_non_plaintext_input() -> Result<()> {
+        // A query that takes a single plaintext input. We then call it with a `Value::Future`
+        // and expect the entry-point pre-validation to reject with a clear "must be a plaintext
+        // value, got a future" error rather than a generic store-mismatch.
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program qy_input_kind.aleo;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query echo:
+    input r0 as u64.public;
+    add r0 0u64 into r1;
+    output r1 as u64.public;",
+        )?;
+
+        let process = Process::<CurrentNetwork>::load()?;
+        let stack = Stack::new(&process, &program)?;
+        let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
+
+        // Build a non-plaintext Value: a Future with an empty argument list (the contents
+        // don't matter; we only care that it's not Plaintext).
+        let future_value =
+            Value::Future(console::program::Future::new(*program.id(), Identifier::from_str("noop")?, vec![]));
+
+        let result =
+            evaluate_query(sample_finalize_state(1), &finalize_store, &stack, &Identifier::from_str("echo")?, vec![
+                future_value,
+            ]);
+
+        let err = match result {
+            Ok(_) => panic!("expected error for non-plaintext input"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("future"), "unexpected error message: {err}");
+        assert!(err.contains("plaintext"), "unexpected error message: {err}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_rejects_block_timestamp_operand() -> Result<()> {
+        // A query that reads `block.timestamp`. Deployment must fail at type-check time —
+        // queries have no meaningful timestamp, so the runtime would otherwise bail with a
+        // confusing "not available until V12" error on every call.
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program qy_block_ts.aleo;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query reads_ts:
+    add block.timestamp 0i64 into r0;
+    output r0 as i64.public;",
+        )?;
+
+        let process = Process::<CurrentNetwork>::load()?;
+        // `Stack::new` runs `FinalizeTypes::from_query` over every query at construction time,
+        // so the rejection surfaces here.
+        let err = match Stack::new(&process, &program) {
+            Ok(_) => panic!("expected stack construction to reject block.timestamp in a query"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("block.timestamp"), "unexpected error message: {err}");
         Ok(())
     }
 }

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -1,0 +1,293 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{FinalizeRegisters, FinalizeTypes, Process, Stack};
+use console::{
+    network::prelude::*,
+    program::{Identifier, ProgramID, Value},
+};
+use snarkvm_ledger_store::{FinalizeStorage, FinalizeStore};
+use snarkvm_synthesizer_program::{Command, FinalizeGlobalState, RegistersTrait, StackTrait};
+
+impl<N: Network> Process<N> {
+    /// Evaluates a query function in the program identified by `program_id` and returns its outputs.
+    ///
+    /// This is the public-facing query API: callers pass a program ID and query function name,
+    /// not a `&Stack<N>`. It mirrors the shape of `Process::authorize` / `Process::execute`,
+    /// minus the proof stage.
+    #[inline]
+    pub fn evaluate_query<P: FinalizeStorage<N>>(
+        &self,
+        state: FinalizeGlobalState,
+        store: &FinalizeStore<N, P>,
+        program_id: impl TryInto<ProgramID<N>>,
+        query_name: impl TryInto<Identifier<N>>,
+        inputs: Vec<Value<N>>,
+    ) -> Result<Vec<Value<N>>> {
+        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        let query_name = query_name.try_into().map_err(|_| anyhow!("Invalid query function name"))?;
+        let stack = self.get_stack(program_id)?;
+        evaluate_query(state, store, &stack, &query_name, inputs)
+    }
+}
+
+/// Evaluates a query function on a populated finalize store and returns the declared outputs.
+///
+/// This is the prototype query path. It is invoked by external callers only — query functions
+/// cannot be called from inside other program components in this prototype.
+pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
+    state: FinalizeGlobalState,
+    store: &FinalizeStore<N, P>,
+    stack: &Stack<N>,
+    query_name: &Identifier<N>,
+    inputs: Vec<Value<N>>,
+) -> Result<Vec<Value<N>>> {
+    // Resolve the query function in the stack's program.
+    let query = stack.program().get_query_ref(query_name)?;
+
+    // Compute the register types for the query body.
+    let types = FinalizeTypes::from_query(stack, query)?;
+
+    // Queries are read-only and externally-callable: no transition is associated. Use a default
+    // transition ID and a zero nonce. The block height in `state` is the only state-binding.
+    let transition_id = N::TransitionID::default();
+    let mut registers = FinalizeRegisters::new(state, transition_id, *query.name(), types, 0);
+
+    // Validate the input arity.
+    ensure!(
+        query.inputs().len() == inputs.len(),
+        "Query '{}' expects {} inputs, got {}",
+        query.name(),
+        query.inputs().len(),
+        inputs.len(),
+    );
+
+    // Store the inputs.
+    for (input_stmt, value) in query.inputs().iter().zip(inputs.into_iter()) {
+        registers.store(stack, input_stmt.register(), value)?;
+    }
+
+    // Evaluate the commands. Queries cannot await; branches are inlined.
+    let mut counter = 0;
+    while counter < query.commands().len() {
+        let command = &query.commands()[counter];
+        match command {
+            Command::Await(_) => bail!("'await' is forbidden in a query function"),
+            Command::BranchEq(branch) => {
+                counter = evaluate_branch_eq(counter, branch, query.positions(), stack, &registers)?;
+            }
+            Command::BranchNeq(branch) => {
+                counter = evaluate_branch_neq(counter, branch, query.positions(), stack, &registers)?;
+            }
+            other => {
+                other.finalize(stack, store, &mut registers)?;
+                counter += 1;
+            }
+        }
+    }
+
+    // Load the outputs.
+    let mut outputs = Vec::with_capacity(query.outputs().len());
+    for output in query.outputs() {
+        outputs.push(registers.load(stack, output.operand())?);
+    }
+    Ok(outputs)
+}
+
+fn evaluate_branch_eq<N: Network>(
+    counter: usize,
+    branch: &snarkvm_synthesizer_program::BranchEq<N>,
+    positions: &std::collections::HashMap<Identifier<N>, usize>,
+    stack: &impl StackTrait<N>,
+    registers: &impl RegistersTrait<N>,
+) -> Result<usize> {
+    let first = registers.load(stack, branch.first())?;
+    let second = registers.load(stack, branch.second())?;
+    if first == second {
+        let position = branch.position();
+        match positions.get(position) {
+            Some(index) if *index > counter => Ok(*index),
+            Some(_) => bail!("Cannot branch to an earlier position '{position}'"),
+            None => bail!("The position '{position}' does not exist."),
+        }
+    } else {
+        Ok(counter + 1)
+    }
+}
+
+fn evaluate_branch_neq<N: Network>(
+    counter: usize,
+    branch: &snarkvm_synthesizer_program::BranchNeq<N>,
+    positions: &std::collections::HashMap<Identifier<N>, usize>,
+    stack: &impl StackTrait<N>,
+    registers: &impl RegistersTrait<N>,
+) -> Result<usize> {
+    let first = registers.load(stack, branch.first())?;
+    let second = registers.load(stack, branch.second())?;
+    if first != second {
+        let position = branch.position();
+        match positions.get(position) {
+            Some(index) if *index > counter => Ok(*index),
+            Some(_) => bail!("Cannot branch to an earlier position '{position}'"),
+            None => bail!("The position '{position}' does not exist."),
+        }
+    } else {
+        Ok(counter + 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Process;
+    use console::{
+        account::PrivateKey,
+        network::MainnetV0,
+        program::{Literal, Plaintext},
+        types::U64,
+    };
+    use snarkvm_ledger_store::helpers::memory::FinalizeMemory;
+    use snarkvm_synthesizer_program::{FinalizeStoreTrait, Program};
+
+    type CurrentNetwork = MainnetV0;
+
+    fn sample_finalize_state(block_height: u32) -> FinalizeGlobalState {
+        FinalizeGlobalState::from(block_height as u64, block_height, None, [0u8; 32])
+    }
+
+    #[test]
+    fn test_evaluate_query_simple() -> Result<()> {
+        // A program with a mapping and a query function that sums two mappings for an address.
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program token_with_query.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
+
+mapping staked:
+    key as address.public;
+    value as u64.public;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query total_balance:
+    input r0 as address.public;
+    get.or_use balances[r0] 0u64 into r1;
+    get.or_use staked[r0] 0u64 into r2;
+    add r1 r2 into r3;
+    output r3 as u64.public;",
+        )?;
+
+        // Initialize a process and a stack for this program (no deployment needed here).
+        let process = Process::<CurrentNetwork>::load()?;
+        let stack = Stack::new(&process, &program)?;
+
+        // Initialize the finalize store and seed mapping values.
+        let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
+
+        let program_id = *program.id();
+        finalize_store.initialize_mapping(program_id, Identifier::from_str("balances")?)?;
+        finalize_store.initialize_mapping(program_id, Identifier::from_str("staked")?)?;
+
+        // Pick a deterministic address.
+        let mut rng = console::prelude::TestRng::default();
+        let private_key = PrivateKey::<CurrentNetwork>::new(&mut rng)?;
+        let address = console::account::Address::try_from(&private_key)?;
+        let address_key = Plaintext::from(Literal::Address(address));
+
+        finalize_store.update_key_value(
+            program_id,
+            Identifier::from_str("balances")?,
+            address_key.clone(),
+            Value::Plaintext(Plaintext::from(Literal::U64(U64::new(40)))),
+        )?;
+        finalize_store.update_key_value(
+            program_id,
+            Identifier::from_str("staked")?,
+            address_key.clone(),
+            Value::Plaintext(Plaintext::from(Literal::U64(U64::new(2)))),
+        )?;
+
+        // Evaluate the query.
+        let outputs = evaluate_query(
+            sample_finalize_state(1),
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("total_balance")?,
+            vec![Value::Plaintext(address_key.clone())],
+        )?;
+
+        // Expect a single u64 output equal to 42.
+        assert_eq!(outputs.len(), 1);
+        match &outputs[0] {
+            Value::Plaintext(Plaintext::Literal(Literal::U64(v), _)) => assert_eq!(**v, 42),
+            other => panic!("unexpected output: {other}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_evaluate_query_uses_or_default_when_key_missing() -> Result<()> {
+        // Same program, but query an address that's never been stored.
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program token_with_query.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query fetch_balance:
+    input r0 as address.public;
+    get.or_use balances[r0] 7u64 into r1;
+    output r1 as u64.public;",
+        )?;
+
+        let process = Process::<CurrentNetwork>::load()?;
+        let stack = Stack::new(&process, &program)?;
+
+        let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
+        finalize_store.initialize_mapping(*program.id(), Identifier::from_str("balances")?)?;
+
+        let mut rng = console::prelude::TestRng::default();
+        let private_key = PrivateKey::<CurrentNetwork>::new(&mut rng)?;
+        let address = console::account::Address::try_from(&private_key)?;
+        let address_key = Plaintext::from(Literal::Address(address));
+
+        let outputs = evaluate_query(
+            sample_finalize_state(1),
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("fetch_balance")?,
+            vec![Value::Plaintext(address_key)],
+        )?;
+
+        assert_eq!(outputs.len(), 1);
+        match &outputs[0] {
+            Value::Plaintext(Plaintext::Literal(Literal::U64(v), _)) => assert_eq!(**v, 7),
+            other => panic!("unexpected output: {other}"),
+        }
+        Ok(())
+    }
+}

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -290,4 +290,51 @@ query fetch_balance:
         }
         Ok(())
     }
+
+    #[test]
+    fn test_evaluate_query_errors_when_mapping_not_initialized() -> Result<()> {
+        // Same shape of program as the other tests, but the finalize store is intentionally not
+        // initialized for `balances`. The runtime path must surface the existing
+        // "Mapping ... does not exist" error rather than panic or silently succeed.
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program token_with_query.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query fetch_balance:
+    input r0 as address.public;
+    get.or_use balances[r0] 7u64 into r1;
+    output r1 as u64.public;",
+        )?;
+
+        let process = Process::<CurrentNetwork>::load()?;
+        let stack = Stack::new(&process, &program)?;
+
+        // Open an empty finalize store. Note: `initialize_mapping` is deliberately NOT called.
+        let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
+
+        let mut rng = console::prelude::TestRng::default();
+        let private_key = PrivateKey::<CurrentNetwork>::new(&mut rng)?;
+        let address = console::account::Address::try_from(&private_key)?;
+        let address_key = Plaintext::from(Literal::Address(address));
+
+        let result = evaluate_query(
+            sample_finalize_state(1),
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("fetch_balance")?,
+            vec![Value::Plaintext(address_key)],
+        );
+
+        let err = result.expect_err("expected error when mapping is not initialized").to_string();
+        assert!(err.contains("does not exist"), "unexpected error message: {err}");
+        Ok(())
+    }
 }

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -60,10 +60,10 @@ pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
     // Compute the register types for the query body.
     let types = FinalizeTypes::from_query(stack, query)?;
 
-    // Queries are read-only and externally-callable: no transition is associated. Use a default
-    // transition ID and a zero nonce. The block height in `state` is the only state-binding.
-    let transition_id = N::TransitionID::default();
-    let mut registers = FinalizeRegisters::new(state, transition_id, *query.name(), types, 0);
+    // Queries are read-only and externally-callable: no transition is associated. The block
+    // height inside `state` is the only state-binding; `transition_id` and `nonce` are filled
+    // with defaults by the dedicated constructor (they are unused on a query path).
+    let mut registers = FinalizeRegisters::new_for_query(state, *query.name(), types);
 
     // Validate the input arity.
     ensure!(

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -123,7 +123,7 @@ mod tests {
     type CurrentNetwork = MainnetV0;
 
     fn sample_finalize_state(block_height: u32) -> FinalizeGlobalState {
-        FinalizeGlobalState::from(block_height as u64, block_height, None, [0u8; 32])
+        FinalizeGlobalState::for_query(block_height)
     }
 
     #[test]

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -18,39 +18,25 @@ use console::{
     network::prelude::*,
     program::{Identifier, ProgramID, Value},
 };
-use snarkvm_ledger_store::{FinalizeMode, FinalizeStorage, FinalizeStore, atomic_finalize};
+use snarkvm_ledger_store::{FinalizeStorage, FinalizeStore};
 use snarkvm_synthesizer_program::{FinalizeGlobalState, FinalizeStoreTrait, RegistersTrait, StackTrait};
 
 impl<N: Network> Process<N> {
-    /// Evaluates a query function in the program identified by `program_id` and returns its outputs.
-    ///
-    /// This is the public-facing query API: callers pass a program ID and query function name,
-    /// not a `&Stack<N>`. It mirrors the shape of `Process::authorize` / `Process::execute`,
-    /// minus the proof stage. **No transitions are produced and no finalize-store writes occur** —
-    /// queries are read-only by construction (`add_command` rejects `set` / `remove` / `async` /
-    /// `await` / `call` / `rand.chacha` / record-touching ops).
-    #[inline]
-    pub fn evaluate_query<P: FinalizeStorage<N>>(
-        &self,
-        state: FinalizeGlobalState,
-        store: &FinalizeStore<N, P>,
-        program_id: impl TryInto<ProgramID<N>>,
-        query_name: impl TryInto<Identifier<N>>,
-        inputs: Vec<Value<N>>,
-    ) -> Result<Vec<Value<N>>> {
-        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
-        let query_name = query_name.try_into().map_err(|_| anyhow!("Invalid query function name"))?;
-        let stack = self.get_stack(program_id)?;
-        evaluate_query(state, store, &stack, &query_name, inputs)
-    }
-
     /// Evaluates a query function against historic finalize-store state at the given block
-    /// height. Mirrors [`evaluate_query`], but routes mapping reads through the finalize store's
-    /// historical update map. The caller (typically `VM::evaluate_query_at_height`) is responsible
-    /// for constructing `state` from the historic block at `height` so query operands reading
-    /// block metadata see the historic block's values. Available only when snarkVM is built
-    /// with `--features history`.
-    #[cfg(feature = "history")]
+    /// height. Routes mapping reads through the finalize store's historical update map (per-key
+    /// values keyed by `(program, mapping, key, height)`), so all reads in the query body are
+    /// pinned to `height` — block production advancing past `height` during evaluation cannot
+    /// disturb the result. The caller (typically `VM::evaluate_query_at_height`) constructs
+    /// `state` from the historic block at `height` so query operands reading block metadata
+    /// see the historic block's values.
+    ///
+    /// **No transitions are produced and no finalize-store writes occur** — queries are
+    /// read-only by construction (`add_command` rejects `set` / `remove` / `async` / `await` /
+    /// `call` / `rand.chacha` / record-touching ops), and the adapter additionally bails on
+    /// every write entry point.
+    ///
+    /// Available only when snarkVM is built with `--features history`. snarkOS calls this with
+    /// `current_block_height()` for "latest", or any earlier height for historic queries.
     #[inline]
     pub fn evaluate_query_at_height<P: FinalizeStorage<N>>(
         &self,
@@ -68,47 +54,20 @@ impl<N: Network> Process<N> {
     }
 }
 
-/// Evaluates a query function on a populated finalize store and returns the declared outputs.
-///
-/// This is the prototype query path. It is invoked by external callers only — query functions
-/// cannot be called from inside other program components in this prototype.
-///
-/// Isolation:
-/// The entire evaluation runs inside an `atomic_finalize!(DryRun)` batch over the finalize
-/// store. Two consequences:
-///   1. **Confirmed-state reads.** While the batch is open, the finalize store's
-///      `*_speculative` reads (used by `Get` / `Contains` / `GetOrUse`) only see this batch's
-///      state, which performs no writes — so each read transparently falls through to the
-///      confirmed map. A concurrent `finalize_atomic_batch` (block production / dry-run
-///      speculation) would otherwise expose pending writes via the same speculative path.
-///   2. **No store writes.** The DryRun batch is always aborted at the end, so even a future
-///      change that inadvertently introduces a write cannot reach the canonical store.
-///
-/// Cost: a query attempted while another atomic batch is in progress (block finalization, or
-/// another query) fails fast with the macro's standard error. snarkOS is expected to handle
-/// retry / rate-limiting at the RPC layer.
-pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
-    state: FinalizeGlobalState,
-    store: &FinalizeStore<N, P>,
-    stack: &Stack<N>,
-    query_name: &Identifier<N>,
-    inputs: Vec<Value<N>>,
-) -> Result<Vec<Value<N>>> {
-    atomic_finalize!(store, FinalizeMode::DryRun, {
-        evaluate_query_inner(state, store, stack, query_name, inputs).map_err(|e| e.to_string())
-    })
-}
-
 /// Evaluates a query function against historic finalize-store state at the given block
 /// `height`. Mapping reads route through `FinalizeStore::get_historical_mapping_value`, which
-/// reconstructs the value applicable at `height` from the per-key update log.
+/// reconstructs the value applicable at `height` from the per-key update log (a confirmed-only
+/// table — entries are only written during finalize, never modified). Pinning every read to
+/// `height` therefore gives true snapshot semantics: block production advancing past `height`
+/// during evaluation cannot disturb the result, and we don't need to take an atomic batch on
+/// the store (so this path doesn't contend with block finalization either).
 ///
 /// `state` is supplied by the caller — typically `VM::evaluate_query_at_height` constructs it
 /// from the historic block at `height` so query operands reading block metadata
 /// (`block.height`, `block.timestamp`, the random seed) reflect that block.
 ///
-/// Available only when snarkVM is built with `--features history`.
-#[cfg(feature = "history")]
+/// Available only when snarkVM is built with `--features history`. snarkOS calls this with
+/// `current_block_height()` for "latest", or any earlier height for historic queries.
 pub fn evaluate_query_at_height<N: Network, P: FinalizeStorage<N>>(
     state: FinalizeGlobalState,
     store: &FinalizeStore<N, P>,
@@ -118,22 +77,18 @@ pub fn evaluate_query_at_height<N: Network, P: FinalizeStorage<N>>(
     height: u32,
 ) -> Result<Vec<Value<N>>> {
     let historic = HistoricFinalizeStore { store, height };
-    atomic_finalize!(store, FinalizeMode::DryRun, {
-        evaluate_query_inner(state, &historic, stack, query_name, inputs).map_err(|e| e.to_string())
-    })
+    evaluate_query_inner(state, &historic, stack, query_name, inputs)
 }
 
 /// Read-only `FinalizeStoreTrait` adapter that routes mapping reads through the finalize
 /// store's historical update map at a fixed `height`. Writes bail — they are unreachable on
 /// the query path (queries reject `set` / `remove` at construction), but bailing here
 /// preserves that invariant if the adapter is ever passed to other code.
-#[cfg(feature = "history")]
 struct HistoricFinalizeStore<'a, N: Network, P: FinalizeStorage<N>> {
     store: &'a FinalizeStore<N, P>,
     height: u32,
 }
 
-#[cfg(feature = "history")]
 impl<N: Network, P: FinalizeStorage<N>> FinalizeStoreTrait<N> for HistoricFinalizeStore<'_, N, P> {
     fn contains_mapping_confirmed(
         &self,
@@ -205,13 +160,9 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStoreTrait<N> for HistoricFinali
     }
 }
 
-/// Inner evaluation of a query. The outer wrapper enforces isolation via
-/// `atomic_finalize!(DryRun)` — see [`evaluate_query`] for the rationale.
-///
-/// Generic over the store so that `evaluate_query` (current state) and
-/// `evaluate_query_at_height` (historic state via the `--history` feature) can share the
-/// loop body. The historic path passes a read-only adapter that routes to
-/// `FinalizeStore::get_historical_mapping_value`.
+/// Inner evaluation of a query. Generic over the store; the public path
+/// ([`evaluate_query_at_height`]) wraps the underlying `FinalizeStore` in a
+/// [`HistoricFinalizeStore`] adapter that pins reads to a fixed height.
 fn evaluate_query_inner<N: Network>(
     state: FinalizeGlobalState,
     store: &impl FinalizeStoreTrait<N>,
@@ -385,13 +336,15 @@ query total_balance:
             Value::Plaintext(Plaintext::from(Literal::U64(U64::new(2)))),
         )?;
 
-        // Evaluate the query.
-        let outputs = evaluate_query(
-            sample_finalize_state(1),
+        // Evaluate the query at height 0 (the default `current_block_height` for the in-memory
+        // store; `update_key_value` records the historic entries at that height).
+        let outputs = evaluate_query_at_height(
+            sample_finalize_state(0),
             &finalize_store,
             &stack,
             &Identifier::from_str("total_balance")?,
             vec![Value::Plaintext(address_key.clone())],
+            0,
         )?;
 
         // Expect a single u64 output equal to 42.
@@ -436,12 +389,13 @@ query fetch_balance:
         let address = console::account::Address::try_from(&private_key)?;
         let address_key = Plaintext::from(Literal::Address(address));
 
-        let outputs = evaluate_query(
-            sample_finalize_state(1),
+        let outputs = evaluate_query_at_height(
+            sample_finalize_state(0),
             &finalize_store,
             &stack,
             &Identifier::from_str("fetch_balance")?,
             vec![Value::Plaintext(address_key)],
+            0,
         )?;
 
         assert_eq!(outputs.len(), 1);
@@ -486,12 +440,13 @@ query fetch_balance:
         let address = console::account::Address::try_from(&private_key)?;
         let address_key = Plaintext::from(Literal::Address(address));
 
-        let result = evaluate_query(
-            sample_finalize_state(1),
+        let result = evaluate_query_at_height(
+            sample_finalize_state(0),
             &finalize_store,
             &stack,
             &Identifier::from_str("fetch_balance")?,
             vec![Value::Plaintext(address_key)],
+            0,
         );
 
         let err = result.expect_err("expected error when mapping is not initialized").to_string();
@@ -527,10 +482,14 @@ query echo:
         let future_value =
             Value::Future(console::program::Future::new(*program.id(), Identifier::from_str("noop")?, vec![]));
 
-        let result =
-            evaluate_query(sample_finalize_state(1), &finalize_store, &stack, &Identifier::from_str("echo")?, vec![
-                future_value,
-            ]);
+        let result = evaluate_query_at_height(
+            sample_finalize_state(0),
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("echo")?,
+            vec![future_value],
+            0,
+        );
 
         let err = match result {
             Ok(_) => panic!("expected error for non-plaintext input"),
@@ -542,47 +501,77 @@ query echo:
     }
 
     #[test]
-    fn test_evaluate_query_fails_when_atomic_batch_in_progress() -> Result<()> {
-        // If another atomic batch is in progress on the finalize store (e.g. block
-        // finalization), `evaluate_query`'s `atomic_finalize!(DryRun)` wrapper bails
-        // immediately rather than racing or seeing pending writes.
+    fn test_evaluate_query_ignores_pending_writes() -> Result<()> {
+        // The query path uses the `ConfirmedFinalizeStore` adapter, so reads bypass the
+        // atomic-batch pending state. This test simulates an in-flight finalize batch by
+        // staging a write inside an atomic batch (without committing) and then querying:
+        // the pending write must NOT be visible to the query.
         let program = Program::<CurrentNetwork>::from_str(
             r"
-program qy_atomic_guard.aleo;
+program qy_pending_isolate.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
 
 function noop:
     input r0 as u64.private;
     output r0 as u64.private;
 
-query fixed_value:
-    add 0u64 1u64 into r0;
-    output r0 as u64.public;",
+query lookup:
+    input r0 as address.public;
+    get.or_use balances[r0] 0u64 into r1;
+    output r1 as u64.public;",
         )?;
 
         let process = Process::<CurrentNetwork>::load()?;
         let stack = Stack::new(&process, &program)?;
         let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
 
-        // Simulate an in-flight atomic batch (the same condition produced by block finalization).
+        let program_id = *program.id();
+        let mapping_name = Identifier::from_str("balances")?;
+        finalize_store.initialize_mapping(program_id, mapping_name)?;
+
+        // Pick a deterministic address.
+        let mut rng = console::prelude::TestRng::default();
+        let private_key = PrivateKey::<CurrentNetwork>::new(&mut rng)?;
+        let address = console::account::Address::try_from(&private_key)?;
+        let address_key = Plaintext::from(Literal::Address(address));
+
+        // Stage a pending write inside an atomic batch — DO NOT commit it. Mirrors the
+        // mid-finalize-batch state a concurrent block-production thread would produce.
         finalize_store.start_atomic();
+        finalize_store.update_key_value(
+            program_id,
+            mapping_name,
+            address_key.clone(),
+            Value::Plaintext(Plaintext::from(Literal::U64(U64::new(99)))),
+        )?;
         assert!(finalize_store.is_atomic_in_progress());
 
-        let result = evaluate_query(
-            sample_finalize_state(1),
+        // Query with the batch still open: the historic adapter reads from the per-height
+        // update map via `get_confirmed`, which skips pending atomic-batch writes. So the
+        // query sees the mapping's default (0), not the pending 99.
+        let outputs = evaluate_query_at_height(
+            sample_finalize_state(0),
             &finalize_store,
             &stack,
-            &Identifier::from_str("fixed_value")?,
-            vec![],
-        );
+            &Identifier::from_str("lookup")?,
+            vec![Value::Plaintext(address_key)],
+            0,
+        )?;
 
-        // Cleanup before asserting so a panic doesn't leave the store in a bad state.
+        // Abort the batch (cleanup; the pending write was a fixture, not a real commit).
         finalize_store.abort_atomic();
 
-        let err = match result {
-            Ok(_) => panic!("expected evaluate_query to bail when an atomic batch is in progress"),
-            Err(err) => err.to_string(),
-        };
-        assert!(err.contains("atomic batch"), "unexpected error message: {err}");
+        assert_eq!(outputs.len(), 1);
+        match &outputs[0] {
+            Value::Plaintext(Plaintext::Literal(Literal::U64(v), _)) => assert_eq!(
+                **v, 0,
+                "query should observe confirmed state (default 0), not the pending in-batch write (99)"
+            ),
+            other => panic!("unexpected output: {other}"),
+        }
         Ok(())
     }
 
@@ -610,7 +599,8 @@ query reads_ts:
 
         // Build a state with a non-trivial timestamp, mimicking what a real VM would supply.
         let state = FinalizeGlobalState::from(1, 1, Some(1234567890), [0u8; 32]);
-        let outputs = evaluate_query(state, &finalize_store, &stack, &Identifier::from_str("reads_ts")?, vec![])?;
+        let outputs =
+            evaluate_query_at_height(state, &finalize_store, &stack, &Identifier::from_str("reads_ts")?, vec![], 1)?;
 
         assert_eq!(outputs.len(), 1);
         match &outputs[0] {
@@ -622,7 +612,6 @@ query reads_ts:
 
     /// Drives a value through two updates at different block heights and asserts that
     /// `evaluate_query_at_height` returns the value applicable at each height.
-    #[cfg(feature = "history")]
     #[test]
     fn test_evaluate_query_at_height_returns_historic_value() -> Result<()> {
         use std::sync::atomic::Ordering;
@@ -681,13 +670,17 @@ query lookup:
             other => panic!("expected u64, got: {other}"),
         };
 
-        // Sanity: confirmed/current state reflects the LAST write (V2 = 55). Historic queries
-        // below must therefore return 11 (not 55) at heights ≤ 4, distinguishing the historic
-        // path from any accidental fall-through to current speculative state.
-        let outputs =
-            evaluate_query(sample_finalize_state(5), &finalize_store, &stack, &Identifier::from_str("lookup")?, vec![
-                Value::Plaintext(address_key.clone()),
-            ])?;
+        // Sanity: querying at the latest height (5) reflects the LAST write (V2 = 55). Historic
+        // queries below must therefore return 11 (not 55) at heights ≤ 4, distinguishing the
+        // historic path from any accidental fall-through to current state.
+        let outputs = evaluate_query_at_height(
+            sample_finalize_state(5),
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("lookup")?,
+            vec![Value::Plaintext(address_key.clone())],
+            5,
+        )?;
         assert_eq!(extract(outputs), 55, "current state should reflect the most recent write");
 
         // Query at height 1 → V1.

--- a/synthesizer/process/src/query.rs
+++ b/synthesizer/process/src/query.rs
@@ -18,7 +18,7 @@ use console::{
     network::prelude::*,
     program::{Identifier, ProgramID, Value},
 };
-use snarkvm_ledger_store::{FinalizeStorage, FinalizeStore};
+use snarkvm_ledger_store::{FinalizeMode, FinalizeStorage, FinalizeStore, atomic_finalize};
 use snarkvm_synthesizer_program::{Command, FinalizeGlobalState, RegistersTrait, StackTrait};
 
 impl<N: Network> Process<N> {
@@ -49,7 +49,36 @@ impl<N: Network> Process<N> {
 ///
 /// This is the prototype query path. It is invoked by external callers only — query functions
 /// cannot be called from inside other program components in this prototype.
+///
+/// Isolation:
+/// The entire evaluation runs inside an `atomic_finalize!(DryRun)` batch over the finalize
+/// store. Two consequences:
+///   1. **Confirmed-state reads.** While the batch is open, the finalize store's
+///      `*_speculative` reads (used by `Get` / `Contains` / `GetOrUse`) only see this batch's
+///      state, which performs no writes — so each read transparently falls through to the
+///      confirmed map. A concurrent `finalize_atomic_batch` (block production / dry-run
+///      speculation) would otherwise expose pending writes via the same speculative path.
+///   2. **No store writes.** The DryRun batch is always aborted at the end, so even a future
+///      change that inadvertently introduces a write cannot reach the canonical store.
+///
+/// Cost: a query attempted while another atomic batch is in progress (block finalization, or
+/// another query) fails fast with the macro's standard error. snarkOS is expected to handle
+/// retry / rate-limiting at the RPC layer.
 pub fn evaluate_query<N: Network, P: FinalizeStorage<N>>(
+    state: FinalizeGlobalState,
+    store: &FinalizeStore<N, P>,
+    stack: &Stack<N>,
+    query_name: &Identifier<N>,
+    inputs: Vec<Value<N>>,
+) -> Result<Vec<Value<N>>> {
+    atomic_finalize!(store, FinalizeMode::DryRun, {
+        evaluate_query_inner(state, store, stack, query_name, inputs).map_err(|e| e.to_string())
+    })
+}
+
+/// Inner evaluation of a query. The outer wrapper enforces isolation via
+/// `atomic_finalize!(DryRun)` — see [`evaluate_query`] for the rationale.
+fn evaluate_query_inner<N: Network, P: FinalizeStorage<N>>(
     state: FinalizeGlobalState,
     store: &FinalizeStore<N, P>,
     stack: &Stack<N>,
@@ -366,6 +395,51 @@ query echo:
         };
         assert!(err.contains("future"), "unexpected error message: {err}");
         assert!(err.contains("plaintext"), "unexpected error message: {err}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_evaluate_query_fails_when_atomic_batch_in_progress() -> Result<()> {
+        // If another atomic batch is in progress on the finalize store (e.g. block
+        // finalization), `evaluate_query`'s `atomic_finalize!(DryRun)` wrapper bails
+        // immediately rather than racing or seeing pending writes.
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program qy_atomic_guard.aleo;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query fixed_value:
+    add 0u64 1u64 into r0;
+    output r0 as u64.public;",
+        )?;
+
+        let process = Process::<CurrentNetwork>::load()?;
+        let stack = Stack::new(&process, &program)?;
+        let finalize_store = FinalizeStore::<_, FinalizeMemory<_>>::open(aleo_std::StorageMode::new_test(None))?;
+
+        // Simulate an in-flight atomic batch (the same condition produced by block finalization).
+        finalize_store.start_atomic();
+        assert!(finalize_store.is_atomic_in_progress());
+
+        let result = evaluate_query(
+            sample_finalize_state(1),
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("fixed_value")?,
+            vec![],
+        );
+
+        // Cleanup before asserting so a panic doesn't leave the store in a bad state.
+        finalize_store.abort_atomic();
+
+        let err = match result {
+            Ok(_) => panic!("expected evaluate_query to bail when an atomic batch is in progress"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("atomic batch"), "unexpected error message: {err}");
         Ok(())
     }
 

--- a/synthesizer/process/src/stack/finalize_registers/mod.rs
+++ b/synthesizer/process/src/stack/finalize_registers/mod.rs
@@ -30,7 +30,9 @@ pub struct FinalizeRegisters<N: Network> {
     /// The global state for the finalize scope.
     state: FinalizeGlobalState,
     /// The transition ID for the finalize scope.
-    transition_id: N::TransitionID,
+    /// `None` on the query path (queries have no associated transition); always `Some(...)`
+    /// on the finalize / constructor paths.
+    transition_id: Option<N::TransitionID>,
     /// The function name for the finalize scope.
     /// This is set to the program ID for constructors.
     function_name: Identifier<N>,
@@ -39,20 +41,26 @@ pub struct FinalizeRegisters<N: Network> {
     /// The mapping of assigned registers to their values.
     registers: IndexMap<u64, Value<N>>,
     /// A nonce for finalize registers.
-    nonce: u64,
+    /// `None` on the query path; always `Some(...)` on the finalize / constructor paths.
+    nonce: Option<u64>,
     /// The tracker for the last register locator.
     last_register: Option<u64>,
 }
 
 impl<N: Network> FinalizeRegisters<N> {
     /// Initializes a new set of registers, given the finalize types.
+    ///
+    /// `transition_id` and `nonce` are `Option`s so that callers can express "no transition is
+    /// associated with this scope" (the query path) without needing a sentinel default value.
+    /// On the finalize / constructor paths, both are always `Some(...)` and the absence of a
+    /// transition ID at any read site (e.g. `rand.chacha`) is treated as a runtime error.
     #[inline]
     pub fn new(
         state: FinalizeGlobalState,
-        transition_id: N::TransitionID,
+        transition_id: Option<N::TransitionID>,
         function_name: Identifier<N>,
         finalize_types: FinalizeTypes<N>,
-        nonce: u64,
+        nonce: Option<u64>,
     ) -> Self {
         Self {
             state,
@@ -64,21 +72,6 @@ impl<N: Network> FinalizeRegisters<N> {
             last_register: None,
         }
     }
-
-    /// Initializes a set of registers for a query function evaluation.
-    ///
-    /// Queries are externally-callable and not associated with a transition, so the
-    /// `transition_id` and `nonce` slots have no meaningful value. They are filled with
-    /// defaults here; query commands cannot include `rand.chacha` (the only consumer of
-    /// those fields), so they are never read on a query path.
-    #[inline]
-    pub fn new_for_query(
-        state: FinalizeGlobalState,
-        function_name: Identifier<N>,
-        finalize_types: FinalizeTypes<N>,
-    ) -> Self {
-        Self::new(state, N::TransitionID::default(), function_name, finalize_types, 0)
-    }
 }
 
 impl<N: Network> FinalizeRegistersState<N> for FinalizeRegisters<N> {
@@ -88,10 +81,10 @@ impl<N: Network> FinalizeRegistersState<N> for FinalizeRegisters<N> {
         &self.state
     }
 
-    /// Returns the transition ID for the finalize scope.
+    /// Returns the transition ID for the finalize scope, if one is associated with this scope.
     #[inline]
-    fn transition_id(&self) -> &N::TransitionID {
-        &self.transition_id
+    fn transition_id(&self) -> Option<&N::TransitionID> {
+        self.transition_id.as_ref()
     }
 
     /// Returns the function name for the finalize scope.
@@ -100,9 +93,9 @@ impl<N: Network> FinalizeRegistersState<N> for FinalizeRegisters<N> {
         &self.function_name
     }
 
-    /// Returns the nonce for the finalize registers.
+    /// Returns the nonce for the finalize registers, if one is associated with this scope.
     #[inline]
-    fn nonce(&self) -> u64 {
+    fn nonce(&self) -> Option<u64> {
         self.nonce
     }
 }

--- a/synthesizer/process/src/stack/finalize_registers/mod.rs
+++ b/synthesizer/process/src/stack/finalize_registers/mod.rs
@@ -64,6 +64,21 @@ impl<N: Network> FinalizeRegisters<N> {
             last_register: None,
         }
     }
+
+    /// Initializes a set of registers for a query function evaluation.
+    ///
+    /// Queries are externally-callable and not associated with a transition, so the
+    /// `transition_id` and `nonce` slots have no meaningful value. They are filled with
+    /// defaults here; query commands cannot include `rand.chacha` (the only consumer of
+    /// those fields), so they are never read on a query path.
+    #[inline]
+    pub fn new_for_query(
+        state: FinalizeGlobalState,
+        function_name: Identifier<N>,
+        finalize_types: FinalizeTypes<N>,
+    ) -> Self {
+        Self::new(state, N::TransitionID::default(), function_name, finalize_types, 0)
+    }
 }
 
 impl<N: Network> FinalizeRegistersState<N> for FinalizeRegisters<N> {

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -56,25 +56,6 @@ impl<N: Network> FinalizeTypes<N> {
     ) -> Result<Self> {
         let mut finalize_types = Self { inputs: IndexMap::new(), destinations: IndexMap::new() };
 
-        // Reject `block.timestamp` reads at deploy time. Queries are not bound to a specific
-        // block timestamp (`FinalizeGlobalState::for_query` sets it to `None`), so the runtime
-        // path would otherwise bail with the misleading "not available until ConsensusVersion::V12"
-        // error on every call.
-        for command in query.commands() {
-            for operand in command.operands() {
-                ensure!(
-                    !matches!(operand, Operand::BlockTimestamp),
-                    "Forbidden operand: query functions cannot read 'block.timestamp'"
-                );
-            }
-        }
-        for output in query.outputs() {
-            ensure!(
-                !matches!(output.operand(), Operand::BlockTimestamp),
-                "Forbidden operand: query functions cannot output 'block.timestamp'"
-            );
-        }
-
         // Type-check the inputs. Query inputs are guaranteed to be plaintext at construction time.
         for input in query.inputs() {
             finalize_types.check_input(stack, input.register(), input.finalize_type())?;

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -43,6 +43,45 @@ impl<N: Network> FinalizeTypes<N> {
         Ok(finalize_types)
     }
 
+    /// Initializes a new instance of `FinalizeTypes` for the given query function.
+    /// Checks that the given query is well-formed for the given stack.
+    ///
+    /// Queries share the finalize register/command shape, but cannot await futures and cannot
+    /// produce side effects. The forbidden-command list (writes, async, await, call, rand.chacha)
+    /// is enforced at `QueryCore` construction; this function only needs to type-check the body.
+    #[inline]
+    pub(super) fn initialize_finalize_types_from_query(
+        stack: &Stack<N>,
+        query: &snarkvm_synthesizer_program::QueryCore<N>,
+    ) -> Result<Self> {
+        let mut finalize_types = Self { inputs: IndexMap::new(), destinations: IndexMap::new() };
+
+        // Type-check the inputs. Query inputs are guaranteed to be plaintext at construction time.
+        for input in query.inputs() {
+            finalize_types.check_input(stack, input.register(), input.finalize_type())?;
+        }
+
+        // Type-check the commands.
+        for command in query.commands() {
+            finalize_types.check_command(stack, query.positions(), command)?;
+        }
+
+        // Type-check the outputs: each output operand must resolve and match the declared type.
+        for output in query.outputs() {
+            let actual = finalize_types.get_type_from_operand(stack, output.operand())?;
+            if &actual != output.finalize_type() {
+                bail!(
+                    "Query output type mismatch: declared '{}' but operand '{}' has type '{}'",
+                    output.finalize_type(),
+                    output.operand(),
+                    actual,
+                );
+            }
+        }
+
+        Ok(finalize_types)
+    }
+
     /// Initializes a new instance of `FinalizeTypes` for the given finalize.
     /// Checks that the given finalize is well-formed for the given stack.
     ///

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -56,6 +56,25 @@ impl<N: Network> FinalizeTypes<N> {
     ) -> Result<Self> {
         let mut finalize_types = Self { inputs: IndexMap::new(), destinations: IndexMap::new() };
 
+        // Reject `block.timestamp` reads at deploy time. Queries are not bound to a specific
+        // block timestamp (`FinalizeGlobalState::for_query` sets it to `None`), so the runtime
+        // path would otherwise bail with the misleading "not available until ConsensusVersion::V12"
+        // error on every call.
+        for command in query.commands() {
+            for operand in command.operands() {
+                ensure!(
+                    !matches!(operand, Operand::BlockTimestamp),
+                    "Forbidden operand: query functions cannot read 'block.timestamp'"
+                );
+            }
+        }
+        for output in query.outputs() {
+            ensure!(
+                !matches!(output.operand(), Operand::BlockTimestamp),
+                "Forbidden operand: query functions cannot output 'block.timestamp'"
+            );
+        }
+
         // Type-check the inputs. Query inputs are guaranteed to be plaintext at construction time.
         for input in query.inputs() {
             finalize_types.check_input(stack, input.register(), input.finalize_type())?;

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -32,8 +32,8 @@ impl<N: Network> FinalizeTypes<N> {
         for command in constructor.commands() {
             // Ensure the command is not a call instruction.
             ensure!(!command.is_call(), "`call` commands are not allowed in constructors.");
-            // Ensure the command is not a cast to record instruction.
-            ensure!(!command.is_cast_to_record(), "`cast` (to record) commands are not allowed in constructors.");
+            // Ensure the command does not operate on a record (cast-to-record or `get.record.dynamic`).
+            ensure!(!command.is_instruction_for_record(), "Record operations are not allowed in constructors.");
             // Ensure the command is not an await command.
             ensure!(!command.is_await(), "`await` commands are not allowed in constructors.");
             // Check the command opcode, operands, and destinations.

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -87,6 +87,13 @@ impl<N: Network> FinalizeTypes<N> {
         Self::initialize_finalize_types_from_finalize(stack, finalize)
     }
 
+    /// Initializes a new instance of `FinalizeTypes` for the given query function.
+    /// Checks that the given query is well-formed for the given stack.
+    #[inline]
+    pub fn from_query(stack: &Stack<N>, query: &snarkvm_synthesizer_program::QueryCore<N>) -> Result<Self> {
+        Self::initialize_finalize_types_from_query(stack, query)
+    }
+
     /// Returns `true` if the given register exists.
     pub fn contains(&self, register: &Register<N>) -> bool {
         // Retrieve the register locator.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -377,6 +377,13 @@ impl<N: Network> Stack<N> {
             }
         }
 
+        // Type-check every query function. The result is not cached on the stack here;
+        // it is recomputed by the query evaluator. This is acceptable for the prototype
+        // and ensures that ill-typed queries are rejected at deploy time.
+        for query in self.program.queries().values() {
+            let _ = FinalizeTypes::from_query(self, query)?;
+        }
+
         // Drop the locks since the types have been initialized.
         drop(constructor_types);
         drop(register_types);

--- a/synthesizer/program/src/bytes.rs
+++ b/synthesizer/program/src/bytes.rs
@@ -56,6 +56,8 @@ impl<N: Network> FromBytes for ProgramCore<N> {
                 4 => program.add_function(FunctionCore::read_le(&mut reader)?).map_err(error)?,
                 // Read the constructor.
                 5 => program.add_constructor(ConstructorCore::read_le(&mut reader)?).map_err(error)?,
+                // Read the query function.
+                6 => program.add_query(QueryCore::read_le(&mut reader)?).map_err(error)?,
                 // Invalid variant.
                 _ => return Err(error(format!("Failed to parse program. Invalid component variant '{variant}'"))),
             }
@@ -145,6 +147,15 @@ impl<N: Network> ToBytes for ProgramCore<N> {
                             }
                             None => return Err(error(format!("Function '{identifier}' is not defined."))),
                         },
+                        ProgramDefinition::Query => match self.queries.get(identifier) {
+                            Some(query) => {
+                                // Write the variant.
+                                6u8.write_le(&mut writer)?;
+                                // Write the query function.
+                                query.write_le(&mut writer)?;
+                            }
+                            None => return Err(error(format!("Query '{identifier}' is not defined."))),
+                        },
                     }
                 }
             }
@@ -160,6 +171,35 @@ mod tests {
     use console::network::MainnetV0;
 
     type CurrentNetwork = MainnetV0;
+
+    #[test]
+    fn test_bytes_with_query() -> Result<()> {
+        let program = r"
+program token_with_query.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query total_balance:
+    input r0 as address.public;
+    get.or_use balances[r0] 0u64 into r1;
+    output r1 as u64.public;";
+
+        let (string, expected) = Program::<CurrentNetwork>::parse(program).unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+        let expected_bytes = expected.to_bytes_le()?;
+        let candidate = Program::<CurrentNetwork>::from_bytes_le(&expected_bytes)?;
+        assert_eq!(expected, candidate);
+        assert_eq!(expected_bytes, candidate.to_bytes_le()?);
+
+        Ok(())
+    }
 
     #[test]
     fn test_bytes() -> Result<()> {

--- a/synthesizer/program/src/constructor/mod.rs
+++ b/synthesizer/program/src/constructor/mod.rs
@@ -99,8 +99,8 @@ impl<N: Network> ConstructorCore<N> {
         ensure!(!command.is_async(), "Forbidden operation: Constructor cannot invoke an 'async' instruction");
         // Ensure the command is not a call instruction.
         ensure!(!command.is_call(), "Forbidden operation: Constructor cannot invoke a 'call'");
-        // Ensure the command is not a cast to record instruction.
-        ensure!(!command.is_cast_to_record(), "Forbidden operation: Constructor cannot cast to a record");
+        // Ensure the command does not operate on a record (cast-to-record or `get.record.dynamic`).
+        ensure!(!command.is_instruction_for_record(), "Forbidden operation: Constructor cannot operate on records");
         // Ensure the command is not an await command.
         ensure!(!command.is_await(), "Forbidden operation: Constructor cannot 'await'");
 

--- a/synthesizer/program/src/finalize/mod.rs
+++ b/synthesizer/program/src/finalize/mod.rs
@@ -169,8 +169,8 @@ impl<N: Network> FinalizeCore<N> {
         ensure!(!command.is_async(), "Forbidden operation: Finalize cannot invoke an 'async' instruction");
         // Ensure the command is not a call instruction.
         ensure!(!command.is_call(), "Forbidden operation: Finalize cannot invoke a 'call'");
-        // Ensure the command is not a cast to record instruction.
-        ensure!(!command.is_cast_to_record(), "Forbidden operation: Finalize cannot cast to a record");
+        // Ensure the command does not operate on a record (cast-to-record or `get.record.dynamic`).
+        ensure!(!command.is_instruction_for_record(), "Forbidden operation: Finalize cannot operate on records");
 
         // Check the destination registers.
         for register in command.destinations() {
@@ -317,5 +317,25 @@ mod tests {
                 false => assert!(finalize.add_command(command).is_err()),
             }
         }
+    }
+
+    #[test]
+    fn test_reject_cast_to_dynamic_record_in_finalize() {
+        let name = Identifier::from_str("finalize_core_test").unwrap();
+        let mut finalize = Finalize::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("cast r0 into r1 as dynamic.record;").unwrap();
+        let err = finalize.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("operate on records"));
+    }
+
+    #[test]
+    fn test_reject_get_record_dynamic_in_finalize() {
+        let name = Identifier::from_str("finalize_core_test").unwrap();
+        let mut finalize = Finalize::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("get.record.dynamic r0.x into r1 as bool;").unwrap();
+        let err = finalize.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("operate on records"));
     }
 }

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -261,7 +261,6 @@ impl<N: Network> ProgramCore<N> {
         "value",
         "async",
         "finalize",
-        "query",
         // Reserved (catch all)
         "global",
         "block",
@@ -294,6 +293,7 @@ impl<N: Network> ProgramCore<N> {
     pub const RESTRICTED_KEYWORDS: &'static [(ConsensusVersion, &'static [&'static str])] = &[
         (ConsensusVersion::V6, &["constructor"]),
         (ConsensusVersion::V14, &["dynamic", "identifier"]),
+        (ConsensusVersion::V15, &["query"]),
     ];
 
     /// Initializes an empty program.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -41,6 +41,11 @@ pub use function::*;
 mod import;
 pub use import::*;
 
+pub mod query;
+pub use query::QueryCore;
+
+pub type Query<N> = crate::QueryCore<N>;
+
 pub mod logic;
 pub use logic::*;
 
@@ -145,6 +150,8 @@ enum ProgramDefinition {
     Closure,
     /// A program function.
     Function,
+    /// A program query function.
+    Query,
 }
 
 #[derive(Clone)]
@@ -167,6 +174,8 @@ pub struct ProgramCore<N: Network> {
     closures: IndexMap<Identifier<N>, ClosureCore<N>>,
     /// A map of the declared functions for the program.
     functions: IndexMap<Identifier<N>, FunctionCore<N>>,
+    /// A map of the declared query functions for the program.
+    queries: IndexMap<Identifier<N>, QueryCore<N>>,
 }
 
 impl<N: Network> PartialEq for ProgramCore<N> {
@@ -191,6 +200,7 @@ impl<N: Network> PartialEq for ProgramCore<N> {
             && self.records == other.records
             && self.closures == other.closures
             && self.functions == other.functions
+            && self.queries == other.queries
     }
 }
 
@@ -251,6 +261,7 @@ impl<N: Network> ProgramCore<N> {
         "value",
         "async",
         "finalize",
+        "query",
         // Reserved (catch all)
         "global",
         "block",
@@ -301,6 +312,7 @@ impl<N: Network> ProgramCore<N> {
             records: IndexMap::new(),
             closures: IndexMap::new(),
             functions: IndexMap::new(),
+            queries: IndexMap::new(),
         })
     }
 
@@ -350,6 +362,11 @@ impl<N: Network> ProgramCore<N> {
         &self.functions
     }
 
+    /// Returns the query functions in the program.
+    pub const fn queries(&self) -> &IndexMap<Identifier<N>, QueryCore<N>> {
+        &self.queries
+    }
+
     /// Returns `true` if the program contains an import with the given program ID.
     pub fn contains_import(&self, id: &ProgramID<N>) -> bool {
         self.imports.contains_key(id)
@@ -383,6 +400,11 @@ impl<N: Network> ProgramCore<N> {
     /// Returns `true` if the program contains a function with the given name.
     pub fn contains_function(&self, name: &Identifier<N>) -> bool {
         self.functions.contains_key(name)
+    }
+
+    /// Returns `true` if the program contains a query function with the given name.
+    pub fn contains_query(&self, name: &Identifier<N>) -> bool {
+        self.queries.contains_key(name)
     }
 
     /// Returns the mapping with the given name.
@@ -459,6 +481,21 @@ impl<N: Network> ProgramCore<N> {
         ensure!(function.outputs().len() <= N::MAX_OUTPUTS, "Function exceeds maximum number of outputs");
         // Return the function.
         Ok(function)
+    }
+
+    /// Returns the query function with the given name.
+    pub fn get_query(&self, name: &Identifier<N>) -> Result<QueryCore<N>> {
+        self.get_query_ref(name).cloned()
+    }
+
+    /// Returns a reference to the query function with the given name.
+    pub fn get_query_ref(&self, name: &Identifier<N>) -> Result<&QueryCore<N>> {
+        let query = self.queries.get(name).ok_or(anyhow!("Query '{}/{name}' is not defined.", self.id))?;
+        ensure!(query.name() == name, "Expected query '{name}', but found query '{}'", query.name());
+        ensure!(query.inputs().len() <= N::MAX_INPUTS, "Query exceeds maximum number of inputs");
+        ensure!(query.commands().len() <= N::MAX_COMMANDS, "Query exceeds maximum number of commands");
+        ensure!(query.outputs().len() <= N::MAX_OUTPUTS, "Query exceeds maximum number of outputs");
+        Ok(query)
     }
 
     /// Adds a new import statement to the program.
@@ -793,6 +830,37 @@ impl<N: Network> ProgramCore<N> {
         // Add the function to the program.
         if self.functions.insert(function_name, function).is_some() {
             bail!("'{function_name}' already exists in the program.")
+        }
+        Ok(())
+    }
+
+    /// Adds a new query function to the program.
+    ///
+    /// # Errors
+    /// This method will halt if the query function name is already in use in the program.
+    /// This method will halt if the query function name is a reserved opcode or keyword.
+    #[inline]
+    fn add_query(&mut self, query: QueryCore<N>) -> Result<()> {
+        let query_name = *query.name();
+
+        // Reuse the closure cap as the prototype budget for query functions.
+        ensure!(self.queries.len() < N::MAX_CLOSURES, "Program exceeds the maximum number of query functions.");
+
+        ensure!(self.is_unique_name(&query_name), "'{query_name}' is already in use.");
+        ensure!(!Self::is_reserved_opcode(&query_name.to_string()), "'{query_name}' is a reserved opcode.");
+        ensure!(!Self::is_reserved_keyword(&query_name), "'{query_name}' is a reserved keyword.");
+
+        // Queries must have at least one command and at least one output.
+        ensure!(!query.commands().is_empty(), "Cannot evaluate a query function without commands");
+        ensure!(!query.outputs().is_empty(), "A query function must declare at least one output");
+        ensure!(query.inputs().len() <= N::MAX_INPUTS, "Query exceeds maximum number of inputs");
+        ensure!(query.outputs().len() <= N::MAX_OUTPUTS, "Query exceeds maximum number of outputs");
+
+        if self.components.insert(ProgramLabel::Identifier(query_name), ProgramDefinition::Query).is_some() {
+            bail!("'{query_name}' already exists in the program.")
+        }
+        if self.queries.insert(query_name, query).is_some() {
+            bail!("'{query_name}' already exists in the program.")
         }
         Ok(())
     }

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -843,8 +843,7 @@ impl<N: Network> ProgramCore<N> {
     fn add_query(&mut self, query: QueryCore<N>) -> Result<()> {
         let query_name = *query.name();
 
-        // Reuse the closure cap as the prototype budget for query functions.
-        ensure!(self.queries.len() < N::MAX_CLOSURES, "Program exceeds the maximum number of query functions.");
+        ensure!(self.queries.len() < N::MAX_QUERIES, "Program exceeds the maximum number of query functions.");
 
         ensure!(self.is_unique_name(&query_name), "'{query_name}' is already in use.");
         ensure!(!Self::is_reserved_opcode(&query_name.to_string()), "'{query_name}' is a reserved opcode.");

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -1057,6 +1057,7 @@ impl<N: Network> ProgramCore<N> {
             || self.closures.values().any(|closure| closure.contains_external_struct())
             || self.functions.values().any(|function| function.contains_external_struct())
             || self.constructor.iter().any(|constructor| constructor.contains_external_struct())
+            || self.queries.values().any(|query| query.contains_external_struct())
     }
 
     /// Returns `true` if this program violates pre-V13 rules for external records
@@ -1179,6 +1180,7 @@ impl<N: Network> ProgramCore<N> {
             || self.closures.values().any(|closure| closure.exceeds_max_array_size(max_array_size))
             || self.functions.values().any(|function| function.exceeds_max_array_size(max_array_size))
             || self.constructor.iter().any(|constructor| constructor.exceeds_max_array_size(max_array_size))
+            || self.queries.values().any(|query| query.exceeds_max_array_size(max_array_size))
     }
 
     /// Returns `true` if a program contains any V11 syntax.
@@ -1393,6 +1395,7 @@ impl<N: Network> ProgramCore<N> {
     /// Returns `true` if a program contains any V15 syntax.
     /// This includes:
     /// 1. `commit.*.raw` opcodes (raw commit variants).
+    /// 2. `query` blocks (new on-disk component variant 6).
     ///
     /// This is enforced to be `false` for programs before `ConsensusVersion::V15`.
     #[inline]
@@ -1417,7 +1420,7 @@ impl<N: Network> ProgramCore<N> {
             .chain(cfg_iter!(self.constructor).flat_map(|constructor| constructor.commands()))
             .any(|command| matches!(command, Command::Instruction(instruction) if has_op(*instruction.opcode())));
 
-        function_contains || closure_contains || command_contains
+        function_contains || closure_contains || command_contains || !self.queries.is_empty()
     }
 
     /// Returns `true` if a program contains any string type.
@@ -1431,6 +1434,7 @@ impl<N: Network> ProgramCore<N> {
             || self.closures.values().any(|closure| closure.contains_string_type())
             || self.functions.values().any(|function| function.contains_string_type())
             || self.constructor.iter().any(|constructor| constructor.contains_string_type())
+            || self.queries.values().any(|query| query.contains_string_type())
     }
 }
 

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -105,9 +105,28 @@ impl<N: Network> Command<N> {
         matches!(self, Command::Instruction(Instruction::Call(_) | Instruction::CallDynamic(_)))
     }
 
-    /// Returns `true` if the command is a cast to record instruction.
+    /// Returns `true` if the command is a cast-to-record instruction. Covers all three
+    /// record cast variants: static `record`, `external_record`, and `dynamic.record`.
     pub fn is_cast_to_record(&self) -> bool {
-        matches!(self, Command::Instruction(Instruction::Cast(cast)) if matches!(cast.cast_type(), CastType::Record(_) | CastType::ExternalRecord(_)))
+        matches!(
+            self,
+            Command::Instruction(Instruction::Cast(cast))
+                if matches!(
+                    cast.cast_type(),
+                    CastType::Record(_) | CastType::ExternalRecord(_) | CastType::DynamicRecord
+                )
+        )
+    }
+
+    /// Returns `true` if the command is a `get.record.dynamic` instruction.
+    pub fn is_get_record_dynamic(&self) -> bool {
+        matches!(self, Command::Instruction(Instruction::GetRecordDynamic(_)))
+    }
+
+    /// Returns `true` if the command operates on a record value, either by creating one via
+    /// `cast` (static, external, or dynamic) or by reading one via `get.record.dynamic`.
+    pub fn is_instruction_for_record(&self) -> bool {
+        self.is_cast_to_record() || self.is_get_record_dynamic()
     }
 
     /// Returns `true` if the command is a `rand.chacha` command.

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -110,6 +110,11 @@ impl<N: Network> Command<N> {
         matches!(self, Command::Instruction(Instruction::Cast(cast)) if matches!(cast.cast_type(), CastType::Record(_) | CastType::ExternalRecord(_)))
     }
 
+    /// Returns `true` if the command is a `rand.chacha` command.
+    pub fn is_rand_chacha(&self) -> bool {
+        matches!(self, Command::RandChaCha(_))
+    }
+
     /// Returns `true` if the command is a write operation.
     pub fn is_write(&self) -> bool {
         matches!(self, Command::Set(_) | Command::Remove(_))

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -88,11 +88,18 @@ impl<N: Network> RandChaCha<N> {
         // Construct the random seed.
         // If the height is greater than or equal to consensus V3, then use the new preimage definition.
         // The difference is that a nonce is also included in the new definition.
+        //
+        // `transition_id` and `nonce` are `Option`s on the trait — the query path leaves both as
+        // `None`. Queries already reject `rand.chacha` at construction, so reaching this code on
+        // a query is unreachable, but we surface a clear runtime error here as a defense in depth.
         let consensus_version = N::CONSENSUS_VERSION(registers.state().block_height())?;
+        let transition_id = registers
+            .transition_id()
+            .ok_or_else(|| anyhow!("'rand.chacha' requires a transition ID, which is not available in this scope"))?;
         let preimage = if (ConsensusVersion::V1..=ConsensusVersion::V2).contains(&consensus_version) {
             to_bits_le![
                 registers.state().random_seed(),
-                **registers.transition_id(),
+                **transition_id,
                 stack.program_id(),
                 registers.function_name(),
                 self.destination.locator(),
@@ -100,12 +107,15 @@ impl<N: Network> RandChaCha<N> {
                 seeds
             ]
         } else {
+            let nonce = registers
+                .nonce()
+                .ok_or_else(|| anyhow!("'rand.chacha' requires a nonce, which is not available in this scope"))?;
             to_bits_le![
                 registers.state().random_seed(),
-                **registers.transition_id(),
+                **transition_id,
                 stack.program_id(),
                 registers.function_name(),
-                registers.nonce(),
+                nonce,
                 self.destination.locator(),
                 self.destination_type.type_id(),
                 seeds

--- a/synthesizer/program/src/logic/finalize_global_state/mod.rs
+++ b/synthesizer/program/src/logic/finalize_global_state/mod.rs
@@ -93,21 +93,6 @@ impl FinalizeGlobalState {
         Self { block_round, block_height, block_timestamp, random_seed }
     }
 
-    /// Initializes a global state for a query function evaluation.
-    ///
-    /// Queries are not associated with consensus state beyond the block height. The
-    /// other fields are filled with safe defaults:
-    ///   - `block_round`: `0`. Queries are not produced by a consensus round, so no real
-    ///     value is meaningful. We pick `0` rather than the block height so that any
-    ///     future opcode reading `block_round` from inside a query gets an unambiguous
-    ///     "no round" sentinel instead of a misleading height-as-round value.
-    ///   - `block_timestamp`: `None`. Same reasoning — queries are off-consensus.
-    ///   - `random_seed`: `[0u8; 32]`. Only read by `rand.chacha`, which queries forbid.
-    #[inline]
-    pub const fn for_query(block_height: u32) -> Self {
-        Self { block_round: 0, block_height, block_timestamp: None, random_seed: [0u8; 32] }
-    }
-
     /// Returns the block round.
     #[inline]
     pub const fn block_round(&self) -> u64 {

--- a/synthesizer/program/src/logic/finalize_global_state/mod.rs
+++ b/synthesizer/program/src/logic/finalize_global_state/mod.rs
@@ -96,12 +96,16 @@ impl FinalizeGlobalState {
     /// Initializes a global state for a query function evaluation.
     ///
     /// Queries are not associated with consensus state beyond the block height. The
-    /// other fields (`block_round`, `block_timestamp`, `random_seed`) are filled with
-    /// safe defaults: queries forbid `rand.chacha` (the only reader of `random_seed`),
-    /// and no query path reads `block_round` or `block_timestamp`.
+    /// other fields are filled with safe defaults:
+    ///   - `block_round`: `0`. Queries are not produced by a consensus round, so no real
+    ///     value is meaningful. We pick `0` rather than the block height so that any
+    ///     future opcode reading `block_round` from inside a query gets an unambiguous
+    ///     "no round" sentinel instead of a misleading height-as-round value.
+    ///   - `block_timestamp`: `None`. Same reasoning — queries are off-consensus.
+    ///   - `random_seed`: `[0u8; 32]`. Only read by `rand.chacha`, which queries forbid.
     #[inline]
     pub const fn for_query(block_height: u32) -> Self {
-        Self { block_round: block_height as u64, block_height, block_timestamp: None, random_seed: [0u8; 32] }
+        Self { block_round: 0, block_height, block_timestamp: None, random_seed: [0u8; 32] }
     }
 
     /// Returns the block round.

--- a/synthesizer/program/src/logic/finalize_global_state/mod.rs
+++ b/synthesizer/program/src/logic/finalize_global_state/mod.rs
@@ -93,6 +93,17 @@ impl FinalizeGlobalState {
         Self { block_round, block_height, block_timestamp, random_seed }
     }
 
+    /// Initializes a global state for a query function evaluation.
+    ///
+    /// Queries are not associated with consensus state beyond the block height. The
+    /// other fields (`block_round`, `block_timestamp`, `random_seed`) are filled with
+    /// safe defaults: queries forbid `rand.chacha` (the only reader of `random_seed`),
+    /// and no query path reads `block_round` or `block_timestamp`.
+    #[inline]
+    pub const fn for_query(block_height: u32) -> Self {
+        Self { block_round: block_height as u64, block_height, block_timestamp: None, random_seed: [0u8; 32] }
+    }
+
     /// Returns the block round.
     #[inline]
     pub const fn block_round(&self) -> u64 {

--- a/synthesizer/program/src/parse.rs
+++ b/synthesizer/program/src/parse.rs
@@ -27,6 +27,7 @@ impl<N: Network> Parser for ProgramCore<N> {
             R(RecordType<N>),
             C(ClosureCore<N>),
             F(FunctionCore<N>),
+            Q(QueryCore<N>),
         }
 
         // Parse the imports from the string.
@@ -60,6 +61,8 @@ impl<N: Network> Parser for ProgramCore<N> {
                 map(ClosureCore::parse, |closure| P::<N>::C(closure))(string)
             } else if string.starts_with(FunctionCore::<N>::type_name()) {
                 map(FunctionCore::parse, |function| P::<N>::F(function))(string)
+            } else if string.starts_with(QueryCore::<N>::type_name()) {
+                map(QueryCore::parse, |query| P::<N>::Q(query))(string)
             } else {
                 Err(Err::Error(make_error(string, ErrorKind::Alt)))
             }
@@ -99,6 +102,7 @@ impl<N: Network> Parser for ProgramCore<N> {
                 P::R(record) => program.add_record(record),
                 P::C(closure) => program.add_closure(closure),
                 P::F(function) => program.add_function(function),
+                P::Q(query) => program.add_query(query),
             };
 
             match result {
@@ -189,6 +193,10 @@ impl<N: Network> Display for ProgramCore<N> {
                         Some(function) => writeln!(f, "{function}")?,
                         None => return Err(fmt::Error),
                     },
+                    ProgramDefinition::Query => match self.queries.get(identifier) {
+                        Some(query) => writeln!(f, "{query}")?,
+                        None => return Err(fmt::Error),
+                    },
                 },
             }
 
@@ -235,6 +243,94 @@ function compute:
         assert!(program.contains_function(&Identifier::from_str("compute")?));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_program_parse_with_query_zero_inputs() -> Result<()> {
+        let program = Program::<CurrentNetwork>::from_str(
+            r"
+program qy_zeroin.aleo;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query fixed_value:
+    add 0u64 1234u64 into r0;
+    output r0 as u64.public;",
+        )?;
+        assert_eq!(program.queries().len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_program_parse_with_query() -> Result<()> {
+        let (string, program) = Program::<CurrentNetwork>::parse(
+            r"
+program token_with_query.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+query total_balance:
+    input r0 as address.public;
+    get.or_use balances[r0] 0u64 into r1;
+    output r1 as u64.public;",
+        )
+        .unwrap();
+        assert!(string.is_empty(), "Parser did not consume all of the string: '{string}'");
+
+        // The program should expose the query by name.
+        let query_name = Identifier::from_str("total_balance")?;
+        assert!(program.contains_query(&query_name));
+        assert_eq!(1, program.queries().len());
+        let query = program.get_query_ref(&query_name)?;
+        assert_eq!(1, query.inputs().len());
+        assert_eq!(1, query.commands().len());
+        assert_eq!(1, query.outputs().len());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_program_query_rejects_writes() {
+        let result = Program::<CurrentNetwork>::from_str(
+            r"
+program bad_query.aleo;
+
+mapping balances:
+    key as address.public;
+    value as u64.public;
+
+query mutate:
+    input r0 as address.public;
+    set 1u64 into balances[r0];
+    output r0 as address.public;",
+        );
+        assert!(result.is_err(), "expected program parse to fail when query contains 'set'");
+    }
+
+    #[test]
+    fn test_program_query_rejects_call() {
+        let result = Program::<CurrentNetwork>::from_str(
+            r"
+program bad_query.aleo;
+
+closure helper:
+    input r0 as field;
+    output r0 as field;
+
+query uses_call:
+    input r0 as field.public;
+    call helper r0 into r1;
+    output r1 as field.public;",
+        );
+        assert!(result.is_err(), "expected program parse to fail when query contains 'call'");
     }
 
     #[test]

--- a/synthesizer/program/src/query/bytes.rs
+++ b/synthesizer/program/src/query/bytes.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for QueryCore<N> {
+    /// Reads the query function from a buffer.
+    #[inline]
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the query function name.
+        let name = Identifier::<N>::read_le(&mut reader)?;
+
+        // Read the inputs.
+        let num_inputs = u16::read_le(&mut reader)?;
+        if num_inputs > u16::try_from(N::MAX_INPUTS).map_err(error)? {
+            return Err(error(format!("Failed to deserialize query: too many inputs ({num_inputs})")));
+        }
+        let mut inputs = Vec::with_capacity(num_inputs as usize);
+        for _ in 0..num_inputs {
+            inputs.push(Input::read_le(&mut reader)?);
+        }
+
+        // Read the commands.
+        let num_commands = u16::read_le(&mut reader)?;
+        if num_commands.is_zero() {
+            return Err(error("Failed to deserialize query: needs at least one command".to_string()));
+        }
+        if num_commands > u16::try_from(N::MAX_COMMANDS).map_err(error)? {
+            return Err(error(format!("Failed to deserialize query: too many commands ({num_commands})")));
+        }
+        let mut commands = Vec::with_capacity(num_commands as usize);
+        for _ in 0..num_commands {
+            commands.push(Command::read_le(&mut reader)?);
+        }
+
+        // Read the outputs.
+        let num_outputs = u16::read_le(&mut reader)?;
+        if num_outputs.is_zero() {
+            return Err(error("Failed to deserialize query: needs at least one output".to_string()));
+        }
+        if num_outputs > u16::try_from(N::MAX_OUTPUTS).map_err(error)? {
+            return Err(error(format!("Failed to deserialize query: too many outputs ({num_outputs})")));
+        }
+        let mut outputs = Vec::with_capacity(num_outputs as usize);
+        for _ in 0..num_outputs {
+            outputs.push(Output::read_le(&mut reader)?);
+        }
+
+        // Initialize a new query.
+        let mut query = Self::new(name);
+        inputs.into_iter().try_for_each(|input| query.add_input(input)).map_err(error)?;
+        commands.into_iter().try_for_each(|command| query.add_command(command)).map_err(error)?;
+        outputs.into_iter().try_for_each(|output| query.add_output(output)).map_err(error)?;
+
+        Ok(query)
+    }
+}
+
+impl<N: Network> ToBytes for QueryCore<N> {
+    /// Writes the query function to a buffer.
+    #[inline]
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the query function name.
+        self.name.write_le(&mut writer)?;
+
+        // Write the number of inputs.
+        let num_inputs = self.inputs.len();
+        match num_inputs <= N::MAX_INPUTS {
+            true => u16::try_from(num_inputs).map_err(error)?.write_le(&mut writer)?,
+            false => return Err(error(format!("Failed to write {num_inputs} inputs as bytes"))),
+        }
+        for input in self.inputs.iter() {
+            input.write_le(&mut writer)?;
+        }
+
+        // Write the number of commands.
+        let num_commands = self.commands.len();
+        match 0 < num_commands && num_commands <= N::MAX_COMMANDS {
+            true => u16::try_from(num_commands).map_err(error)?.write_le(&mut writer)?,
+            false => return Err(error(format!("Failed to write {num_commands} commands as bytes"))),
+        }
+        for command in self.commands.iter() {
+            command.write_le(&mut writer)?;
+        }
+
+        // Write the number of outputs.
+        let num_outputs = self.outputs.len();
+        match 0 < num_outputs && num_outputs <= N::MAX_OUTPUTS {
+            true => u16::try_from(num_outputs).map_err(error)?.write_le(&mut writer)?,
+            false => return Err(error(format!("Failed to write {num_outputs} outputs as bytes"))),
+        }
+        for output in self.outputs.iter() {
+            output.write_le(&mut writer)?;
+        }
+
+        Ok(())
+    }
+}

--- a/synthesizer/program/src/query/input/bytes.rs
+++ b/synthesizer/program/src/query/input/bytes.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for Input<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let register = FromBytes::read_le(&mut reader)?;
+        let finalize_type = FromBytes::read_le(&mut reader)?;
+
+        match matches!(register, Register::Locator(..)) {
+            true => Ok(Self { register, finalize_type }),
+            false => Err(error(format!("Input '{register}' cannot be a register member"))),
+        }
+    }
+}
+
+impl<N: Network> ToBytes for Input<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        if !matches!(self.register, Register::Locator(..)) {
+            return Err(error(format!("Input '{}' cannot be a register member", self.register)));
+        }
+        self.register.write_le(&mut writer)?;
+        self.finalize_type.write_le(&mut writer)
+    }
+}

--- a/synthesizer/program/src/query/input/mod.rs
+++ b/synthesizer/program/src/query/input/mod.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod parse;
+
+use console::{
+    network::prelude::*,
+    program::{FinalizeType, Register},
+};
+
+/// An input statement defines an input argument to a query function, of the form
+/// `input {register} as {finalize_type};`.
+///
+/// Query inputs reuse the finalize input shape because query bodies share the finalize
+/// command set and therefore the same plaintext-only register model.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Input<N: Network> {
+    /// The input register.
+    register: Register<N>,
+    /// The input finalize type.
+    finalize_type: FinalizeType<N>,
+}
+
+impl<N: Network> Input<N> {
+    /// Returns the input register.
+    #[inline]
+    pub const fn register(&self) -> &Register<N> {
+        &self.register
+    }
+
+    /// Returns the input finalize type.
+    #[inline]
+    pub const fn finalize_type(&self) -> &FinalizeType<N> {
+        &self.finalize_type
+    }
+}
+
+impl<N: Network> TypeName for Input<N> {
+    /// Returns the type name as a string.
+    #[inline]
+    fn type_name() -> &'static str {
+        "input"
+    }
+}
+
+impl<N: Network> Ord for Input<N> {
+    /// Ordering is determined by the register (the finalize type is ignored).
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.register().cmp(other.register())
+    }
+}
+
+impl<N: Network> PartialOrd for Input<N> {
+    /// Ordering is determined by the register (the finalize type is ignored).
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/synthesizer/program/src/query/input/parse.rs
+++ b/synthesizer/program/src/query/input/parse.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Parser for Input<N> {
+    /// Parses a string into an input statement.
+    /// The input statement is of the form `input {register} as {plaintext_type}.public;`.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the input keyword from the string.
+        let (string, _) = tag(Self::type_name())(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the register from the string.
+        let (string, register) = map_res(Register::parse, |register| match &register {
+            Register::Locator(..) => Ok(register),
+            Register::Access(..) => Err(error(format!("Input register {register} cannot be a register member"))),
+        })(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "as" from the string.
+        let (string, _) = tag("as")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the finalize type from the string.
+        let (string, finalize_type) = FinalizeType::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the semicolon from the string.
+        let (string, _) = tag(";")(string)?;
+        // Return the input statement.
+        Ok((string, Self { register, finalize_type }))
+    }
+}
+
+impl<N: Network> FromStr for Input<N> {
+    type Err = Error;
+
+    #[inline]
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for Input<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for Input<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{} {} as {};", Self::type_name(), self.register, self.finalize_type)
+    }
+}

--- a/synthesizer/program/src/query/input/parse.rs
+++ b/synthesizer/program/src/query/input/parse.rs
@@ -74,3 +74,55 @@ impl<N: Network> Display for Input<N> {
         write!(f, "{} {} as {};", Self::type_name(), self.register, self.finalize_type)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::network::MainnetV0;
+
+    type CurrentNetwork = MainnetV0;
+
+    #[test]
+    fn test_input_parse() -> Result<()> {
+        let input = Input::<CurrentNetwork>::parse("input r0 as field.public;").unwrap().1;
+        assert_eq!(input.register(), &Register::<CurrentNetwork>::Locator(0));
+        assert_eq!(input.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("field.public")?);
+
+        let input = Input::<CurrentNetwork>::parse("input r1 as u64.public;").unwrap().1;
+        assert_eq!(input.register(), &Register::<CurrentNetwork>::Locator(1));
+        assert_eq!(input.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("u64.public")?);
+
+        let input = Input::<CurrentNetwork>::parse("input r2 as address.public;").unwrap().1;
+        assert_eq!(input.register(), &Register::<CurrentNetwork>::Locator(2));
+        assert_eq!(input.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("address.public")?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_input_display() -> Result<()> {
+        let input = Input::<CurrentNetwork>::from_str("input r0 as field.public;")?;
+        assert_eq!("input r0 as field.public;", input.to_string());
+
+        let input = Input::<CurrentNetwork>::from_str("input r3 as u64.public;")?;
+        assert_eq!("input r3 as u64.public;", input.to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_input_parse_fails() {
+        // Register member is rejected (must be a locator).
+        assert!(Input::<CurrentNetwork>::from_str("input r0.x as field.public;").is_err());
+        // Missing trailing semicolon.
+        assert!(Input::<CurrentNetwork>::from_str("input r0 as field.public").is_err());
+        // Missing 'as' keyword.
+        assert!(Input::<CurrentNetwork>::from_str("input r0 field.public;").is_err());
+        // Missing register.
+        assert!(Input::<CurrentNetwork>::from_str("input as field.public;").is_err());
+        // Missing 'input' keyword.
+        assert!(Input::<CurrentNetwork>::from_str("r0 as field.public;").is_err());
+        // Missing finalize type.
+        assert!(Input::<CurrentNetwork>::from_str("input r0 as ;").is_err());
+    }
+}

--- a/synthesizer/program/src/query/mod.rs
+++ b/synthesizer/program/src/query/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Command, Instruction};
+use crate::Command;
 
 mod input;
 pub use input::*;
@@ -141,11 +141,6 @@ impl<N: Network> QueryCore<N> {
         ensure!(!command.is_cast_to_record(), "Forbidden operation: query functions cannot cast to a record");
         // `rand.chacha` is only meaningful with finalize global state.
         ensure!(!command.is_rand_chacha(), "Forbidden operation: query functions cannot use 'rand.chacha'");
-
-        // Reject `async` instructions explicitly (already covered by is_async, but be paranoid).
-        if let Command::Instruction(Instruction::Async(_)) = &command {
-            bail!("Forbidden operation: query functions cannot invoke 'async'");
-        }
 
         // Check the destination registers.
         for register in command.destinations() {

--- a/synthesizer/program/src/query/mod.rs
+++ b/synthesizer/program/src/query/mod.rs
@@ -138,7 +138,7 @@ impl<N: Network> QueryCore<N> {
         ensure!(!command.is_async(), "Forbidden operation: query functions cannot invoke an 'async' instruction");
         ensure!(!command.is_await(), "Forbidden operation: query functions cannot 'await' a future");
         ensure!(!command.is_call(), "Forbidden operation: query functions cannot 'call' another function");
-        ensure!(!command.is_cast_to_record(), "Forbidden operation: query functions cannot cast to a record");
+        ensure!(!command.is_instruction_for_record(), "Forbidden operation: query functions cannot operate on records");
         // `rand.chacha` is only meaningful with finalize global state.
         ensure!(!command.is_rand_chacha(), "Forbidden operation: query functions cannot use 'rand.chacha'");
 
@@ -260,7 +260,27 @@ mod tests {
         let cmd =
             Command::<CurrentNetwork>::from_str("cast r0.owner r0.token_amount into r1 as token.record;").unwrap();
         let err = query.add_command(cmd).unwrap_err();
-        assert!(err.to_string().contains("cast to a record"));
+        assert!(err.to_string().contains("operate on records"));
+    }
+
+    #[test]
+    fn test_reject_cast_to_dynamic_record() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("cast r0 into r1 as dynamic.record;").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("operate on records"));
+    }
+
+    #[test]
+    fn test_reject_get_record_dynamic() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("get.record.dynamic r0.x into r1 as bool;").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("operate on records"));
     }
 
     #[test]

--- a/synthesizer/program/src/query/mod.rs
+++ b/synthesizer/program/src/query/mod.rs
@@ -51,7 +51,7 @@ pub struct QueryCore<N: Network> {
 }
 
 impl<N: Network> QueryCore<N> {
-    /// Initializes a new read with the given name.
+    /// Initializes a new query function with the given name.
     pub fn new(name: Identifier<N>) -> Self {
         Self {
             name,
@@ -95,6 +95,45 @@ impl<N: Network> QueryCore<N> {
     /// Returns the mapping of `Position`s to their index in `commands`.
     pub const fn positions(&self) -> &HashMap<Identifier<N>, usize> {
         &self.positions
+    }
+
+    /// Returns `true` if the query contains an array type with a size that exceeds the given maximum.
+    /// Mirrors `Finalize::exceeds_max_array_size` and additionally walks `outputs`, since queries
+    /// declare typed outputs.
+    pub fn exceeds_max_array_size(&self, max_array_size: u32) -> bool {
+        self.inputs.iter().any(|input| {
+            matches!(input.finalize_type(), FinalizeType::Plaintext(p) if p.exceeds_max_array_size(max_array_size))
+        }) || self.commands.iter().any(|command| command.exceeds_max_array_size(max_array_size))
+            || self.outputs.iter().any(|output| {
+                matches!(output.finalize_type(), FinalizeType::Plaintext(p) if p.exceeds_max_array_size(max_array_size))
+            })
+    }
+
+    /// Returns `true` if the query refers to an external struct in its inputs, body, or outputs.
+    pub fn contains_external_struct(&self) -> bool {
+        self.inputs
+            .iter()
+            .any(|input| matches!(input.finalize_type(), FinalizeType::Plaintext(p) if p.contains_external_struct()))
+            || self
+                .commands
+                .iter()
+                .any(|command| matches!(command, Command::Instruction(inst) if inst.contains_external_struct()))
+            || self.outputs.iter().any(
+                |output| matches!(output.finalize_type(), FinalizeType::Plaintext(p) if p.contains_external_struct()),
+            )
+    }
+
+    /// Returns `true` if the query contains a string type. Mirrors `Finalize::contains_string_type`
+    /// and additionally walks `outputs`.
+    pub fn contains_string_type(&self) -> bool {
+        self.inputs
+            .iter()
+            .any(|input| matches!(input.finalize_type(), FinalizeType::Plaintext(p) if p.contains_string_type()))
+            || self.commands.iter().any(|command| command.contains_string_type())
+            || self
+                .outputs
+                .iter()
+                .any(|output| matches!(output.finalize_type(), FinalizeType::Plaintext(p) if p.contains_string_type()))
     }
 }
 

--- a/synthesizer/program/src/query/mod.rs
+++ b/synthesizer/program/src/query/mod.rs
@@ -1,0 +1,242 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Command, Instruction};
+
+mod input;
+pub use input::*;
+
+mod output;
+pub use output::*;
+
+mod bytes;
+mod parse;
+
+use console::{
+    network::{error, prelude::*},
+    program::{FinalizeType, Identifier, Register},
+};
+
+use indexmap::IndexSet;
+use std::collections::HashMap;
+
+/// A query function: a top-level, externally-callable, read-only block that returns typed values.
+///
+/// Queries share the finalize command set (so they can `get`, `get.or_use`, `contains` against
+/// mappings), but cannot mutate state, schedule futures, or call other functions.
+#[derive(Clone, PartialEq, Eq)]
+pub struct QueryCore<N: Network> {
+    /// The name of the query function.
+    name: Identifier<N>,
+    /// The input statements, added in order of the input registers.
+    inputs: IndexSet<Input<N>>,
+    /// The commands, in order of execution.
+    commands: Vec<Command<N>>,
+    /// The output statements, in order of the desired output.
+    outputs: IndexSet<Output<N>>,
+    /// A mapping from `Position`s to their index in `commands`.
+    positions: HashMap<Identifier<N>, usize>,
+}
+
+impl<N: Network> QueryCore<N> {
+    /// Initializes a new read with the given name.
+    pub fn new(name: Identifier<N>) -> Self {
+        Self {
+            name,
+            inputs: IndexSet::new(),
+            commands: Vec::new(),
+            outputs: IndexSet::new(),
+            positions: HashMap::new(),
+        }
+    }
+
+    /// Returns the name of the query function.
+    pub const fn name(&self) -> &Identifier<N> {
+        &self.name
+    }
+
+    /// Returns the query inputs.
+    pub const fn inputs(&self) -> &IndexSet<Input<N>> {
+        &self.inputs
+    }
+
+    /// Returns the query input types.
+    pub fn input_types(&self) -> Vec<FinalizeType<N>> {
+        self.inputs.iter().map(|input| input.finalize_type()).cloned().collect()
+    }
+
+    /// Returns the query commands.
+    pub fn commands(&self) -> &[Command<N>] {
+        &self.commands
+    }
+
+    /// Returns the query outputs.
+    pub const fn outputs(&self) -> &IndexSet<Output<N>> {
+        &self.outputs
+    }
+
+    /// Returns the query output types.
+    pub fn output_types(&self) -> Vec<FinalizeType<N>> {
+        self.outputs.iter().map(|output| output.finalize_type()).cloned().collect()
+    }
+
+    /// Returns the mapping of `Position`s to their index in `commands`.
+    pub const fn positions(&self) -> &HashMap<Identifier<N>, usize> {
+        &self.positions
+    }
+}
+
+impl<N: Network> QueryCore<N> {
+    /// Adds the input statement to the query.
+    #[inline]
+    fn add_input(&mut self, input: Input<N>) -> Result<()> {
+        // Ensure there are no commands or outputs in memory.
+        ensure!(self.commands.is_empty(), "Cannot add inputs after commands have been added");
+        ensure!(self.outputs.is_empty(), "Cannot add inputs after outputs have been added");
+
+        // Ensure the maximum number of inputs has not been exceeded.
+        ensure!(self.inputs.len() < N::MAX_INPUTS, "Cannot add more than {} inputs", N::MAX_INPUTS);
+        // Ensure the input statement was not previously added.
+        ensure!(!self.inputs.contains(&input), "Cannot add duplicate input statement");
+
+        // Queries are externally-callable; futures and dynamic futures are not meaningful here.
+        ensure!(
+            matches!(input.finalize_type(), FinalizeType::Plaintext(..)),
+            "Query inputs must be plaintext (futures are forbidden)"
+        );
+
+        // Ensure the input register is a locator.
+        ensure!(matches!(input.register(), Register::Locator(..)), "Input register must be a locator");
+
+        self.inputs.insert(input);
+        Ok(())
+    }
+
+    /// Adds the given command to the query.
+    #[inline]
+    pub fn add_command(&mut self, command: Command<N>) -> Result<()> {
+        // Ensure there are no outputs already.
+        ensure!(self.outputs.is_empty(), "Cannot add commands after outputs have been added");
+
+        // Ensure the maximum number of commands has not been exceeded.
+        ensure!(self.commands.len() < N::MAX_COMMANDS, "Cannot add more than {} commands", N::MAX_COMMANDS);
+
+        // Reject any state-mutating or non-deterministic command.
+        ensure!(!command.is_write(), "Forbidden operation: query functions cannot use 'set' or 'remove'");
+        ensure!(!command.is_async(), "Forbidden operation: query functions cannot invoke an 'async' instruction");
+        ensure!(!command.is_await(), "Forbidden operation: query functions cannot 'await' a future");
+        ensure!(!command.is_call(), "Forbidden operation: query functions cannot 'call' another function");
+        ensure!(!command.is_cast_to_record(), "Forbidden operation: query functions cannot cast to a record");
+
+        // Reject `rand.chacha`. It is only meaningful with finalize global state.
+        if matches!(&command, Command::RandChaCha(_)) {
+            bail!("Forbidden operation: query functions cannot use 'rand.chacha'");
+        }
+
+        // Reject `async` instructions explicitly (already covered by is_async, but be paranoid).
+        if let Command::Instruction(Instruction::Async(_)) = &command {
+            bail!("Forbidden operation: query functions cannot invoke 'async'");
+        }
+
+        // Check the destination registers.
+        for register in command.destinations() {
+            ensure!(matches!(register, Register::Locator(..)), "Destination register must be a locator");
+        }
+
+        // Branch target validation.
+        if let Some(position) = command.branch_to() {
+            ensure!(!self.positions.contains_key(position), "Cannot branch to an earlier position '{position}'");
+        }
+
+        if let Some(position) = command.position() {
+            ensure!(!self.positions.contains_key(position), "Cannot redefine position '{position}'");
+            ensure!(self.positions.len() < N::MAX_POSITIONS, "Cannot add more than {} positions", N::MAX_POSITIONS);
+            self.positions.insert(*position, self.commands.len());
+        }
+
+        self.commands.push(command);
+        Ok(())
+    }
+
+    /// Adds the output statement to the query.
+    #[inline]
+    fn add_output(&mut self, output: Output<N>) -> Result<()> {
+        // Ensure the maximum number of outputs has not been exceeded.
+        ensure!(self.outputs.len() < N::MAX_OUTPUTS, "Cannot add more than {} outputs", N::MAX_OUTPUTS);
+
+        // Queries return plaintext only.
+        ensure!(
+            matches!(output.finalize_type(), FinalizeType::Plaintext(..)),
+            "Query outputs must be plaintext (futures are forbidden)"
+        );
+
+        self.outputs.insert(output);
+        Ok(())
+    }
+}
+
+impl<N: Network> TypeName for QueryCore<N> {
+    #[inline]
+    fn type_name() -> &'static str {
+        "query"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type CurrentNetwork = console::network::MainnetV0;
+
+    #[test]
+    fn test_add_input() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let input = Input::<CurrentNetwork>::from_str("input r0 as field.public;").unwrap();
+        assert!(query.add_input(input.clone()).is_ok());
+        assert!(query.add_input(input).is_err());
+    }
+
+    #[test]
+    fn test_reject_set_command() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("set 1u64 into balances[0u64];").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("'set' or 'remove'"));
+    }
+
+    #[test]
+    fn test_reject_remove_command() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("remove balances[0u64];").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("'set' or 'remove'"));
+    }
+
+    #[test]
+    fn test_reject_rand_chacha() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("rand.chacha into r0 as u64;").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("rand.chacha"));
+    }
+}

--- a/synthesizer/program/src/query/mod.rs
+++ b/synthesizer/program/src/query/mod.rs
@@ -139,11 +139,8 @@ impl<N: Network> QueryCore<N> {
         ensure!(!command.is_await(), "Forbidden operation: query functions cannot 'await' a future");
         ensure!(!command.is_call(), "Forbidden operation: query functions cannot 'call' another function");
         ensure!(!command.is_cast_to_record(), "Forbidden operation: query functions cannot cast to a record");
-
-        // Reject `rand.chacha`. It is only meaningful with finalize global state.
-        if matches!(&command, Command::RandChaCha(_)) {
-            bail!("Forbidden operation: query functions cannot use 'rand.chacha'");
-        }
+        // `rand.chacha` is only meaningful with finalize global state.
+        ensure!(!command.is_rand_chacha(), "Forbidden operation: query functions cannot use 'rand.chacha'");
 
         // Reject `async` instructions explicitly (already covered by is_async, but be paranoid).
         if let Command::Instruction(Instruction::Async(_)) = &command {
@@ -238,5 +235,46 @@ mod tests {
         let cmd = Command::<CurrentNetwork>::from_str("rand.chacha into r0 as u64;").unwrap();
         let err = query.add_command(cmd).unwrap_err();
         assert!(err.to_string().contains("rand.chacha"));
+    }
+
+    #[test]
+    fn test_reject_await_command() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("await r0;").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("'await'"));
+    }
+
+    #[test]
+    fn test_reject_call_instruction() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("call foo r0 into r1;").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("'call'"));
+    }
+
+    #[test]
+    fn test_reject_cast_to_record() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd =
+            Command::<CurrentNetwork>::from_str("cast r0.owner r0.token_amount into r1 as token.record;").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("cast to a record"));
+    }
+
+    #[test]
+    fn test_reject_async_instruction() {
+        let name = Identifier::from_str("query_core_test").unwrap();
+        let mut query = QueryCore::<CurrentNetwork>::new(name);
+
+        let cmd = Command::<CurrentNetwork>::from_str("async foo r0 r1 into r3;").unwrap();
+        let err = query.add_command(cmd).unwrap_err();
+        assert!(err.to_string().contains("'async'"));
     }
 }

--- a/synthesizer/program/src/query/output/bytes.rs
+++ b/synthesizer/program/src/query/output/bytes.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> FromBytes for Output<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let operand = FromBytes::read_le(&mut reader)?;
+        let finalize_type = FromBytes::read_le(&mut reader)?;
+        Ok(Self { operand, finalize_type })
+    }
+}
+
+impl<N: Network> ToBytes for Output<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.operand.write_le(&mut writer)?;
+        self.finalize_type.write_le(&mut writer)
+    }
+}

--- a/synthesizer/program/src/query/output/mod.rs
+++ b/synthesizer/program/src/query/output/mod.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bytes;
+mod parse;
+
+use crate::Operand;
+
+use console::{network::prelude::*, program::FinalizeType};
+
+/// An output statement defines an output of a query function.
+/// An output statement is of the form `output {operand} as {finalize_type};`.
+///
+/// The finalize type carries the same plaintext-only constraints as finalize inputs:
+/// futures and dynamic futures are rejected at construction time.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Output<N: Network> {
+    /// The output operand.
+    operand: Operand<N>,
+    /// The output finalize type.
+    finalize_type: FinalizeType<N>,
+}
+
+impl<N: Network> Output<N> {
+    /// Returns the output operand.
+    #[inline]
+    pub const fn operand(&self) -> &Operand<N> {
+        &self.operand
+    }
+
+    /// Returns the output finalize type.
+    #[inline]
+    pub const fn finalize_type(&self) -> &FinalizeType<N> {
+        &self.finalize_type
+    }
+}
+
+impl<N: Network> TypeName for Output<N> {
+    #[inline]
+    fn type_name() -> &'static str {
+        "output"
+    }
+}

--- a/synthesizer/program/src/query/output/parse.rs
+++ b/synthesizer/program/src/query/output/parse.rs
@@ -76,3 +76,51 @@ impl<N: Network> Display for Output<N> {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::network::MainnetV0;
+
+    type CurrentNetwork = MainnetV0;
+
+    #[test]
+    fn test_output_parse() -> Result<()> {
+        // Register operand.
+        let output = Output::<CurrentNetwork>::parse("output r0 as field.public;").unwrap().1;
+        assert_eq!(output.operand(), &Operand::<CurrentNetwork>::from_str("r0")?);
+        assert_eq!(output.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("field.public")?);
+
+        // Literal operand.
+        let output = Output::<CurrentNetwork>::parse("output 1u64 as u64.public;").unwrap().1;
+        assert_eq!(output.operand(), &Operand::<CurrentNetwork>::from_str("1u64")?);
+        assert_eq!(output.finalize_type(), &FinalizeType::<CurrentNetwork>::from_str("u64.public")?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_output_display() -> Result<()> {
+        let output = Output::<CurrentNetwork>::from_str("output r0 as field.public;")?;
+        assert_eq!("output r0 as field.public;", output.to_string());
+
+        let output = Output::<CurrentNetwork>::from_str("output 1u64 as u64.public;")?;
+        assert_eq!("output 1u64 as u64.public;", output.to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_output_parse_fails() {
+        // Missing trailing semicolon.
+        assert!(Output::<CurrentNetwork>::from_str("output r0 as field.public").is_err());
+        // Missing 'as' keyword.
+        assert!(Output::<CurrentNetwork>::from_str("output r0 field.public;").is_err());
+        // Missing operand.
+        assert!(Output::<CurrentNetwork>::from_str("output as field.public;").is_err());
+        // Missing 'output' keyword.
+        assert!(Output::<CurrentNetwork>::from_str("r0 as field.public;").is_err());
+        // Missing finalize type.
+        assert!(Output::<CurrentNetwork>::from_str("output r0 as ;").is_err());
+    }
+}

--- a/synthesizer/program/src/query/output/parse.rs
+++ b/synthesizer/program/src/query/output/parse.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Parser for Output<N> {
+    /// Parses a string into an output statement.
+    /// The output statement is of the form `output {operand} as {finalize_type};`.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the output keyword from the string.
+        let (string, _) = tag(Self::type_name())(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the operand from the string.
+        let (string, operand) = Operand::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the "as" from the string.
+        let (string, _) = tag("as")(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the finalize type from the string.
+        let (string, finalize_type) = FinalizeType::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the semicolon from the string.
+        let (string, _) = tag(";")(string)?;
+        Ok((string, Self { operand, finalize_type }))
+    }
+}
+
+impl<N: Network> FromStr for Output<N> {
+    type Err = Error;
+
+    #[inline]
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for Output<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for Output<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{type_} {operand} as {finalize_type};",
+            type_ = Self::type_name(),
+            operand = self.operand,
+            finalize_type = self.finalize_type,
+        )
+    }
+}

--- a/synthesizer/program/src/query/parse.rs
+++ b/synthesizer/program/src/query/parse.rs
@@ -77,3 +77,109 @@ impl<N: Network> Display for QueryCore<N> {
         self.outputs.iter().try_for_each(|output| write!(f, "\n    {output}"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::network::MainnetV0;
+
+    type CurrentNetwork = MainnetV0;
+
+    #[test]
+    fn test_query_parse() {
+        let query = QueryCore::<CurrentNetwork>::parse(
+            r"
+query foo:
+    input r0 as field.public;
+    input r1 as field.public;
+    add r0 r1 into r2;
+    output r2 as field.public;",
+        )
+        .unwrap()
+        .1;
+        assert_eq!("foo", query.name().to_string());
+        assert_eq!(2, query.inputs().len());
+        assert_eq!(1, query.commands().len());
+        assert_eq!(1, query.outputs().len());
+    }
+
+    #[test]
+    fn test_query_parse_no_inputs() {
+        let query = QueryCore::<CurrentNetwork>::parse(
+            r"
+query foo:
+    add 1u64 2u64 into r0;
+    output r0 as u64.public;",
+        )
+        .unwrap()
+        .1;
+        assert_eq!("foo", query.name().to_string());
+        assert_eq!(0, query.inputs().len());
+        assert_eq!(1, query.commands().len());
+        assert_eq!(1, query.outputs().len());
+    }
+
+    #[test]
+    fn test_query_display() {
+        let expected = r"query foo:
+    input r0 as field.public;
+    input r1 as field.public;
+    add r0 r1 into r2;
+    output r2 as field.public;";
+        let query = QueryCore::<CurrentNetwork>::parse(expected).unwrap().1;
+        assert_eq!(expected, format!("{query}"));
+    }
+
+    #[test]
+    fn test_query_parse_fails() {
+        // Missing 'query' keyword.
+        assert!(
+            QueryCore::<CurrentNetwork>::from_str(
+                r"
+foo:
+    add 1u64 2u64 into r0;
+    output r0 as u64.public;"
+            )
+            .is_err()
+        );
+        // Missing colon after the query name.
+        assert!(
+            QueryCore::<CurrentNetwork>::from_str(
+                r"
+query foo
+    add 1u64 2u64 into r0;
+    output r0 as u64.public;"
+            )
+            .is_err()
+        );
+        // Missing output (a query must have at least one).
+        assert!(
+            QueryCore::<CurrentNetwork>::from_str(
+                r"
+query foo:
+    add 1u64 2u64 into r0;"
+            )
+            .is_err()
+        );
+        // Missing commands (a query must have at least one).
+        assert!(
+            QueryCore::<CurrentNetwork>::from_str(
+                r"
+query foo:
+    output r0 as u64.public;"
+            )
+            .is_err()
+        );
+        // 'set' is forbidden in a query.
+        assert!(
+            QueryCore::<CurrentNetwork>::from_str(
+                r"
+query foo:
+    input r0 as u64.public;
+    set r0 into balances[r0];
+    output r0 as u64.public;"
+            )
+            .is_err()
+        );
+    }
+}

--- a/synthesizer/program/src/query/parse.rs
+++ b/synthesizer/program/src/query/parse.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+impl<N: Network> Parser for QueryCore<N> {
+    /// Parses a string into a query function.
+    #[inline]
+    fn parse(string: &str) -> ParserResult<Self> {
+        // Parse the whitespace and comments from the string.
+        let (string, _) = Sanitizer::parse(string)?;
+        // Parse the 'query' keyword from the string.
+        let (string, _) = tag(Self::type_name())(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the query name from the string.
+        let (string, name) = Identifier::<N>::parse(string)?;
+        // Parse the whitespace from the string.
+        let (string, _) = Sanitizer::parse_whitespaces(string)?;
+        // Parse the colon ':' keyword from the string.
+        let (string, _) = tag(":")(string)?;
+
+        // Parse the inputs from the string.
+        let (string, inputs) = many0(Input::parse)(string)?;
+        // Parse the commands from the string.
+        let (string, commands) = many1(Command::<N>::parse)(string)?;
+        // Parse the outputs from the string.
+        let (string, outputs) = many1(Output::parse)(string)?;
+
+        map_res(take(0usize), move |_| {
+            let mut query = Self::new(name);
+            inputs.iter().cloned().try_for_each(|input| query.add_input(input))?;
+            commands.iter().cloned().try_for_each(|command| query.add_command(command))?;
+            outputs.iter().cloned().try_for_each(|output| query.add_output(output))?;
+            Ok::<_, Error>(query)
+        })(string)
+    }
+}
+
+impl<N: Network> FromStr for QueryCore<N> {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self> {
+        match Self::parse(string) {
+            Ok((remainder, object)) => {
+                ensure!(remainder.is_empty(), "Failed to parse string. Found invalid character in: \"{remainder}\"");
+                Ok(object)
+            }
+            Err(error) => bail!("Failed to parse string. {error}"),
+        }
+    }
+}
+
+impl<N: Network> Debug for QueryCore<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<N: Network> Display for QueryCore<N> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{} {}:", Self::type_name(), self.name)?;
+        self.inputs.iter().try_for_each(|input| write!(f, "\n    {input}"))?;
+        self.commands.iter().try_for_each(|command| write!(f, "\n    {command}"))?;
+        self.outputs.iter().try_for_each(|output| write!(f, "\n    {output}"))
+    }
+}

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -283,14 +283,17 @@ pub trait FinalizeRegistersState<N: Network>: RegistersTrait<N> {
     /// Returns the global state for the finalize scope.
     fn state(&self) -> &FinalizeGlobalState;
 
-    /// Returns the transition ID for the finalize scope.
-    fn transition_id(&self) -> &N::TransitionID;
+    /// Returns the transition ID for the finalize scope, if one is associated with this scope.
+    /// Query functions are externally-callable and have no associated transition, so this is
+    /// `None` on the query path; finalize and constructor scopes always have `Some(...)`.
+    fn transition_id(&self) -> Option<&N::TransitionID>;
 
     /// Returns the function name for the finalize scope.
     fn function_name(&self) -> &Identifier<N>;
 
-    /// Returns the nonce for the finalize registers.
-    fn nonce(&self) -> u64;
+    /// Returns the nonce for the finalize registers, if one is associated with this scope.
+    /// `None` on the query path (no transition → no nonce); always `Some(...)` on finalize.
+    fn nonce(&self) -> Option<u64>;
 }
 
 pub trait RegistersSigner<N: Network>: RegistersTrait<N> {

--- a/synthesizer/program/tests/helpers/sample.rs
+++ b/synthesizer/program/tests/helpers/sample.rs
@@ -65,10 +65,10 @@ pub fn sample_finalize_registers(
     // Initialize the registers.
     let mut finalize_registers = FinalizeRegisters::<CurrentNetwork>::new(
         FinalizeGlobalState::from(1, 1, None, [0; 32]),
-        <CurrentNetwork as Network>::TransitionID::default(),
+        Some(<CurrentNetwork as Network>::TransitionID::default()),
         *function_name,
         stack.get_finalize_types(function_name)?.clone(),
-        0u64,
+        Some(0u64),
     );
 
     // For each literal,

--- a/synthesizer/program/tests/instruction/ecdsa.rs
+++ b/synthesizer/program/tests/instruction/ecdsa.rs
@@ -180,10 +180,10 @@ pub fn sample_ecdsa_finalize_registers(
     // Initialize the registers.
     let mut finalize_registers = FinalizeRegisters::<CurrentNetwork>::new(
         FinalizeGlobalState::from(1, 1, None, [0; 32]),
-        <CurrentNetwork as Network>::TransitionID::default(),
+        Some(<CurrentNetwork as Network>::TransitionID::default()),
         *function_name,
         stack.get_finalize_types(function_name)?.clone(),
-        0u64,
+        Some(0u64),
     );
 
     // Initialize the signature.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -318,12 +318,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         query_name: impl TryInto<Identifier<N>>,
         inputs: Vec<Value<N>>,
     ) -> Result<(u32, Vec<Value<N>>)> {
-        // Bind the query to the current finalize state. Prototype queries do not depend on the
-        // seed material, so a zero previous-block-hash is acceptable here; matches the pattern
-        // used by `sample_finalize_state` in the test helpers.
+        // Bind the query to the current block height. The dedicated constructor fills the
+        // other `FinalizeGlobalState` fields with safe defaults (queries forbid `rand.chacha`,
+        // the only consumer of `random_seed`).
         let block_height = self.block_store().current_block_height();
-        let block_round = block_height as u64;
-        let state = FinalizeGlobalState::from(block_round, block_height, None, [0u8; 32]);
+        let state = FinalizeGlobalState::for_query(block_height);
 
         // Delegate to `Process::evaluate_query`. `self.process` derefs through the `Arc`.
         //

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -326,6 +326,17 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let state = FinalizeGlobalState::from(block_round, block_height, None, [0u8; 32]);
 
         // Delegate to `Process::evaluate_query`. `self.process` derefs through the `Arc`.
+        //
+        // We deliberately do NOT take `self.process.lock()` here. That guard is the same
+        // exclusive `Mutex` held for the entire duration of `finalize_atomic_batch`, so
+        // grabbing it for a query would (a) serialize all concurrent queries and (b) block
+        // chain advancement while any query runs. Instead, the query relies on:
+        //   - `Arc<Stack<N>>` immutability: once `Process::get_stack` returns an Arc, the
+        //     stack contents do not change for the lifetime of that Arc.
+        //   - The finalize store's own internal locking for each mapping read.
+        // A query interleaved with a `revert_stacks`/redeploy can briefly observe program
+        // metadata and finalize state from different boundaries; consumers that need stricter
+        // consistency should index/cache externally or rate-limit at the snarkOS layer.
         let outputs = self.process.evaluate_query(state, self.finalize_store(), program_id, query_name, inputs)?;
         Ok((block_height, outputs))
     }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -302,18 +302,22 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     }
 
     /// Evaluates a query function in the program identified by `program_id` against the
-    /// VM's current finalize state. Returns the typed outputs.
+    /// VM's current finalize state. Returns the block height the query was bound to,
+    /// together with the typed outputs.
     ///
     /// This is the most ergonomic call site for query functions: the caller supplies only the
     /// program ID, query name, and inputs. The block height, finalize store, and stack are all
-    /// resolved from the VM. Queries are a node-local lookup; no transaction is produced.
+    /// resolved from the VM. Returning the block height alongside the outputs lets callers
+    /// (UIs, caches, indexers) attribute the answer to a specific chain state without a
+    /// follow-up `current_block_height()` call that could race chain progression.
+    /// Queries are a node-local lookup; no transaction is produced.
     #[inline]
     pub fn evaluate_query(
         &self,
         program_id: impl TryInto<ProgramID<N>>,
         query_name: impl TryInto<Identifier<N>>,
         inputs: Vec<Value<N>>,
-    ) -> Result<Vec<Value<N>>> {
+    ) -> Result<(u32, Vec<Value<N>>)> {
         // Bind the query to the current finalize state. Prototype queries do not depend on the
         // seed material, so a zero previous-block-hash is acceptable here; matches the pattern
         // used by `sample_finalize_state` in the test helpers.
@@ -322,7 +326,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let state = FinalizeGlobalState::from(block_round, block_height, None, [0u8; 32]);
 
         // Delegate to `Process::evaluate_query`. `self.process` derefs through the `Arc`.
-        self.process.evaluate_query(state, self.finalize_store(), program_id, query_name, inputs)
+        let outputs = self.process.evaluate_query(state, self.finalize_store(), program_id, query_name, inputs)?;
+        Ok((block_height, outputs))
     }
 
     /// Returns the transition store.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -340,6 +340,31 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         Ok((block_height, outputs))
     }
 
+    /// Evaluates a query function against historic finalize-store state at the given block
+    /// `height`. Returns the typed outputs (no `(height, outputs)` tuple — the caller already
+    /// supplied the height).
+    ///
+    /// Mapping reads route through the finalize store's historical update map, which is only
+    /// populated when snarkVM is built with `--features history`.
+    ///
+    /// `height` must satisfy `height <= current_block_height()`. Reading a future height
+    /// returns the same "not found" surface a missing key would. The caller is expected to
+    /// validate this at the snarkOS RPC layer if desired.
+    #[cfg(feature = "history")]
+    #[inline]
+    pub fn evaluate_query_at_height(
+        &self,
+        program_id: impl TryInto<ProgramID<N>>,
+        query_name: impl TryInto<Identifier<N>>,
+        inputs: Vec<Value<N>>,
+        height: u32,
+    ) -> Result<Vec<Value<N>>> {
+        // Same isolation reasoning as `evaluate_query`: do not take `self.process.lock()`,
+        // rely on `Arc<Stack>` immutability and the `atomic_finalize!(DryRun)` wrapper that
+        // `Process::evaluate_query_at_height` opens around the historic-read path.
+        self.process.evaluate_query_at_height(self.finalize_store(), program_id, query_name, inputs, height)
+    }
+
     /// Returns the transition store.
     #[inline]
     pub fn transition_store(&self) -> &TransitionStore<N, C::TransitionStorage> {

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -302,6 +302,31 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         self.store.transaction_store()
     }
 
+    /// Evaluates a query function in the program identified by `program_id` against the
+    /// VM's current finalize state. Returns the typed outputs.
+    ///
+    /// This is the most ergonomic call site for query functions: the caller supplies only the
+    /// program ID, query name, and inputs. The block height, finalize store, and stack are all
+    /// resolved from the VM. Queries are a node-local lookup; no transaction is produced.
+    #[inline]
+    pub fn evaluate_query(
+        &self,
+        program_id: impl TryInto<ProgramID<N>>,
+        query_name: impl TryInto<Identifier<N>>,
+        inputs: Vec<Value<N>>,
+    ) -> Result<Vec<Value<N>>> {
+        // Bind the query to the current finalize state. Prototype queries do not depend on the
+        // seed material, so a zero previous-block-hash is acceptable here; matches the pattern
+        // used by `sample_finalize_state` in the test helpers.
+        let block_height = self.block_store().current_block_height();
+        let block_round = block_height as u64;
+        let state = FinalizeGlobalState::from(block_round, block_height, None, [0u8; 32]);
+
+        // Delegate to `Process::evaluate_query`.
+        let process = self.process.read();
+        process.evaluate_query(state, self.finalize_store(), program_id, query_name, inputs)
+    }
+
     /// Returns the transition store.
     #[inline]
     pub fn transition_store(&self) -> &TransitionStore<N, C::TransitionStorage> {

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -308,6 +308,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// cumulative weights, and the previous-block hash from the actual block — so any
     /// operand or opcode that reads from `FinalizeGlobalState` (block.height,
     /// block.timestamp, random_seed via rand.chacha, etc.) sees real values.
+    #[cfg(feature = "history")]
     fn finalize_state_for_block(&self, height: u32) -> Result<FinalizeGlobalState> {
         let block_hash =
             self.block_store().get_block_hash(height)?.ok_or_else(|| anyhow!("No block exists at height {height}"))?;
@@ -328,56 +329,26 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         )
     }
 
-    /// Evaluates a query function in the program identified by `program_id` against the
-    /// VM's current finalize state. Returns the block height the query was bound to,
-    /// together with the typed outputs.
+    /// Evaluates a query function against finalize-store state at the given block `height`.
+    /// Returns the typed outputs (no `(height, outputs)` tuple — the caller already supplied
+    /// the height).
     ///
-    /// This is the most ergonomic call site for query functions: the caller supplies only the
-    /// program ID, query name, and inputs. The block height, finalize store, and stack are all
-    /// resolved from the VM. Returning the block height alongside the outputs lets callers
-    /// (UIs, caches, indexers) attribute the answer to a specific chain state without a
-    /// follow-up `current_block_height()` call that could race chain progression.
-    /// Queries are a node-local lookup; no transaction is produced.
-    #[inline]
-    pub fn evaluate_query(
-        &self,
-        program_id: impl TryInto<ProgramID<N>>,
-        query_name: impl TryInto<Identifier<N>>,
-        inputs: Vec<Value<N>>,
-    ) -> Result<(u32, Vec<Value<N>>)> {
-        // Bind the query to the current block height and the corresponding `FinalizeGlobalState`
-        // (round / timestamp / cumulative weights / previous hash) — same shape as the
-        // consensus finalize path, so query operands reading those fields see real values.
-        let block_height = self.block_store().current_block_height();
-        let state = self.finalize_state_for_block(block_height)?;
-
-        // Delegate to `Process::evaluate_query`. `self.process` derefs through the `Arc`.
-        //
-        // We deliberately do NOT take `self.process.lock()` here. That guard is the same
-        // exclusive `Mutex` held for the entire duration of `finalize_atomic_batch`, so
-        // grabbing it for a query would (a) serialize all concurrent queries and (b) block
-        // chain advancement while any query runs. Instead, the query relies on:
-        //   - `Arc<Stack<N>>` immutability: once `Process::get_stack` returns an Arc, the
-        //     stack contents do not change for the lifetime of that Arc.
-        //   - The finalize store's own internal locking for each mapping read.
-        // A query interleaved with a `revert_stacks`/redeploy can briefly observe program
-        // metadata and finalize state from different boundaries; consumers that need stricter
-        // consistency should index/cache externally or rate-limit at the snarkOS layer.
-        let outputs = self.process.evaluate_query(state, self.finalize_store(), program_id, query_name, inputs)?;
-        Ok((block_height, outputs))
-    }
-
-    /// Evaluates a query function against historic finalize-store state at the given block
-    /// `height`. Returns the typed outputs (no `(height, outputs)` tuple — the caller already
-    /// supplied the height).
+    /// All mapping reads are pinned to `height` via the finalize store's per-key historical
+    /// update map (entries at any given height are immutable once written), so block production
+    /// advancing past `height` mid-evaluation cannot disturb the result. The
+    /// `FinalizeGlobalState` is also reconstructed from the block at `height`, so query operands
+    /// reading block metadata see that block's values.
     ///
-    /// Mapping reads route through the finalize store's historical update map, which is only
-    /// populated when snarkVM is built with `--features history`. The `FinalizeGlobalState`
-    /// passed to the evaluator is also reconstructed from the block at `height`, so query
-    /// operands that read block metadata see the metadata from that historic block.
+    /// snarkOS calls this with `current_block_height()` for "latest" semantics, or any earlier
+    /// height for historic queries. Available only when snarkVM is built with `--features history`
+    /// — the per-height update map that pins reads is only populated under that feature.
     ///
     /// `height` must satisfy `height <= current_block_height()`. Reading a future height
     /// returns "no block exists" rather than a misleading None.
+    ///
+    /// Concurrency: this call does NOT take `self.process.lock()` (which would serialize
+    /// queries against block production); it relies on `Arc<Stack<N>>` immutability and on the
+    /// fact that historic-table entries are immutable.
     #[cfg(feature = "history")]
     #[inline]
     pub fn evaluate_query_at_height(
@@ -387,9 +358,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         inputs: Vec<Value<N>>,
         height: u32,
     ) -> Result<Vec<Value<N>>> {
-        // Build the `FinalizeGlobalState` from the actual block at `height`, then route to
-        // the historic adapter inside `Process::evaluate_query_at_height`. Same isolation
-        // story as `evaluate_query`.
         let state = self.finalize_state_for_block(height)?;
         self.process.evaluate_query_at_height(state, self.finalize_store(), program_id, query_name, inputs, height)
     }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -301,6 +301,33 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         self.store.transaction_store()
     }
 
+    /// Builds a `FinalizeGlobalState` from the block at the given `height`.
+    ///
+    /// Returns an error if no block exists at `height`. Queries reuse the same shape that
+    /// the consensus path uses in `add_next_block_inner`, populating round, timestamp, the
+    /// cumulative weights, and the previous-block hash from the actual block — so any
+    /// operand or opcode that reads from `FinalizeGlobalState` (block.height,
+    /// block.timestamp, random_seed via rand.chacha, etc.) sees real values.
+    fn finalize_state_for_block(&self, height: u32) -> Result<FinalizeGlobalState> {
+        let block_hash =
+            self.block_store().get_block_hash(height)?.ok_or_else(|| anyhow!("No block exists at height {height}"))?;
+        let block = self
+            .block_store()
+            .get_block(&block_hash)?
+            .ok_or_else(|| anyhow!("Block hash for height {height} resolved but the block could not be loaded"))?;
+        // Match the consensus path's gating: the timestamp is only included from V12 onward.
+        let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
+            .then_some(block.timestamp());
+        FinalizeGlobalState::new::<N>(
+            block.round(),
+            block.height(),
+            block_timestamp,
+            block.cumulative_weight(),
+            block.cumulative_proof_target(),
+            block.previous_hash(),
+        )
+    }
+
     /// Evaluates a query function in the program identified by `program_id` against the
     /// VM's current finalize state. Returns the block height the query was bound to,
     /// together with the typed outputs.
@@ -318,11 +345,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         query_name: impl TryInto<Identifier<N>>,
         inputs: Vec<Value<N>>,
     ) -> Result<(u32, Vec<Value<N>>)> {
-        // Bind the query to the current block height. The dedicated constructor fills the
-        // other `FinalizeGlobalState` fields with safe defaults (queries forbid `rand.chacha`,
-        // the only consumer of `random_seed`).
+        // Bind the query to the current block height and the corresponding `FinalizeGlobalState`
+        // (round / timestamp / cumulative weights / previous hash) — same shape as the
+        // consensus finalize path, so query operands reading those fields see real values.
         let block_height = self.block_store().current_block_height();
-        let state = FinalizeGlobalState::for_query(block_height);
+        let state = self.finalize_state_for_block(block_height)?;
 
         // Delegate to `Process::evaluate_query`. `self.process` derefs through the `Arc`.
         //
@@ -345,11 +372,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// supplied the height).
     ///
     /// Mapping reads route through the finalize store's historical update map, which is only
-    /// populated when snarkVM is built with `--features history`.
+    /// populated when snarkVM is built with `--features history`. The `FinalizeGlobalState`
+    /// passed to the evaluator is also reconstructed from the block at `height`, so query
+    /// operands that read block metadata see the metadata from that historic block.
     ///
     /// `height` must satisfy `height <= current_block_height()`. Reading a future height
-    /// returns the same "not found" surface a missing key would. The caller is expected to
-    /// validate this at the snarkOS RPC layer if desired.
+    /// returns "no block exists" rather than a misleading None.
     #[cfg(feature = "history")]
     #[inline]
     pub fn evaluate_query_at_height(
@@ -359,10 +387,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         inputs: Vec<Value<N>>,
         height: u32,
     ) -> Result<Vec<Value<N>>> {
-        // Same isolation reasoning as `evaluate_query`: do not take `self.process.lock()`,
-        // rely on `Arc<Stack>` immutability and the `atomic_finalize!(DryRun)` wrapper that
-        // `Process::evaluate_query_at_height` opens around the historic-read path.
-        self.process.evaluate_query_at_height(self.finalize_store(), program_id, query_name, inputs, height)
+        // Build the `FinalizeGlobalState` from the actual block at `height`, then route to
+        // the historic adapter inside `Process::evaluate_query_at_height`. Same isolation
+        // story as `evaluate_query`.
+        let state = self.finalize_state_for_block(height)?;
+        self.process.evaluate_query_at_height(state, self.finalize_store(), program_id, query_name, inputs, height)
     }
 
     /// Returns the transition store.

--- a/synthesizer/src/vm/tests/test_v15/mod.rs
+++ b/synthesizer/src/vm/tests/test_v15/mod.rs
@@ -27,6 +27,9 @@ mod cost_for_call;
 // Tests for the externally-callable `query` function prototype.
 mod queries;
 
+// Tests for restricted keywords at V15.
+mod restricted_keywords;
+
 use super::*;
 
 use crate::vm::test_helpers::{sample_vm_at_height, *};

--- a/synthesizer/src/vm/tests/test_v15/mod.rs
+++ b/synthesizer/src/vm/tests/test_v15/mod.rs
@@ -24,6 +24,9 @@ mod commit_raw;
 // Additional test for cost estimation without a private key.
 mod cost_for_call;
 
+// Tests for the externally-callable `query` function prototype.
+mod queries;
+
 use super::*;
 
 use crate::vm::test_helpers::{sample_vm_at_height, *};

--- a/synthesizer/src/vm/tests/test_v15/queries.rs
+++ b/synthesizer/src/vm/tests/test_v15/queries.rs
@@ -1,0 +1,463 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end tests for the `query` function prototype.
+//!
+//! These tests build a real VM at V15 height, deploy programs containing query functions, run
+//! transactions that mutate mappings via `finalize`, then call `vm.evaluate_query(...)` to
+//! verify the typed return values reflect on-chain state.
+
+use super::*;
+
+use console::program::{Literal, Plaintext};
+
+/// Convenience: extract a single `u64` from a single-output query result.
+fn expect_u64(outputs: &[Value<CurrentNetwork>]) -> u64 {
+    assert_eq!(outputs.len(), 1, "expected exactly one output, got {}", outputs.len());
+    match &outputs[0] {
+        Value::Plaintext(Plaintext::Literal(Literal::U64(v), _)) => **v,
+        other => panic!("expected u64 plaintext, got: {other}"),
+    }
+}
+
+/// Full lifecycle: deploy a program with a query function, run a transition that updates a
+/// mapping via finalize, then evaluate the query and observe the new value.
+#[test]
+fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    // The program defines:
+    //   - `balances` mapping
+    //   - `increment(addr, amount)` transition + finalize that writes balances[addr] += amount
+    //   - `total_balance(addr)` query that returns balances[addr] (default 0)
+    let program = Program::from_str(
+        r"
+        program qy_lifecycle.aleo;
+
+        mapping balances:
+            key as address.public;
+            value as u64.public;
+
+        function increment:
+            input r0 as address.public;
+            input r1 as u64.public;
+            async increment r0 r1 into r2;
+            output r2 as qy_lifecycle.aleo/increment.future;
+
+        finalize increment:
+            input r0 as address.public;
+            input r1 as u64.public;
+            get.or_use balances[r0] 0u64 into r2;
+            add r2 r1 into r3;
+            set r3 into balances[r0];
+
+        query total_balance:
+            input r0 as address.public;
+            get.or_use balances[r0] 0u64 into r1;
+            output r1 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+
+    // Deploy.
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    // Read against an untouched mapping should return the default (0).
+    let outputs =
+        vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
+    assert_eq!(expect_u64(&outputs), 0);
+
+    // Execute increment(addr, 10).
+    let inputs = [Value::from_str(&caller_address.to_string())?, Value::from_str("10u64")?];
+    let tx = vm.execute(&caller_private_key, ("qy_lifecycle.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
+
+    // Read should now reflect the finalize-set value.
+    let outputs =
+        vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
+    assert_eq!(expect_u64(&outputs), 10);
+
+    // Increment again by 32. New total: 42.
+    let inputs = [Value::from_str(&caller_address.to_string())?, Value::from_str("32u64")?];
+    let tx = vm.execute(&caller_private_key, ("qy_lifecycle.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
+
+    let outputs =
+        vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
+    assert_eq!(expect_u64(&outputs), 42);
+
+    Ok(())
+}
+
+/// Read with multiple outputs returns each in declaration order.
+#[test]
+fn test_evaluate_query_multi_output() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    let program = Program::from_str(
+        r"
+        program qy_multi_output.aleo;
+
+        mapping balances:
+            key as address.public;
+            value as u64.public;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        query summary:
+            input r0 as address.public;
+            get.or_use balances[r0] 0u64 into r1;
+            add r1 1u64 into r2;
+            mul r1 2u64 into r3;
+            output r1 as u64.public;
+            output r2 as u64.public;
+            output r3 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    let outputs =
+        vm.evaluate_query("qy_multi_output.aleo", "summary", vec![Value::from_str(&caller_address.to_string())?])?;
+
+    // Default 0u64 for the unknown key, then +1 and *2.
+    assert_eq!(outputs.len(), 3);
+    assert_eq!(expect_u64(&outputs[0..1]), 0);
+    assert_eq!(expect_u64(&outputs[1..2]), 1);
+    assert_eq!(expect_u64(&outputs[2..3]), 0);
+    Ok(())
+}
+
+/// Read with multiple inputs computes a typed return.
+#[test]
+fn test_evaluate_query_multi_input() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    // Pure-arithmetic query, no mappings needed.
+    let program = Program::from_str(
+        r"
+        program qy_multi_in.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        query add3:
+            input r0 as u64.public;
+            input r1 as u64.public;
+            input r2 as u64.public;
+            add r0 r1 into r3;
+            add r3 r2 into r4;
+            output r4 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    let outputs = vm.evaluate_query("qy_multi_in.aleo", "add3", vec![
+        Value::from_str("10u64")?,
+        Value::from_str("20u64")?,
+        Value::from_str("12u64")?,
+    ])?;
+    assert_eq!(expect_u64(&outputs), 42);
+    Ok(())
+}
+
+/// Read that uses `branch.eq` to take a forward branch over a noop. The output is
+/// invariant under the branch (computed before it), but the branch path itself is
+/// exercised: when `r0 == 0`, the doubling step is skipped at runtime; when `r0 != 0`,
+/// the doubling step runs and writes `r2`. Either way the query's declared output
+/// references `r1`, which is always written. This proves the query evaluator handles
+/// `branch.eq` without crashing under both taken and not-taken paths.
+#[test]
+fn test_evaluate_query_with_branch() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    let program = Program::from_str(
+        r"
+        program qy_branch.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        query maybe_extra:
+            input r0 as u64.public;
+            add r0 10u64 into r1;
+            branch.eq r0 0u64 to skip;
+            add r1 r1 into r2;
+            position skip;
+            output r1 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    // r0 = 0: branch is taken, doubling is skipped.
+    let outputs = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("0u64")?])?;
+    assert_eq!(expect_u64(&outputs), 10);
+
+    // r0 = 5: branch is NOT taken, the unused r2 destination is written but we still output r1.
+    let outputs = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("5u64")?])?;
+    assert_eq!(expect_u64(&outputs), 15);
+    Ok(())
+}
+
+/// Read with no inputs (queries a fixed-key mapping or just returns a constant).
+#[test]
+fn test_evaluate_query_zero_inputs() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    let program = Program::from_str(
+        r"
+        program qy_zeroin.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        query fixed_value:
+            add 0u64 1234u64 into r0;
+            output r0 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    let outputs = vm.evaluate_query("qy_zeroin.aleo", "fixed_value", vec![])?;
+    assert_eq!(expect_u64(&outputs), 1234);
+    Ok(())
+}
+
+/// Calling evaluate_query with the wrong input arity returns an error.
+#[test]
+fn test_evaluate_query_arity_mismatch() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    let program = Program::from_str(
+        r"
+        program qy_arity.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        query takes_two:
+            input r0 as u64.public;
+            input r1 as u64.public;
+            add r0 r1 into r2;
+            output r2 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    // Too few inputs.
+    let result = vm.evaluate_query("qy_arity.aleo", "takes_two", vec![Value::from_str("1u64")?]);
+    assert!(result.is_err(), "expected error for too few inputs");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("expects 2"), "error should mention input count: {err}");
+
+    // Too many inputs.
+    let result = vm.evaluate_query("qy_arity.aleo", "takes_two", vec![
+        Value::from_str("1u64")?,
+        Value::from_str("2u64")?,
+        Value::from_str("3u64")?,
+    ]);
+    assert!(result.is_err(), "expected error for too many inputs");
+
+    Ok(())
+}
+
+/// Calling a query that does not exist on a deployed program returns a "not defined" error.
+#[test]
+fn test_evaluate_query_unknown_query() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    let program = Program::from_str(
+        r"
+        program qy_unknown.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        query existing:
+            add 0u64 1u64 into r0;
+            output r0 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    let result = vm.evaluate_query("qy_unknown.aleo", "missing", vec![]);
+    assert!(result.is_err(), "expected error for unknown query");
+    Ok(())
+}
+
+/// Calling evaluate_query against a program that was never deployed returns a "no such program" error.
+#[test]
+fn test_evaluate_query_unknown_program() {
+    let rng = &mut TestRng::default();
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+
+    let result = vm.evaluate_query("never_deployed.aleo", "anything", vec![]);
+    assert!(result.is_err(), "expected error for unknown program");
+}
+
+/// Construction-time rejection: declared output type must match the operand's actual type.
+#[test]
+fn test_query_output_type_mismatch_rejected() {
+    // `r1` is a `u64`, but the query declares its output as `u32`.
+    let result = Program::<CurrentNetwork>::from_str(
+        r"
+        program qy_typecheck.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        query bad_output:
+            input r0 as u64.public;
+            add r0 1u64 into r1;
+            output r1 as u32.public;
+        ",
+    );
+    // Parsing succeeds (the query is structurally valid); the mismatch is caught when the
+    // stack is computed from the program at deploy time. We assert here that *either* parse
+    // or the subsequent type-check rejects this — whichever fails first is acceptable.
+    if let Ok(program) = result {
+        let rng = &mut TestRng::default();
+        let caller_private_key = sample_genesis_private_key(rng);
+        let caller_address = Address::try_from(&caller_private_key).unwrap();
+        let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+        let deploy = vm.deploy(&caller_private_key, &program, None, 0, None, rng);
+        assert!(deploy.is_err(), "deploy should reject type-mismatched query output");
+        let _ = caller_address;
+    }
+}
+
+/// Construction-time rejection: write-style commands inside a query are rejected at parse.
+#[test]
+fn test_query_rejects_write_commands_at_parse() {
+    let cases = [
+        // `set` into a mapping
+        r"
+        program qy_bad_set.aleo;
+        mapping m:
+            key as u64.public;
+            value as u64.public;
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+        query bad:
+            input r0 as u64.public;
+            set r0 into m[r0];
+            output r0 as u64.public;
+        ",
+        // `remove` from a mapping
+        r"
+        program qy_bad_rm.aleo;
+        mapping m:
+            key as u64.public;
+            value as u64.public;
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+        query bad:
+            input r0 as u64.public;
+            remove m[r0];
+            output r0 as u64.public;
+        ",
+        // `rand.chacha`
+        r"
+        program qy_bad_rand.aleo;
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+        query bad:
+            rand.chacha into r0 as u64;
+            output r0 as u64.public;
+        ",
+    ];
+
+    for source in cases {
+        let result = Program::<CurrentNetwork>::from_str(source);
+        assert!(result.is_err(), "expected parse error for query with forbidden command:\n{source}");
+    }
+}

--- a/synthesizer/src/vm/tests/test_v15/queries.rs
+++ b/synthesizer/src/vm/tests/test_v15/queries.rs
@@ -21,9 +21,11 @@
 
 use super::*;
 
+#[cfg(feature = "history")]
 use console::program::{Literal, Plaintext};
 
 /// Convenience: extract a single `u64` from a single-output query result.
+#[cfg(feature = "history")]
 fn expect_u64(outputs: &[Value<CurrentNetwork>]) -> u64 {
     assert_eq!(outputs.len(), 1, "expected exactly one output, got {}", outputs.len());
     match &outputs[0] {
@@ -34,6 +36,7 @@ fn expect_u64(outputs: &[Value<CurrentNetwork>]) -> u64 {
 
 /// Full lifecycle: deploy a program with a query function, run a transition that updates a
 /// mapping via finalize, then evaluate the query and observe the new value.
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -82,9 +85,13 @@ fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // Read against an untouched mapping should return the default (0).
-    let (height, outputs) =
-        vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
-    assert_eq!(height, vm.block_store().current_block_height());
+    let height = vm.block_store().current_block_height();
+    let outputs = vm.evaluate_query_at_height(
+        "qy_lifecycle.aleo",
+        "total_balance",
+        vec![Value::from_str(&caller_address.to_string())?],
+        height,
+    )?;
     assert_eq!(expect_u64(&outputs), 0);
 
     // Execute increment(addr, 10).
@@ -93,9 +100,13 @@ fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
 
     // Read should now reflect the finalize-set value.
-    let (height, outputs) =
-        vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
-    assert_eq!(height, vm.block_store().current_block_height());
+    let height = vm.block_store().current_block_height();
+    let outputs = vm.evaluate_query_at_height(
+        "qy_lifecycle.aleo",
+        "total_balance",
+        vec![Value::from_str(&caller_address.to_string())?],
+        height,
+    )?;
     assert_eq!(expect_u64(&outputs), 10);
 
     // Increment again by 32. New total: 42.
@@ -103,15 +114,20 @@ fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
     let tx = vm.execute(&caller_private_key, ("qy_lifecycle.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
 
-    let (height, outputs) =
-        vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
-    assert_eq!(height, vm.block_store().current_block_height());
+    let height = vm.block_store().current_block_height();
+    let outputs = vm.evaluate_query_at_height(
+        "qy_lifecycle.aleo",
+        "total_balance",
+        vec![Value::from_str(&caller_address.to_string())?],
+        height,
+    )?;
     assert_eq!(expect_u64(&outputs), 42);
 
     Ok(())
 }
 
 /// Read with multiple outputs returns each in declaration order.
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_multi_output() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -148,8 +164,12 @@ fn test_evaluate_query_multi_output() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let (_, outputs) =
-        vm.evaluate_query("qy_multi_output.aleo", "summary", vec![Value::from_str(&caller_address.to_string())?])?;
+    let outputs = vm.evaluate_query_at_height(
+        "qy_multi_output.aleo",
+        "summary",
+        vec![Value::from_str(&caller_address.to_string())?],
+        vm.block_store().current_block_height(),
+    )?;
 
     // Default 0u64 for the unknown key, then +1 and *2.
     assert_eq!(outputs.len(), 3);
@@ -160,6 +180,7 @@ fn test_evaluate_query_multi_output() -> Result<()> {
 }
 
 /// Read with multiple inputs computes a typed return.
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_multi_input() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -192,11 +213,12 @@ fn test_evaluate_query_multi_input() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let (_, outputs) = vm.evaluate_query("qy_multi_in.aleo", "add3", vec![
-        Value::from_str("10u64")?,
-        Value::from_str("20u64")?,
-        Value::from_str("12u64")?,
-    ])?;
+    let outputs = vm.evaluate_query_at_height(
+        "qy_multi_in.aleo",
+        "add3",
+        vec![Value::from_str("10u64")?, Value::from_str("20u64")?, Value::from_str("12u64")?],
+        vm.block_store().current_block_height(),
+    )?;
     assert_eq!(expect_u64(&outputs), 42);
     Ok(())
 }
@@ -207,6 +229,7 @@ fn test_evaluate_query_multi_input() -> Result<()> {
 /// the doubling step runs and writes `r2`. Either way the query's declared output
 /// references `r1`, which is always written. This proves the query evaluator handles
 /// `branch.eq` without crashing under both taken and not-taken paths.
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_with_branch() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -239,16 +262,27 @@ fn test_evaluate_query_with_branch() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // r0 = 0: branch is taken, doubling is skipped.
-    let (_, outputs) = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("0u64")?])?;
+    let outputs = vm.evaluate_query_at_height(
+        "qy_branch.aleo",
+        "maybe_extra",
+        vec![Value::from_str("0u64")?],
+        vm.block_store().current_block_height(),
+    )?;
     assert_eq!(expect_u64(&outputs), 10);
 
     // r0 = 5: branch is NOT taken, the unused r2 destination is written but we still output r1.
-    let (_, outputs) = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("5u64")?])?;
+    let outputs = vm.evaluate_query_at_height(
+        "qy_branch.aleo",
+        "maybe_extra",
+        vec![Value::from_str("5u64")?],
+        vm.block_store().current_block_height(),
+    )?;
     assert_eq!(expect_u64(&outputs), 15);
     Ok(())
 }
 
 /// Read with no inputs (queries a fixed-key mapping or just returns a constant).
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_zero_inputs() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -276,12 +310,14 @@ fn test_evaluate_query_zero_inputs() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let (_, outputs) = vm.evaluate_query("qy_zeroin.aleo", "fixed_value", vec![])?;
+    let outputs =
+        vm.evaluate_query_at_height("qy_zeroin.aleo", "fixed_value", vec![], vm.block_store().current_block_height())?;
     assert_eq!(expect_u64(&outputs), 1234);
     Ok(())
 }
 
 /// Calling evaluate_query with the wrong input arity returns an error.
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_arity_mismatch() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -312,23 +348,30 @@ fn test_evaluate_query_arity_mismatch() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // Too few inputs.
-    let result = vm.evaluate_query("qy_arity.aleo", "takes_two", vec![Value::from_str("1u64")?]);
+    let result = vm.evaluate_query_at_height(
+        "qy_arity.aleo",
+        "takes_two",
+        vec![Value::from_str("1u64")?],
+        vm.block_store().current_block_height(),
+    );
     assert!(result.is_err(), "expected error for too few inputs");
     let err = result.unwrap_err().to_string();
     assert!(err.contains("expects 2"), "error should mention input count: {err}");
 
     // Too many inputs.
-    let result = vm.evaluate_query("qy_arity.aleo", "takes_two", vec![
-        Value::from_str("1u64")?,
-        Value::from_str("2u64")?,
-        Value::from_str("3u64")?,
-    ]);
+    let result = vm.evaluate_query_at_height(
+        "qy_arity.aleo",
+        "takes_two",
+        vec![Value::from_str("1u64")?, Value::from_str("2u64")?, Value::from_str("3u64")?],
+        vm.block_store().current_block_height(),
+    );
     assert!(result.is_err(), "expected error for too many inputs");
 
     Ok(())
 }
 
 /// Calling a query that does not exist on a deployed program returns a "not defined" error.
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_unknown_query() -> Result<()> {
     let rng = &mut TestRng::default();
@@ -356,18 +399,21 @@ fn test_evaluate_query_unknown_query() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let result = vm.evaluate_query("qy_unknown.aleo", "missing", vec![]);
+    let result =
+        vm.evaluate_query_at_height("qy_unknown.aleo", "missing", vec![], vm.block_store().current_block_height());
     assert!(result.is_err(), "expected error for unknown query");
     Ok(())
 }
 
 /// Calling evaluate_query against a program that was never deployed returns a "no such program" error.
+#[cfg(feature = "history")]
 #[test]
 fn test_evaluate_query_unknown_program() {
     let rng = &mut TestRng::default();
     let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
 
-    let result = vm.evaluate_query("never_deployed.aleo", "anything", vec![]);
+    let result =
+        vm.evaluate_query_at_height("never_deployed.aleo", "anything", vec![], vm.block_store().current_block_height());
     assert!(result.is_err(), "expected error for unknown program");
 }
 

--- a/synthesizer/src/vm/tests/test_v15/queries.rs
+++ b/synthesizer/src/vm/tests/test_v15/queries.rs
@@ -464,3 +464,88 @@ fn test_query_rejects_write_commands_at_parse() {
         assert!(result.is_err(), "expected parse error for query with forbidden command:\n{source}");
     }
 }
+
+/// Tests that a program containing a `query` block is rejected at V14 (since `query` is V15
+/// syntax) and accepted at V15. Without this gate, deploying such a program pre-V15 would
+/// fork: new nodes accept the bytes, old nodes reject the unknown component variant.
+#[test]
+fn test_deploy_query_before_and_at_v15() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    // Start one block before V15 so that after the (rejected) deployment block we are
+    // exactly at V15 and the same program is accepted.
+    let v15_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap();
+    let vm = sample_vm_at_height(v15_height - 1, rng);
+
+    let program = Program::from_str(
+        r"
+program qy_v15_gate.aleo;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+constructor:
+    assert.eq true true;
+
+query fixed_value:
+    add 0u64 1234u64 into r0;
+    output r0 as u64.public;
+",
+    )
+    .unwrap();
+
+    // Deployment before V15 should be aborted.
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0, "Deployment with query before V15 should not be accepted");
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 1, "Deployment with query before V15 should be aborted");
+    vm.add_next_block(&block).unwrap();
+
+    // We should now be at V15.
+    assert_eq!(vm.block_store().current_block_height(), v15_height);
+
+    // Deployment at V15 should succeed.
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1, "Deployment with query at V15 should be accepted");
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 0);
+    vm.add_next_block(&block).unwrap();
+}
+
+/// Tests that a query containing a `string` type is rejected at deploy via the strengthened
+/// `Program::contains_string_type` (which now walks `self.queries`). Without that fix, strings
+/// could sneak in through query inputs/outputs even though they're banned post-V12.
+#[test]
+fn test_deploy_query_with_string_type_rejected() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+
+    let program = Program::from_str(
+        r"
+program qy_string_input.aleo;
+
+function noop:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+constructor:
+    assert.eq true true;
+
+query echo:
+    input r0 as string.public;
+    add 0u64 0u64 into r1;
+    output r0 as string.public;
+",
+    )
+    .unwrap();
+
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0, "Deployment with string-typed query input should be rejected");
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
+}

--- a/synthesizer/src/vm/tests/test_v15/queries.rs
+++ b/synthesizer/src/vm/tests/test_v15/queries.rs
@@ -82,8 +82,9 @@ fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // Read against an untouched mapping should return the default (0).
-    let outputs =
+    let (height, outputs) =
         vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
+    assert_eq!(height, vm.block_store().current_block_height());
     assert_eq!(expect_u64(&outputs), 0);
 
     // Execute increment(addr, 10).
@@ -92,8 +93,9 @@ fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
 
     // Read should now reflect the finalize-set value.
-    let outputs =
+    let (height, outputs) =
         vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
+    assert_eq!(height, vm.block_store().current_block_height());
     assert_eq!(expect_u64(&outputs), 10);
 
     // Increment again by 32. New total: 42.
@@ -101,8 +103,9 @@ fn test_evaluate_query_reflects_finalize_state() -> Result<()> {
     let tx = vm.execute(&caller_private_key, ("qy_lifecycle.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
 
-    let outputs =
+    let (height, outputs) =
         vm.evaluate_query("qy_lifecycle.aleo", "total_balance", vec![Value::from_str(&caller_address.to_string())?])?;
+    assert_eq!(height, vm.block_store().current_block_height());
     assert_eq!(expect_u64(&outputs), 42);
 
     Ok(())
@@ -145,7 +148,7 @@ fn test_evaluate_query_multi_output() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs =
+    let (_, outputs) =
         vm.evaluate_query("qy_multi_output.aleo", "summary", vec![Value::from_str(&caller_address.to_string())?])?;
 
     // Default 0u64 for the unknown key, then +1 and *2.
@@ -189,7 +192,7 @@ fn test_evaluate_query_multi_input() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs = vm.evaluate_query("qy_multi_in.aleo", "add3", vec![
+    let (_, outputs) = vm.evaluate_query("qy_multi_in.aleo", "add3", vec![
         Value::from_str("10u64")?,
         Value::from_str("20u64")?,
         Value::from_str("12u64")?,
@@ -236,11 +239,11 @@ fn test_evaluate_query_with_branch() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // r0 = 0: branch is taken, doubling is skipped.
-    let outputs = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("0u64")?])?;
+    let (_, outputs) = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("0u64")?])?;
     assert_eq!(expect_u64(&outputs), 10);
 
     // r0 = 5: branch is NOT taken, the unused r2 destination is written but we still output r1.
-    let outputs = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("5u64")?])?;
+    let (_, outputs) = vm.evaluate_query("qy_branch.aleo", "maybe_extra", vec![Value::from_str("5u64")?])?;
     assert_eq!(expect_u64(&outputs), 15);
     Ok(())
 }
@@ -273,7 +276,7 @@ fn test_evaluate_query_zero_inputs() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs = vm.evaluate_query("qy_zeroin.aleo", "fixed_value", vec![])?;
+    let (_, outputs) = vm.evaluate_query("qy_zeroin.aleo", "fixed_value", vec![])?;
     assert_eq!(expect_u64(&outputs), 1234);
     Ok(())
 }

--- a/synthesizer/src/vm/tests/test_v15/restricted_keywords.rs
+++ b/synthesizer/src/vm/tests/test_v15/restricted_keywords.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+/// Tests that "query" cannot be used as a function name at V15.
+#[test]
+fn test_restricted_keyword_query_function_name() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+
+    let program = Program::from_str(
+        r"
+program query_function_test.aleo;
+
+function query:
+    input r0 as u64.private;
+    output r0 as u64.private;
+",
+    )
+    .unwrap();
+
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
+}
+
+/// Tests that "query" cannot be used as a struct name at V15.
+#[test]
+fn test_restricted_keyword_query_struct_name() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+
+    let program = Program::from_str(
+        r"
+program query_struct_test.aleo;
+
+struct query:
+    amount as u64;
+
+function test:
+    input r0 as u64.private;
+    cast r0 into r1 as query;
+    output r1 as query.private;
+",
+    )
+    .unwrap();
+
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
+}
+
+/// Tests that "query" cannot be used as a mapping name at V15.
+#[test]
+fn test_restricted_keyword_query_mapping_name() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+
+    let program = Program::from_str(
+        r"
+program query_mapping_test.aleo;
+
+mapping query:
+    key as address.public;
+    value as u64.public;
+
+function test:
+    input r0 as u64.private;
+    output r0 as u64.private;
+",
+    )
+    .unwrap();
+
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
+}
+
+/// Tests that "query" cannot be used as a record name at V15.
+#[test]
+fn test_restricted_keyword_query_record_name() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+
+    let program = Program::from_str(
+        r"
+program query_record_test.aleo;
+
+record query:
+    owner as address.private;
+    amount as u64.private;
+
+function test:
+    input r0 as u64.private;
+    output r0 as u64.private;
+",
+    )
+    .unwrap();
+
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
+}
+
+/// Tests that "query" cannot be used as a program name at V15.
+#[test]
+fn test_restricted_keyword_query_program_name() {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+
+    let program = Program::from_str(
+        r"
+program query.aleo;
+
+function test:
+    input r0 as u64.private;
+    output r0 as u64.private;
+",
+    )
+    .unwrap();
+
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.aborted_transaction_ids().len(), 1);
+}


### PR DESCRIPTION
## Summary

Read-only `query` functions: top-level program components that read finalize-store state and return typed plaintext to external callers. No transactions, no proofs, no state writes.

```aleo
query total_balance:
    input r0 as address.public;
    get.or_use balances[r0] 0u64 into r1;
    output r1 as u64.public;
```

Entry point (gated on `--features history`):

```rust
VM::evaluate_query_at_height(program_id, name, inputs, height) -> Result<Vec<Value>>
```

snarkOS calls this with `current_block_height()` for "latest" semantics, or any earlier height for historic queries.

## What's enforced

- **Read-only.** `add_command` rejects `set` / `remove` / `async` / `await` / `call` / `rand.chacha` / record-touching ops. The runtime adapter (`HistoricFinalizeStore`) additionally bails on every write entry point.
- **Plaintext-only.** Inputs and outputs reject records, futures, dynamic records, and dynamic futures.
- **Externally-callable only.** Programs cannot `call` queries; the only entry is `VM::evaluate_query_at_height` (or `Process::evaluate_query_at_height`).
- **Off-consensus.** Each call runs on the receiving node in response to an API request. Not part of block production / transaction execution; no fee paid.
- **Deploy-time bound.** Per-query worst-case compute is checked against `TRANSACTION_SPEND_LIMIT` so a deployer can't register a pathological query.

## Snapshot semantics, no contention

Mapping reads route through `FinalizeStore::get_historical_mapping_value`, which reads the per-key historical update map (entries at any given height are immutable once written). All reads in a query body are therefore pinned to the requested `height` — block production advancing past `height` mid-evaluation cannot disturb the result.

The `FinalizeGlobalState` is reconstructed from the actual block at `height` (round, timestamp, cumulative weights, previous hash), so `block.height`, `block.timestamp`, `random_seed`, etc. all see real values.

The query path does **not** take `Process::lock()` — it would serialize queries against block production. We rely on the immutability of historic-table entries instead. (Note: `Stack` itself has interior mutability around register-type caches, so a concurrent redeploy/upgrade of the same program could in principle perturb the structural side of a running query; this is documented as a known gap and a candidate for follow-up via a `StackSnapshot`-style fix.)

## Consensus gating (V15)

- New on-disk program component variant `6` (queries).
- `Program::contains_v15_syntax` flags programs with query blocks → pre-V15 deployments are rejected with a clear error (closes the variant-6 fork hazard).
- `query` is a V15 `RESTRICTED_KEYWORDS` entry (legacy programs that used `query` as an identifier still parse / deploy).
- New `Network::MAX_QUERIES` constant (numerically equal to `MAX_CLOSURES`).
- Symmetry walks (`contains_string_type`, `contains_external_struct`, `exceeds_max_array_size`) updated to iterate queries.
- `FinalizeRegistersState`'s `transition_id` and `nonce` are `Option`-typed; the query path passes `None`. Existing readers (`rand.chacha`, finalize await) bail explicitly when absent.

## `--features history` is required at runtime

The query module (`synthesizer/process/src/query.rs`) is itself `#[cfg(feature = "history")]` — without the feature, programs with query blocks can be parsed and deployed (so deployment validation still works), but queries cannot be evaluated. snarkOS production builds enable `--features history`. CI runs the relevant test partitions with `--features test,history` so the evaluation path is exercised.

## Known limitations

- Queries cannot call other queries, closures, or functions (queries are leaves; `is_call` is rejected at construction).
- No per-call runtime cost cap below the deploy bound — rate-limiting is expected at the snarkOS RPC layer.
- **Stack interior-mutability gap** (noted above): a concurrent redeploy of the same program could perturb structural state of a running query. Follow-up via a `StackSnapshot`-style fix.

## Tests

- End-to-end (`synthesizer/src/vm/tests/test_v15/queries.rs`): lifecycle, multi-input/output, branching, arity/unknown-program/unknown-query/type-mismatch, V14-rejected vs V15-accepted, string-typed input rejected, parse-time forbidden-command rejection. Evaluation tests are gated `#[cfg(feature = "history")]`.
- Restricted keyword (`synthesizer/src/vm/tests/test_v15/restricted_keywords.rs`): `query` rejected as program/function/struct/mapping/record name at V15.
- Process-level (`synthesizer/process/src/query.rs::tests`, gated): simple eval, default-fallback, uninitialized mapping, `block.timestamp` reads work, non-plaintext input rejected, pending-write isolation, historic-at-height returns the value applicable at that height.
- Program-level (`synthesizer/program/src/query/{mod,parse,input/parse,output/parse}.rs::tests`): construction bans, parse positive/negative, duplicate-name + name-collision rejections.