### PR TITLE
Consolidate Slipstream Plugin dep into main snarkVM crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,6 +3178,8 @@ dependencies = [
  "snarkvm-ledger",
  "snarkvm-metrics",
  "snarkvm-parameters",
+ "snarkvm-slipstream-plugin-interface",
+ "snarkvm-slipstream-plugin-manager",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
  "snarkvm-wasm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ async = [ "snarkvm-ledger/async", "snarkvm-synthesizer/async" ]
 cuda = [ "snarkvm-algorithms/cuda" ]
 history = [ "snarkvm-synthesizer/history" ]
 history-staking-rewards = [ "snarkvm-synthesizer/history-staking-rewards" ]
-slipstream-plugins = [ "snarkvm-synthesizer/slipstream-plugins" ]
+slipstream-plugins = [ "snarkvm-synthesizer/slipstream-plugins", "dep:snarkvm-slipstream-plugin-interface", "dep:snarkvm-slipstream-plugin-manager" ]
 parameters_no_std_out = [ "snarkvm-parameters/no_std_out" ]
 locktick = [
   "snarkvm-console?/locktick",
@@ -592,6 +592,14 @@ workspace = true
 optional = true
 
 [dependencies.snarkvm-parameters]
+workspace = true
+optional = true
+
+[dependencies.snarkvm-slipstream-plugin-interface]
+workspace = true
+optional = true
+
+[dependencies.snarkvm-slipstream-plugin-manager]
 workspace = true
 optional = true
 

--- a/vm/lib.rs
+++ b/vm/lib.rs
@@ -44,6 +44,10 @@ pub use snarkvm_synthesizer as synthesizer;
 pub use snarkvm_utilities as utilities;
 #[cfg(feature = "wasm")]
 pub use snarkvm_wasm as wasm;
+#[cfg(feature = "slipstream-plugins")]
+pub use snarkvm_slipstream_plugin_interface as slipstream_plugin_interface;
+#[cfg(feature = "slipstream-plugins")]
+pub use snarkvm_slipstream_plugin_manager as slipstream_plugin_manager;
 
 pub mod prelude {
     #[cfg(feature = "console")]


### PR DESCRIPTION
Previously, we had the slipstream plugin manager and interface as standalone crates for two main reasons:

1. Dependency weight. The plugin manager pulls in libloading (dynamic library loading), which is a non-trivial OS-level dependency. Any consumer that did use snarkvm would transitively compile it, even if they had no interest in plugins. For validators and provers that just want the VM, this is pure waste.
2. Conceptual separation. The plugin system is an operational concern (streaming chain state to external sinks) rather than a
  consensus or proof-generation concern. Keeping it out of the main facade made that boundary explicit: snarkVM is a ZK VM; the plugin infrastructure is a separate layer that happens to live in the same repo. 

However, in order to maintain simplicity and cleanliness, we pulled those crates under the main snarkVM umbrella and made them optional and feature-gated