### PR TITLE
Enable feature to skip download for large SRS params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ history = [ "snarkvm-synthesizer/history" ]
 history-staking-rewards = [ "snarkvm-synthesizer/history-staking-rewards" ]
 slipstream-plugins = [ "snarkvm-synthesizer/slipstream-plugins", "dep:snarkvm-slipstream-plugin-interface", "dep:snarkvm-slipstream-plugin-manager" ]
 parameters_no_std_out = [ "snarkvm-parameters/no_std_out" ]
+skip-srs-embed = [ "snarkvm-parameters/skip-srs-embed" ]
 locktick = [
   "snarkvm-console?/locktick",
   "snarkvm-algorithms?/locktick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ history = [ "snarkvm-synthesizer/history" ]
 history-staking-rewards = [ "snarkvm-synthesizer/history-staking-rewards" ]
 slipstream-plugins = [ "snarkvm-synthesizer/slipstream-plugins", "dep:snarkvm-slipstream-plugin-interface", "dep:snarkvm-slipstream-plugin-manager" ]
 parameters_no_std_out = [ "snarkvm-parameters/no_std_out" ]
-skip-srs-embed = [ "snarkvm-parameters/skip-srs-embed" ]
+no-embedded-srs = [ "snarkvm-parameters/no-embedded-srs" ]
 locktick = [
   "snarkvm-console?/locktick",
   "snarkvm-algorithms?/locktick",

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -29,6 +29,7 @@ large_params = []
 locktick = ["dep:locktick"]
 no_std_out = []
 rocks = ["snarkvm-ledger-store/rocks"]
+skip-srs-embed = []
 wasm = ["encoding", "js-sys", "web-sys"]
 dev-print = ["snarkvm-utilities/dev-print"]
 

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -29,7 +29,7 @@ large_params = []
 locktick = ["dep:locktick"]
 no_std_out = []
 rocks = ["snarkvm-ledger-store/rocks"]
-skip-srs-embed = []
+no-embedded-srs = []
 wasm = ["encoding", "js-sys", "web-sys"]
 dev-print = ["snarkvm-utilities/dev-print"]
 

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -26,9 +26,9 @@ const REMOTE_URLS: [&str; 2] =
     ["https://parameters.provable.com/mainnet", "https://s3.us-west-1.amazonaws.com/mainnet.parameters"];
 
 // Degrees
-#[cfg(not(feature = "skip-srs-embed"))]
+#[cfg(not(feature = "no-embedded-srs"))]
 impl_local!(Degree15, "resources/", "powers-of-beta-15", "usrs");
-#[cfg(feature = "skip-srs-embed")]
+#[cfg(feature = "no-embedded-srs")]
 impl_remote!(Degree15, REMOTE_URLS, "resources/", "powers-of-beta-15", "usrs");
 impl_remote!(Degree16, REMOTE_URLS, "resources/", "powers-of-beta-16", "usrs");
 impl_remote!(Degree17, REMOTE_URLS, "resources/", "powers-of-beta-17", "usrs");
@@ -53,13 +53,13 @@ impl_remote!(Degree27, REMOTE_URLS, "resources/", "powers-of-beta-27", "usrs");
 impl_remote!(Degree28, REMOTE_URLS, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
-#[cfg(not(feature = "skip-srs-embed"))]
+#[cfg(not(feature = "no-embedded-srs"))]
 impl_local!(ShiftedDegree15, "resources/", "shifted-powers-of-beta-15", "usrs");
-#[cfg(feature = "skip-srs-embed")]
+#[cfg(feature = "no-embedded-srs")]
 impl_remote!(ShiftedDegree15, REMOTE_URLS, "resources/", "shifted-powers-of-beta-15", "usrs");
-#[cfg(not(feature = "skip-srs-embed"))]
+#[cfg(not(feature = "no-embedded-srs"))]
 impl_local!(ShiftedDegree16, "resources/", "shifted-powers-of-beta-16", "usrs");
-#[cfg(feature = "skip-srs-embed")]
+#[cfg(feature = "no-embedded-srs")]
 impl_remote!(ShiftedDegree16, REMOTE_URLS, "resources/", "shifted-powers-of-beta-16", "usrs");
 impl_remote!(ShiftedDegree17, REMOTE_URLS, "resources/", "shifted-powers-of-beta-17", "usrs");
 impl_remote!(ShiftedDegree18, REMOTE_URLS, "resources/", "shifted-powers-of-beta-18", "usrs");

--- a/parameters/src/mainnet/mod.rs
+++ b/parameters/src/mainnet/mod.rs
@@ -26,7 +26,10 @@ const REMOTE_URLS: [&str; 2] =
     ["https://parameters.provable.com/mainnet", "https://s3.us-west-1.amazonaws.com/mainnet.parameters"];
 
 // Degrees
+#[cfg(not(feature = "skip-srs-embed"))]
 impl_local!(Degree15, "resources/", "powers-of-beta-15", "usrs");
+#[cfg(feature = "skip-srs-embed")]
+impl_remote!(Degree15, REMOTE_URLS, "resources/", "powers-of-beta-15", "usrs");
 impl_remote!(Degree16, REMOTE_URLS, "resources/", "powers-of-beta-16", "usrs");
 impl_remote!(Degree17, REMOTE_URLS, "resources/", "powers-of-beta-17", "usrs");
 impl_remote!(Degree18, REMOTE_URLS, "resources/", "powers-of-beta-18", "usrs");
@@ -50,8 +53,14 @@ impl_remote!(Degree27, REMOTE_URLS, "resources/", "powers-of-beta-27", "usrs");
 impl_remote!(Degree28, REMOTE_URLS, "resources/", "powers-of-beta-28", "usrs");
 
 // Shifted Degrees
+#[cfg(not(feature = "skip-srs-embed"))]
 impl_local!(ShiftedDegree15, "resources/", "shifted-powers-of-beta-15", "usrs");
+#[cfg(feature = "skip-srs-embed")]
+impl_remote!(ShiftedDegree15, REMOTE_URLS, "resources/", "shifted-powers-of-beta-15", "usrs");
+#[cfg(not(feature = "skip-srs-embed"))]
 impl_local!(ShiftedDegree16, "resources/", "shifted-powers-of-beta-16", "usrs");
+#[cfg(feature = "skip-srs-embed")]
+impl_remote!(ShiftedDegree16, REMOTE_URLS, "resources/", "shifted-powers-of-beta-16", "usrs");
 impl_remote!(ShiftedDegree17, REMOTE_URLS, "resources/", "shifted-powers-of-beta-17", "usrs");
 impl_remote!(ShiftedDegree18, REMOTE_URLS, "resources/", "shifted-powers-of-beta-18", "usrs");
 impl_remote!(ShiftedDegree19, REMOTE_URLS, "resources/", "shifted-powers-of-beta-19", "usrs");


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR adds a feature that enables users to build snarkVM without including the `Degree15`, `ShiftedDegree15`, and `ShiftedDegree16` SRS params in the build.  Bypassing their inclusion reduces the build size from ~ 12 MB to under 3 MB.

## Documentation

Users can enable this feature in their `Cargo.toml` as follows:
```TOML
[dependencies]
snarkvm = { version = "4.6.0", features = ["no-embedded-srs"] }
```

```TOML
[dependencies]
snarkvm-parameters = { version = "4.6.0", features = ["no-embedded-srs"] }
```