### PR TITLE
Ensure awaits.len() == futures.len() - 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1289,7 +1289,7 @@ workflows:
       or pipeline.git.branch == "canary"
       or pipeline.git.branch == "testnet"
       or pipeline.git.branch == "mainnet"
-      or pipeline.git.branch == "copilot/adjust-transaction-cache-key"
+      or pipeline.git.branch == "ensure_finalize_scopes_match"
     jobs:
       - check-unused-dependencies # This can be cleaned up before releases
       - check-cargo-semver-checks # This can be cleaned up before releases

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -299,8 +299,10 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
             // Check that the total number of `Await` commands evaluated during
             // finalization matches the number of `Future`s defined in the
             // execution's transitions' outputs.
-            let total_futures =
-                execution.transitions().filter(|t| t.outputs().iter().any(|o| o.future().is_some())).count();
+            let total_futures = execution
+                .transitions()
+                .filter(|t| t.outputs().last().and_then(|output| output.future()).is_some())
+                .count();
             let expected_total_awaits = total_futures.saturating_sub(1);
             if total_awaits != expected_total_awaits {
                 indexed_finalize_bail!(
@@ -377,9 +379,17 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
         false => HashMap::new(),
     };
 
-    // Finalize the transition. The fee path has no awaits, so the total_awaits count is unused here.
-    let (finalize_operations, _total_awaits) =
+    // Finalize the transition.
+    let (finalize_operations, total_awaits) =
         finalize_transition(state, store, stack, fee, call_graph, Default::default())?;
+    // Create IndexedFinalizeError if the fee path has awaits.
+    if total_awaits != 0 {
+        indexed_finalize_bail!(
+            Some((*fee.program_id(), *stack.program_edition())),
+            Some(*fee.function_name()),
+            "Fees must not have any awaits"
+        );
+    }
     Ok(finalize_operations)
 }
 

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -21,6 +21,8 @@ use snarkvm_utilities::try_vm_runtime;
 
 use std::collections::HashSet;
 
+type TotalAwaits = usize;
+
 impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
     /// Finalizes the deployment and fee.
     /// This method assumes the given deployment **is valid**.
@@ -291,8 +293,23 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
             // Finalize the root transition.
             // Note that this will result in all the remaining transitions being finalized, since the number
             // of calls matches the number of transitions.
-            let mut finalize_operations =
+            let (mut finalize_operations, total_awaits) =
                 finalize_transition(state, store, &stack, transition, call_graph, dynamic_future_to_future)?;
+
+            // Check that the total number of `Await` commands evaluated during
+            // finalization matches the number of `Future`s defined in the
+            // execution's transitions' outputs.
+            let total_futures =
+                execution.transitions().filter(|t| t.outputs().iter().any(|o| o.future().is_some())).count();
+            let expected_total_awaits = total_futures.saturating_sub(1);
+            if total_awaits != expected_total_awaits {
+                indexed_finalize_bail!(
+                    Some((transition_program_id, *stack.program_edition())),
+                    Some(transition_function_name),
+                    "The number of 'await' calls during finalization is incorrect. \
+                    Expected {expected_total_awaits}, but found {total_awaits}"
+                );
+            }
 
             /* Finalize the fee. */
             if let Some(fee) = fee {
@@ -360,8 +377,10 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
         false => HashMap::new(),
     };
 
-    // Finalize the transition.
-    finalize_transition(state, store, stack, fee, call_graph, Default::default())
+    // Finalize the transition. The fee path has no awaits, so the total_awaits count is unused here.
+    let (finalize_operations, _total_awaits) =
+        finalize_transition(state, store, stack, fee, call_graph, Default::default())?;
+    Ok(finalize_operations)
 }
 
 /// Finalizes the constructor.
@@ -453,7 +472,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
     transition: &Transition<N>,
     call_graph: HashMap<N::TransitionID, Vec<N::TransitionID>>,
     dynamic_future_to_future: HashMap<(Field<N>, Field<N>, Field<N>, Field<N>), &Future<N>>,
-) -> Result<Vec<FinalizeOperation<N>>, IndexedFinalizeError<N, Command<N>>> {
+) -> Result<(Vec<FinalizeOperation<N>>, TotalAwaits), IndexedFinalizeError<N, Command<N>>> {
     // Retrieve the program ID.
     let program_id = transition.program_id();
     // Retrieve the function name.
@@ -465,7 +484,7 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
     // If the last output of the transition is a future, retrieve and finalize it. Otherwise, there are no operations to finalize.
     let future = match transition.outputs().last().and_then(|output| output.future()) {
         Some(future) => future,
-        _ => return Ok(Vec::new()),
+        _ => return Ok((Vec::new(), 0)),
     };
 
     // Check that the program ID and function name of the transition match those in the future.
@@ -495,6 +514,9 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
         Some(*function_name),
         None::<(usize, Command<N>)>,
     )?);
+
+    // Track the total number of `Await` commands evaluated across all `FinalizeState`s.
+    let mut total_awaits: TotalAwaits = 0;
 
     // While there are active finalize states, finalize them.
     'outer: while let Some(FinalizeState { mut counter, mut registers, stack, mut call_counter, mut awaited }) =
@@ -622,6 +644,8 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
 
                     // Increment the call counter.
                     call_counter += 1;
+                    // Increment the total number of `Await` commands evaluated.
+                    total_awaits += 1;
                     // Increment the counter.
                     counter += 1;
                     // Add the awaited register to the tracked set.
@@ -670,8 +694,8 @@ fn finalize_transition<N: Network, P: FinalizeStorage<N>>(
         }
     }
 
-    // Return the finalize operations.
-    Ok(finalize_operations)
+    // Return the finalize operations and the total number of `Await` commands evaluated.
+    Ok((finalize_operations, total_awaits))
 }
 
 // A helper struct to track the execution of a finalize scope.


### PR DESCRIPTION
## Motivation

As a result of an earlier bug report, thought of adding this defense in depth check.

While adding this, also took a full day to research soundness of Dynamic Future handling, and could not find any issues.

## Test Plan /  Backwards compatibility

Besides CI, a sync test could reveal whether this invariant was hypothetically broken in the wild. Because it operates on stateful finalize scope, we can't easily test this in parallel, so I'll just batch it up into our regular E2E sync testing before the next release.