### PR TITLE
Fix timestamp sampling

### DIFF
--- a/ledger/narwhal/batch-header/src/lib.rs
+++ b/ledger/narwhal/batch-header/src/lib.rs
@@ -278,6 +278,7 @@ pub mod test_helpers {
         network::MainnetV0,
         prelude::{TestRng, Uniform},
     };
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     type CurrentNetwork = MainnetV0;
 
@@ -324,8 +325,9 @@ pub mod test_helpers {
         let transmission_ids = snarkvm_ledger_narwhal_transmission_id::test_helpers::sample_transmission_ids(rng)
             .into_iter()
             .collect::<IndexSet<_>>();
-        // Derive the timestamp from the RNG so sample data is reproducible for a fixed seed.
-        let timestamp = i64::rand(rng);
+        // The timestamp needs to be current to pass integration tests.
+        let timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("System time before UNIX epoch").as_secs() as i64;
         // Return the batch header.
         BatchHeader::new(private_key, round, timestamp, committee_id, transmission_ids, previous_certificate_ids, rng)
             .unwrap()


### PR DESCRIPTION
## Motivation

Fix a regression breaking snarkOS CI introduced by https://github.com/ProvableHQ/snarkVM/pull/3255

AI opted for a new library to prevent adding a dependency.
