### PR TITLE
Await testing backwards compatibility

### DIFF
--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -296,21 +296,23 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
             let (mut finalize_operations, total_awaits) =
                 finalize_transition(state, store, &stack, transition, call_graph, dynamic_future_to_future)?;
 
-            // Check that the total number of `Await` commands evaluated during
-            // finalization matches the number of `Future`s defined in the
-            // execution's transitions' outputs.
-            let total_futures = execution
-                .transitions()
-                .filter(|t| t.outputs().last().and_then(|output| output.future()).is_some())
-                .count();
-            let expected_total_awaits = total_futures.saturating_sub(1);
-            if total_awaits != expected_total_awaits {
-                indexed_finalize_bail!(
-                    Some((transition_program_id, *stack.program_edition())),
-                    Some(transition_function_name),
-                    "The number of 'await' calls during finalization is incorrect. \
-                    Expected {expected_total_awaits}, but found {total_awaits}"
-                );
+            if consensus_version >= ConsensusVersion::V15 {
+                // Check that the total number of `Await` commands evaluated during
+                // finalization matches the number of `Future`s defined in the
+                // execution's transitions' outputs.
+                let total_futures = execution
+                    .transitions()
+                    .filter(|t| t.outputs().last().and_then(|output| output.future()).is_some())
+                    .count();
+                let expected_total_awaits = total_futures.saturating_sub(1);
+                if total_awaits != expected_total_awaits {
+                    indexed_finalize_bail!(
+                        Some((transition_program_id, *stack.program_edition())),
+                        Some(transition_function_name),
+                        "The number of 'await' calls during finalization is incorrect. \
+                        Expected {expected_total_awaits}, but found {total_awaits}"
+                    );
+                }
             }
 
             /* Finalize the fee. */

--- a/synthesizer/process/src/finalize.rs
+++ b/synthesizer/process/src/finalize.rs
@@ -385,7 +385,7 @@ fn finalize_fee_transition<N: Network, P: FinalizeStorage<N>>(
     let (finalize_operations, total_awaits) =
         finalize_transition(state, store, stack, fee, call_graph, Default::default())?;
     // Create IndexedFinalizeError if the fee path has awaits.
-    if total_awaits != 0 {
+    if consensus_version >= ConsensusVersion::V15 && total_awaits != 0 {
         indexed_finalize_bail!(
             Some((*fee.program_id(), *stack.program_edition())),
             Some(*fee.function_name()),

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -162,9 +162,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Ensure the transactions after speculation match.
         let confirmed_transactions = confirmed_transactions.into_iter().collect();
         if transactions != &confirmed_transactions {
-            let confirmed_transaction_ids = confirmed_transactions.transaction_ids().collect::<Vec<_>>();
+            let confirmed_transaction_ids =
+                confirmed_transactions.transaction_ids().map(|id| id.to_string()).collect::<Vec<_>>();
             bail!(
-                "The transactions after speculation do not match the transactions in the block. IDs: {confirmed_transaction_ids:?} - Transactions:{transactions:?}"
+                "The transactions after speculation do not match the transactions in the block. IDs: {confirmed_transaction_ids:?} - Transactions:{transactions:?} - confirmed_transactions:{confirmed_transactions:?}"
             );
         }
         // Ensure there are no aborted transaction IDs from this speculation.


### PR DESCRIPTION
## Motivation

You were right @mohammadfawaz - ran an E2E sync test and ran into a halt because the total_awaits invariant was violated on testnet for testing/exposition reasons. Now only enabling it from `ConsensusVersion::V15` onwards and will try running it against mainnet without the consensus guard.