### PR TITLE
chore(deps): bump rocksdb to 0.24 to fix GCC 13+ musl builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,3 @@ rustflags = [
     "-C", "link-arg=-fuse-ld=lld",
     "-C", "target-cpu=native"
 ]
-
-[env]
-CXXFLAGS = "-include cstdint" #TODO: remove once RocksDB 0.24 is released

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
           command: |
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends \
-              clang llvm-dev llvm lld pkg-config xz-utils make libssl-dev libssl-dev
+              clang libclang-dev llvm-dev llvm lld pkg-config xz-utils make libssl-dev
       - restore_cache:
           keys:
             - v4.7.1-rust-1.88.0-deps-{{ checksum "Cargo.lock" }}-
@@ -195,7 +195,7 @@ commands:
           command: |
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends \
-              clang llvm-dev llvm lld pkg-config xz-utils make libssl-dev
+              clang libclang-dev llvm-dev llvm lld pkg-config xz-utils make libssl-dev
 
       - run:
           name: "No-cache mode: clean + disable sccache"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,21 +284,18 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "prettyplease",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote 1.0.45",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
 ]
@@ -317,12 +314,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -511,7 +502,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1828,12 +1818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,14 +1856,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -2164,7 +2147,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2229,12 +2212,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2391,7 +2368,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand 0.8.6",
@@ -2420,7 +2397,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2441,7 +2418,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2632,7 +2609,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2741,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -2754,12 +2731,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2803,7 +2774,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2816,7 +2787,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2980,7 +2951,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4629,7 +4600,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -5052,7 +5023,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -5383,7 +5354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -99,7 +99,7 @@ workspace = true
 workspace = true
 
 [dependencies.rocksdb]
-version = "0.21"
+version = "0.24"
 default-features = false
 features = [ "lz4" ]
 optional = true


### PR DESCRIPTION
## Motivation

`snarkvm-ledger-store` pins `rocksdb = "0.21"`, which transitively pulls `librocksdb-sys 0.11.0+8.1.1` (bundled RocksDB 8.1.1). That bundled RocksDB predates GCC 13's removal of the transitive `<cstdint>` include from `<bits/stdc++.h>`, so any downstream consumer building under GCC ≥ 13 (notably `blackdex/rust-musl:x86_64-musl-stable`) fails during the bundled RocksDB C++ build with:

```
error: 'uint8_t' was not declared in this scope
error: 'uint64_t' was not declared in this scope
```

This currently breaks `leo-lang`'s musl release workflow ([ProvableHQ/leo#29462](https://github.com/ProvableHQ/leo/issues/29462)), which carries a per-job `TARGET_CXXFLAGS="$TARGET_CXXFLAGS -include cstdint"` workaround pending an upstream fix.

snarkVM itself has carried the same workaround unconditionally in `.cargo/config.toml` with a `#TODO: remove once RocksDB 0.24 is released` marker. `rocksdb 0.24.0` (2025-08-10) ships `librocksdb-sys 0.17.3+10.4.2` with upstream RocksDB's GCC 13+ and GCC 15 fixes, so the TODO is now actionable.

## Changes

- Bump `rocksdb` from `0.21` to `0.24` in `ledger/store/Cargo.toml`.
- Remove the `CXXFLAGS = "-include cstdint"` block from `.cargo/config.toml` (the TODO already named 0.24 as the trigger).
- Regenerate `Cargo.lock`: `rocksdb 0.21.0 → 0.24.0`, `librocksdb-sys 0.11.0+8.1.1 → 0.17.3+10.4.2`, `bindgen 0.65.1 → 0.72.1`, and drops `bitflags 1.x` / `lazycell` / `peeking_take_while` / old `rustc-hash` / `librocksdb-sys`'s `glob` dep from the build-deps graph.

## Related

- Closes #3246 (the GCC 13+ angle; the `bindgen-static` for musl angle in that issue is left for #3247 to land on top of this bump if the author still wants it).
- Supersedes #2858 (Dependabot 0.21 → 0.24, auto-closed without a technical objection).
- Unblocks the `TARGET_CXXFLAGS="$TARGET_CXXFLAGS -include cstdint"` workaround in `leo-lang`'s `.github/workflows/release-crate.yml` ([ProvableHQ/leo#29462](https://github.com/ProvableHQ/leo/issues/29462)).