### PR TITLE
Future-proof `Scalar` conversion to bits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1290,6 +1290,7 @@ workflows:
       or pipeline.git.branch == "testnet"
       or pipeline.git.branch == "mainnet"
       or pipeline.git.branch == "ensure_finalize_scopes_match"
+      or pipeline.git.branch == "scalar_conversion"
     jobs:
       - check-unused-dependencies # This can be cleaned up before releases
       - check-cargo-semver-checks # This can be cleaned up before releases

--- a/circuit/environment/src/canary_circuit.rs
+++ b/circuit/environment/src/canary_circuit.rs
@@ -286,8 +286,9 @@ impl Environment for CanaryCircuit {
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
-        // Clear the unconverted-scalars diagnostic.
-        Self::clear_unconverted_scalars();
+        // Ensure all Scalars have been converted to bits.
+        Self::check_unconverted_values().unwrap();
+
         CANARY_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -310,9 +311,9 @@ impl Environment for CanaryCircuit {
 
     /// Returns the R1CS assignment of the circuit, resetting the circuit.
     fn eject_assignment_and_reset() -> Assignment<<Self::Network as console::Environment>::Field> {
-        // Report and clear the unconverted-scalars diagnostic at the end of synthesis.
-        Self::check_unconverted_scalars();
-        Self::clear_unconverted_scalars();
+        // Ensure all Scalars have been converted to bits.
+        Self::check_unconverted_values().unwrap();
+
         CANARY_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -334,8 +335,9 @@ impl Environment for CanaryCircuit {
 
     /// Clears the circuit and initializes an empty environment.
     fn reset() {
-        // Clear the unconverted-scalars diagnostic.
-        Self::clear_unconverted_scalars();
+        // Clear the unconverted-values tracking set.
+        Self::clear_unconverted_values();
+
         CANARY_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -350,6 +352,8 @@ impl Environment for CanaryCircuit {
             assert_eq!(0, circuit.borrow().num_private());
             assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
+            // Ensure the unconverted-value tracking set is empty.
+            assert!(Self::check_unconverted_values().is_ok());
         });
     }
 }

--- a/circuit/environment/src/canary_circuit.rs
+++ b/circuit/environment/src/canary_circuit.rs
@@ -286,6 +286,8 @@ impl Environment for CanaryCircuit {
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+        // Clear the unconverted-scalars diagnostic.
+        Self::clear_unconverted_scalars();
         CANARY_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -308,6 +310,9 @@ impl Environment for CanaryCircuit {
 
     /// Returns the R1CS assignment of the circuit, resetting the circuit.
     fn eject_assignment_and_reset() -> Assignment<<Self::Network as console::Environment>::Field> {
+        // Report and clear the unconverted-scalars diagnostic at the end of synthesis.
+        Self::check_unconverted_scalars();
+        Self::clear_unconverted_scalars();
         CANARY_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -329,6 +334,8 @@ impl Environment for CanaryCircuit {
 
     /// Clears the circuit and initializes an empty environment.
     fn reset() {
+        // Clear the unconverted-scalars diagnostic.
+        Self::clear_unconverted_scalars();
         CANARY_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -310,6 +310,8 @@ impl Environment for Circuit {
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+        // Clear the unconverted-scalars diagnostic.
+        Self::clear_unconverted_scalars();
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -332,6 +334,9 @@ impl Environment for Circuit {
 
     /// Returns the R1CS assignment of the circuit, resetting the circuit.
     fn eject_assignment_and_reset() -> Assignment<<Self::Network as console::Environment>::Field> {
+        // Report and clear the unconverted-scalars diagnostic at the end of synthesis.
+        Self::check_unconverted_scalars();
+        Self::clear_unconverted_scalars();
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -353,6 +358,8 @@ impl Environment for Circuit {
 
     /// Clears the circuit and initializes an empty environment.
     fn reset() {
+        // Clear the unconverted-scalars diagnostic.
+        Self::clear_unconverted_scalars();
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -310,8 +310,9 @@ impl Environment for Circuit {
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
-        // Clear the unconverted-scalars diagnostic.
-        Self::clear_unconverted_scalars();
+        // Ensure all Scalars have been converted to bits.
+        Self::check_unconverted_values().unwrap();
+
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -334,9 +335,9 @@ impl Environment for Circuit {
 
     /// Returns the R1CS assignment of the circuit, resetting the circuit.
     fn eject_assignment_and_reset() -> Assignment<<Self::Network as console::Environment>::Field> {
-        // Report and clear the unconverted-scalars diagnostic at the end of synthesis.
-        Self::check_unconverted_scalars();
-        Self::clear_unconverted_scalars();
+        // Ensure all Scalars have been converted to bits.
+        Self::check_unconverted_values().unwrap();
+
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -358,8 +359,9 @@ impl Environment for Circuit {
 
     /// Clears the circuit and initializes an empty environment.
     fn reset() {
-        // Clear the unconverted-scalars diagnostic.
-        Self::clear_unconverted_scalars();
+        // Clear the unconverted-values tracking set.
+        Self::clear_unconverted_values();
+
         CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -374,6 +376,8 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_private());
             assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
+            // Ensure the unconverted-value tracking set is empty.
+            assert!(Self::check_unconverted_values().is_ok());
         });
     }
 }

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -18,19 +18,22 @@ use snarkvm_curves::AffineCurve;
 use snarkvm_fields::traits::*;
 
 use core::{fmt, hash};
-use std::{cell::RefCell, collections::HashSet};
+use std::{cell::RefCell, collections::BTreeMap};
+
+use anyhow::Result;
 
 thread_local! {
-    /// Tracks the underlying variables of injected `Scalar`s that have not yet been converted to
-    /// bits (i.e. not yet range-checked). Entries are added in `Scalar::new` and removed when a
-    /// scalar is converted to bits. This is a synthesis-time diagnostic and adds no constraints.
-    static UNCONVERTED_SCALARS: RefCell<HashSet<u64>> = RefCell::new(HashSet::new());
+    /// Stores certain injected values which have not been converted to bits yet, alongside a
+    /// closure that converts each of them to bits.
+    // This gives higher-level crates the ability to track any values which must be converted to
+    // bits before the end of synthesis (e.g. Scalars, which are otherwise never range-checked) and
+    // convert them if they have not been.
+    static UNCONVERTED_VALUES: RefCell<BTreeMap<u64, Box<dyn FnOnce()>>> = RefCell::new(BTreeMap::new());
 }
 
-/// Returns a tracking key for a non-constant variable, or `None` for constants.
-/// Public and private variables share the same relative index space, so the high bit is used to
-/// distinguish private variables.
-fn scalar_tracking_key<F: PrimeField>(variable: &Variable<F>) -> Option<u64> {
+/// Returns a tracking key for a non-constant variable, or `None` for constants. An index shift of
+/// 2^63 is used to distinguish private variables from public ones, as they share the same index space.
+fn value_tracking_key<F: PrimeField>(variable: &Variable<F>) -> Option<u64> {
     const PRIVATE_FLAG: u64 = 1 << 63;
     match variable.mode() {
         Mode::Constant => None,
@@ -194,50 +197,60 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>);
 
-    /// Records the underlying variable(s) of an injected scalar as not-yet-converted-to-bits.
-    fn track_unconverted_scalar(scalar: &LinearCombination<Self::BaseField>) {
-        UNCONVERTED_SCALARS.with(|set| {
-            let mut set = set.borrow_mut();
-            for (variable, _) in scalar.to_terms() {
-                if let Some(key) = scalar_tracking_key(variable) {
-                    set.insert(key);
-                }
-            }
-        });
+    /// Records an injected value which has not been converted to bits yet, alongside a closure
+    /// that converts it to bits.
+    // The main purpose of this function is to track (non-constant) Aleo Scalars in higher-level
+    // crates, whose underlying base-field element is not checked to be in the canonical scalar range
+    // until to_bits is called.
+    fn track_unconverted_value(value: &LinearCombination<Self::BaseField>, convert: Box<dyn FnOnce()>) {
+        if let Some(key) = value.to_terms().iter().find_map(|(variable, _)| value_tracking_key(variable)) {
+            UNCONVERTED_VALUES.with(|set| {
+                set.borrow_mut().insert(key, convert);
+            });
+        }
     }
 
-    /// Removes the underlying variable(s) of a scalar from the not-yet-converted-to-bits set,
-    /// indicating that the scalar has been range-checked via its bit decomposition.
-    fn untrack_unconverted_scalar(scalar: &LinearCombination<Self::BaseField>) {
-        UNCONVERTED_SCALARS.with(|set| {
+    /// Removes a value from the set of unconverted values.
+    fn untrack_unconverted_value(value: &LinearCombination<Self::BaseField>) {
+        UNCONVERTED_VALUES.with(|set| {
             let mut set = set.borrow_mut();
-            for (variable, _) in scalar.to_terms() {
-                if let Some(key) = scalar_tracking_key(variable) {
+            for (variable, _) in value.to_terms() {
+                if let Some(key) = value_tracking_key(variable) {
                     set.remove(&key);
                 }
             }
         });
     }
 
-    /// Prints whether every injected scalar was converted to bits during synthesis.
-    /// Returns `true` if the unconverted-scalars set is empty.
-    fn check_unconverted_scalars() -> bool {
-        UNCONVERTED_SCALARS.with(|set| {
+    /// Returns `Ok` if no unconverted values remain in the tracking set and `Err` otherwise.
+    fn check_unconverted_values() -> Result<(), String> {
+        UNCONVERTED_VALUES.with(|set| {
             let set = set.borrow();
-            match set.is_empty() {
-                true => println!("[unconverted-scalars] OK: every injected scalar was converted to bits."),
-                false => println!(
-                    "[unconverted-scalars] WARNING: {} injected scalar variable(s) were never converted to bits (range-unchecked).",
-                    set.len()
-                ),
+            if set.is_empty() {
+                Ok(())
+            } else {
+                Err(format!("{} unconverted value(s) remain(s) in the tracking set: {:#?}", set.len(), set.keys()))
             }
-            set.is_empty()
         })
     }
 
-    /// Clears the unconverted-scalars set.
-    fn clear_unconverted_scalars() {
-        UNCONVERTED_SCALARS.with(|set| set.borrow_mut().clear());
+    /// Converts every unconverted value to bits by calling the stored closure, adding the
+    /// relevant constraints to the current circuit.
+    fn convert_unconverted_values() {
+        // Take ownership of the closures, releasing the borrow before invoking them: each closure is
+        // a `FnOnce` (so must be consumed by value) and converts a value to bits, which re-enters
+        // `untrack_unconverted_value` and would otherwise conflict with the outstanding borrow.
+        let pending: Vec<Box<dyn FnOnce()>> =
+            UNCONVERTED_VALUES.with(|set| core::mem::take(&mut *set.borrow_mut()).into_values().collect());
+        for convert in pending {
+            convert();
+        }
+    }
+
+    /// Clears the set of unconverted values, dropping the stored conversion closures without
+    /// invoking them. Used when resetting the circuit between syntheses.
+    fn clear_unconverted_values() {
+        UNCONVERTED_VALUES.with(|set| set.borrow_mut().clear());
     }
 
     /// Halts the program from further synthesis, evaluation, and execution in the current environment.

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -18,6 +18,26 @@ use snarkvm_curves::AffineCurve;
 use snarkvm_fields::traits::*;
 
 use core::{fmt, hash};
+use std::{cell::RefCell, collections::HashSet};
+
+thread_local! {
+    /// Tracks the underlying variables of injected `Scalar`s that have not yet been converted to
+    /// bits (i.e. not yet range-checked). Entries are added in `Scalar::new` and removed when a
+    /// scalar is converted to bits. This is a synthesis-time diagnostic and adds no constraints.
+    static UNCONVERTED_SCALARS: RefCell<HashSet<u64>> = RefCell::new(HashSet::new());
+}
+
+/// Returns a tracking key for a non-constant variable, or `None` for constants.
+/// Public and private variables share the same relative index space, so the high bit is used to
+/// distinguish private variables.
+fn scalar_tracking_key<F: PrimeField>(variable: &Variable<F>) -> Option<u64> {
+    const PRIVATE_FLAG: u64 = 1 << 63;
+    match variable.mode() {
+        Mode::Constant => None,
+        Mode::Public => Some(variable.index()),
+        Mode::Private => Some(variable.index() | PRIVATE_FLAG),
+    }
+}
 
 /// Attention: Do not use `Send + Sync` on this trait, as it is not thread-safe.
 pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq + PartialEq + hash::Hash {
@@ -173,6 +193,52 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
 
     /// Sets the constraint limit for the circuit.
     fn set_constraint_limit(limit: Option<u64>);
+
+    /// Records the underlying variable(s) of an injected scalar as not-yet-converted-to-bits.
+    fn track_unconverted_scalar(scalar: &LinearCombination<Self::BaseField>) {
+        UNCONVERTED_SCALARS.with(|set| {
+            let mut set = set.borrow_mut();
+            for (variable, _) in scalar.to_terms() {
+                if let Some(key) = scalar_tracking_key(variable) {
+                    set.insert(key);
+                }
+            }
+        });
+    }
+
+    /// Removes the underlying variable(s) of a scalar from the not-yet-converted-to-bits set,
+    /// indicating that the scalar has been range-checked via its bit decomposition.
+    fn untrack_unconverted_scalar(scalar: &LinearCombination<Self::BaseField>) {
+        UNCONVERTED_SCALARS.with(|set| {
+            let mut set = set.borrow_mut();
+            for (variable, _) in scalar.to_terms() {
+                if let Some(key) = scalar_tracking_key(variable) {
+                    set.remove(&key);
+                }
+            }
+        });
+    }
+
+    /// Prints whether every injected scalar was converted to bits during synthesis.
+    /// Returns `true` if the unconverted-scalars set is empty.
+    fn check_unconverted_scalars() -> bool {
+        UNCONVERTED_SCALARS.with(|set| {
+            let set = set.borrow();
+            match set.is_empty() {
+                true => println!("[unconverted-scalars] OK: every injected scalar was converted to bits."),
+                false => println!(
+                    "[unconverted-scalars] WARNING: {} injected scalar variable(s) were never converted to bits (range-unchecked).",
+                    set.len()
+                ),
+            }
+            set.is_empty()
+        })
+    }
+
+    /// Clears the unconverted-scalars set.
+    fn clear_unconverted_scalars() {
+        UNCONVERTED_SCALARS.with(|set| set.borrow_mut().clear());
+    }
 
     /// Halts the program from further synthesis, evaluation, and execution in the current environment.
     fn halt<S: Into<String>, T>(message: S) -> T {

--- a/circuit/environment/src/helpers/assignment.rs
+++ b/circuit/environment/src/helpers/assignment.rs
@@ -303,9 +303,11 @@ pub fn compare_constraints<F: PrimeField>(assignment_1: &Assignment<F>, assignme
 
 #[cfg(test)]
 mod tests {
+    use console::TestRng;
     use snarkvm_algorithms::{AlgebraicSponge, SNARK, r1cs::ConstraintSynthesizer, snark::varuna::VarunaVersion};
     use snarkvm_circuit::prelude::*;
     use snarkvm_curves::bls12_377::Fr;
+    use snarkvm_utilities::Uniform;
 
     /// Compute 2^EXPONENT - 1, in a purposefully constraint-inefficient manner for testing.
     fn create_example_circuit<E: Environment>() -> Field<E> {
@@ -395,5 +397,68 @@ mod tests {
             !VarunaInst::verify(universal_verifier, &fs_pp, &index_vk, varuna_version, [one, one + one], &proof)
                 .unwrap()
         );
+    }
+
+    fn sample_circuit_for_scalars(
+        // Whether to inject a scalar which is never converted or not
+        inject_unconverted_scalar: bool,
+        // True if the assignment should be ejected, false if the R1CS should be ejected
+        eject_assignment: bool,
+        rng: &mut TestRng,
+    ) {
+        // Inject a few innocuous values and add a constraint.
+        let field_1 = Field::<AleoV0>::new(Mode::Private, Uniform::rand(rng));
+        let field_2 = Field::<AleoV0>::new(Mode::Public, Uniform::rand(rng));
+        let _product = &field_1 * &field_2;
+
+        // Inject a Scalar and convert it to bits: this is not problematic.
+        let scalar = Scalar::<AleoV0>::new(Mode::Private, Uniform::rand(rng));
+        let _scalar_bits = scalar.to_bits_le();
+
+        if inject_unconverted_scalar {
+            // Inject a private scalar which is never converted to bits: ejection should fail
+            let _unconverted_scalar = Scalar::<AleoV0>::new(Mode::Private, Uniform::rand(rng));
+        }
+
+        // Hash the injected fields to add a few more constraints.
+        let _fields_hash = AleoV0::hash_psd8(&[field_1, field_2]);
+
+        match (eject_assignment, inject_unconverted_scalar) {
+            // Ejection must fail when an injected scalar was never converted to bits.
+            (true, true) => {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(AleoV0::eject_assignment_and_reset));
+                assert!(result.is_err());
+                AleoV0::reset();
+            }
+            (false, true) => {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(AleoV0::eject_r1cs_and_reset));
+                assert!(result.is_err());
+                AleoV0::reset();
+            }
+            // Ejection succeeds when every injected scalar was converted to bits.
+            (true, false) => {
+                let _assignment = AleoV0::eject_assignment_and_reset();
+            }
+            (false, false) => {
+                let _r1cs = AleoV0::eject_r1cs_and_reset();
+            }
+        }
+
+        AleoV0::reset();
+    }
+
+    #[test]
+    // Checks that a (sample) circuit fails to eject the assignment and the R1CS if a Scalar is
+    // injected and never converted to bits.
+    fn test_unconverted_scalar_rejection() {
+        let rng = &mut TestRng::default();
+
+        // Cases with unconverted scalars at the end: panic expected (caught by assert_panics)
+        sample_circuit_for_scalars(true, true, rng);
+        sample_circuit_for_scalars(true, false, rng);
+
+        // Sanity check: when the (unconverted) scalar is not injected, ejection works
+        sample_circuit_for_scalars(false, true, rng);
+        sample_circuit_for_scalars(false, false, rng);
     }
 }

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -132,7 +132,7 @@ impl<F: PrimeField> LinearCombination<F> {
     }
 
     /// Returns the terms (excluding the constant value) in the linear combination.
-    pub(super) fn to_terms(&self) -> &[(Variable<F>, F)] {
+    pub(crate) fn to_terms(&self) -> &[(Variable<F>, F)] {
         &self.terms
     }
 

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -286,6 +286,8 @@ impl Environment for TestnetCircuit {
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+        // Clear the unconverted-scalars diagnostic.
+        Self::clear_unconverted_scalars();
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -308,6 +310,9 @@ impl Environment for TestnetCircuit {
 
     /// Returns the R1CS assignment of the circuit, resetting the circuit.
     fn eject_assignment_and_reset() -> Assignment<<Self::Network as console::Environment>::Field> {
+        // Report and clear the unconverted-scalars diagnostic at the end of synthesis.
+        Self::check_unconverted_scalars();
+        Self::clear_unconverted_scalars();
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -329,6 +334,8 @@ impl Environment for TestnetCircuit {
 
     /// Clears the circuit and initializes an empty environment.
     fn reset() {
+        // Clear the unconverted-scalars diagnostic.
+        Self::clear_unconverted_scalars();
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -286,8 +286,9 @@ impl Environment for TestnetCircuit {
 
     /// Returns the R1CS circuit, resetting the circuit.
     fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
-        // Clear the unconverted-scalars diagnostic.
-        Self::clear_unconverted_scalars();
+        // Ensure all Scalars have been converted to bits.
+        Self::check_unconverted_values().unwrap();
+
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -310,9 +311,9 @@ impl Environment for TestnetCircuit {
 
     /// Returns the R1CS assignment of the circuit, resetting the circuit.
     fn eject_assignment_and_reset() -> Assignment<<Self::Network as console::Environment>::Field> {
-        // Report and clear the unconverted-scalars diagnostic at the end of synthesis.
-        Self::check_unconverted_scalars();
-        Self::clear_unconverted_scalars();
+        // Ensure all Scalars have been converted to bits.
+        Self::check_unconverted_values().unwrap();
+
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -334,8 +335,9 @@ impl Environment for TestnetCircuit {
 
     /// Clears the circuit and initializes an empty environment.
     fn reset() {
-        // Clear the unconverted-scalars diagnostic.
-        Self::clear_unconverted_scalars();
+        // Clear the unconverted-values tracking set.
+        Self::clear_unconverted_values();
+
         TESTNET_CIRCUIT.with(|circuit| {
             // Reset the witness mode.
             IN_WITNESS.with(|in_witness| in_witness.replace(false));
@@ -350,6 +352,8 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_private());
             assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
+            // Ensure the unconverted-value tracking set is empty.
+            assert!(Self::check_unconverted_values().is_ok());
         });
     }
 }

--- a/circuit/types/scalar/src/helpers/to_bits.rs
+++ b/circuit/types/scalar/src/helpers/to_bits.rs
@@ -50,9 +50,9 @@ impl<E: Environment> ToBits for &Scalar<E> {
                 Boolean::assert_less_than_or_equal_constant(&bits_le, &modulus_minus_one.to_bits_le());
             }
 
-            // The scalar is now range-checked via its bit decomposition, so remove its underlying
-            // variable from the unconverted-scalars diagnostic set.
-            E::untrack_unconverted_scalar(&LinearCombination::from(&self.field));
+            // Now that underlying Field has been checked to represent a correct Scalar, we remove
+            // it from the unconverted-value tracking set.
+            E::untrack_unconverted_value(&LinearCombination::from(&self.field));
 
             bits_le
         });

--- a/circuit/types/scalar/src/helpers/to_bits.rs
+++ b/circuit/types/scalar/src/helpers/to_bits.rs
@@ -50,6 +50,10 @@ impl<E: Environment> ToBits for &Scalar<E> {
                 Boolean::assert_less_than_or_equal_constant(&bits_le, &modulus_minus_one.to_bits_le());
             }
 
+            // The scalar is now range-checked via its bit decomposition, so remove its underlying
+            // variable from the unconverted-scalars diagnostic set.
+            E::untrack_unconverted_scalar(&LinearCombination::from(&self.field));
+
             bits_le
         });
         // Extend the vector with the bits of the scalar.

--- a/circuit/types/scalar/src/lib.rs
+++ b/circuit/types/scalar/src/lib.rs
@@ -57,7 +57,13 @@ impl<E: Environment> Inject for Scalar<E> {
 
         // Initialize the scalar as a field element.
         match console::ToField::to_field(&scalar) {
-            Ok(field) => Self { field: Field::new(mode, field), bits_le: OnceCell::new() },
+            Ok(field) => {
+                let scalar = Self { field: Field::new(mode, field), bits_le: OnceCell::new() };
+                // Track the underlying variable so we can detect, at the end of synthesis, any
+                // scalar that is never range-checked (i.e. never converted to bits).
+                E::track_unconverted_scalar(&LinearCombination::from(&scalar.field));
+                scalar
+            }
             Err(error) => E::halt(format!("Unable to initialize a scalar circuit as a field element: {error}")),
         }
     }

--- a/circuit/types/scalar/src/lib.rs
+++ b/circuit/types/scalar/src/lib.rs
@@ -60,8 +60,16 @@ impl<E: Environment> Inject for Scalar<E> {
             Ok(field) => {
                 let scalar = Self { field: Field::new(mode, field), bits_le: OnceCell::new() };
                 // Track the underlying variable so we can detect, at the end of synthesis, any
-                // scalar that is never range-checked (i.e. never converted to bits).
-                E::track_unconverted_scalar(&LinearCombination::from(&scalar.field));
+                // scalar that is never range-checked. The closure converts this scalar to bits
+                // (range-checking it) if it is never otherwise converted during synthesis.
+                let lc = LinearCombination::from(&scalar.field);
+                let pending = scalar.clone();
+                E::track_unconverted_value(
+                    &lc,
+                    Box::new(move || {
+                        let _ = pending.to_bits_le();
+                    }),
+                );
                 scalar
             }
             Err(error) => E::halt(format!("Unable to initialize a scalar circuit as a field element: {error}")),

--- a/ledger/puzzle/epoch/src/synthesis/program/to_r1cs.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/to_r1cs.rs
@@ -94,6 +94,9 @@ impl<N: Network> EpochProgram<N> {
         );
         lap!(timer, "Ensure the circuit is satisfied");
 
+        // Convert all tracked, still-unconverted values to bits.
+        A::convert_unconverted_values();
+
         // Eject the R1CS and reset the circuit.
         let r1cs = A::eject_r1cs_and_reset();
         finish!(timer, "Eject the circuit assignment and reset the circuit");

--- a/synthesizer/benches/kary_merkle_tree.rs
+++ b/synthesizer/benches/kary_merkle_tree.rs
@@ -112,6 +112,9 @@ fn batch_prove(c: &mut Criterion) {
         let candidate = path.verify(&circuit_leaf_hasher, &circuit_path_hasher, &root, &leaf);
         assert!(candidate.eject_value());
 
+        // Convert all tracked, still-unconverted values to bits.
+        CurrentAleo::convert_unconverted_values();
+
         // Eject the assignment.
         CurrentAleo::eject_assignment_and_reset()
     };

--- a/synthesizer/process/src/stack/call/dynamic.rs
+++ b/synthesizer/process/src/stack/call/dynamic.rs
@@ -254,6 +254,9 @@ impl<N: Network> CallTrait<N> for CallDynamic<N> {
             // Indicate that external calls are never a root request.
             let is_root = false;
 
+            // Convert all tracked, still-unconverted values to bits.
+            A::convert_unconverted_values();
+
             // Eject the existing circuit.
             let r1cs = A::eject_r1cs_and_reset();
             let (request, caller_response_outputs) = {

--- a/synthesizer/process/src/stack/call/standard.rs
+++ b/synthesizer/process/src/stack/call/standard.rs
@@ -255,6 +255,9 @@ impl<N: Network> CallTrait<N> for Call<N> {
             // Indicate that external calls are never a root request.
             let is_root = false;
 
+            // Convert all tracked, still-unconverted values to bits.
+            A::convert_unconverted_values();
+
             use circuit::Eject;
             // Eject the existing circuit.
             let r1cs = A::eject_r1cs_and_reset();

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -567,6 +567,9 @@ impl<N: Network> Stack<N> {
             }
         }
 
+        // Convert all tracked, still-unconverted values to bits.
+        A::convert_unconverted_values();
+
         // Eject the circuit assignment and reset the circuit.
         let assignment = A::eject_assignment_and_reset();
 

--- a/synthesizer/process/src/trace/inclusion/assignment.rs
+++ b/synthesizer/process/src/trace/inclusion/assignment.rs
@@ -127,6 +127,9 @@ impl<N: Network> InclusionAssignment<N> {
             "InclusionAssignment".to_string(),
         );
 
+        // Convert all tracked, still-unconverted values to bits.
+        A::convert_unconverted_values();
+
         // Eject the assignment and reset the circuit environment.
         Ok(A::eject_assignment_and_reset())
     }

--- a/synthesizer/process/src/trace/inclusion/assignment_v0.rs
+++ b/synthesizer/process/src/trace/inclusion/assignment_v0.rs
@@ -88,6 +88,9 @@ impl<N: Network> InclusionV0Assignment<N> {
             "InclusionV0Assignment".to_string(),
         );
 
+        // Convert all tracked, still-unconverted values to bits.
+        A::convert_unconverted_values();
+
         // Eject the assignment and reset the circuit environment.
         Ok(A::eject_assignment_and_reset())
     }

--- a/synthesizer/process/src/trace/translation/assignment.rs
+++ b/synthesizer/process/src/trace/translation/assignment.rs
@@ -282,6 +282,9 @@ impl<N: Network> TranslationAssignment<N> {
             format_args!("Translation circuit for dynamic record with nonce {}", self.record_static.nonce()),
             "TranslationAssignment",
         );
+        // Convert all tracked, still-unconverted values to bits.
+        A::convert_unconverted_values();
+
         Ok(A::eject_assignment_and_reset())
     }
 }

--- a/synthesizer/src/vm/tests/test_v14/mod.rs
+++ b/synthesizer/src/vm/tests/test_v14/mod.rs
@@ -213,3 +213,92 @@ pub(crate) fn add_and_test_with_costs(
         }
     }
 }
+
+// Deploys three programs: one whose function adds two private scalar inputs and outputs the private
+// sum, one whose function hashes two private inputs and outputs the private hash, and one defining a
+// record with a `scalar` entry.
+#[test]
+fn test_scalar_behavior() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V14 height.
+    let v14_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14).unwrap();
+    let vm = sample_vm_at_height(v14_height, rng);
+
+    // A program whose function adds two private scalar inputs and outputs the private sum.
+    let scalar_add_program = Program::<CurrentNetwork>::from_str(
+        r"
+program scalar_add_test.aleo;
+
+function add_scalars:
+    input r0 as scalar.private;
+    input r1 as scalar.private;
+    add r0 r1 into r2;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .unwrap();
+
+    // A program whose function hashes two private inputs and outputs the private hash.
+    let hash_program = Program::<CurrentNetwork>::from_str(
+        r"
+program hash_inputs_test.aleo;
+
+function hash_inputs:
+    input r0 as field.private;
+    input r1 as field.private;
+    hash.bhp256 r0 into r2 as field;
+    hash.bhp256 r1 into r3 as field;
+    output r3 as field.private;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .unwrap();
+
+    // A program defining a record with a `scalar` entry, minted by a function.
+    let scalar_record_program = Program::<CurrentNetwork>::from_str(
+        r"
+program scalar_record_test.aleo;
+
+record holder:
+    owner as address.private;
+    val as scalar.private;
+
+record holder2:
+    owner as address.private;
+    val as scalar.public;
+
+function mint:
+    input r0 as address.private;
+    input r1 as scalar.private;
+    cast r0 r1 into r2 as holder.record;
+    output r2 as holder.record;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .unwrap();
+
+    // Deploy each program (in its own block) and ensure the deployment is accepted.
+    for program in [&scalar_add_program, &hash_program, &scalar_record_program] {
+        println!("Deploying program: {}", program.id());
+        let deployment = vm.deploy(&caller_private_key, program, None, 0, None, rng).unwrap();
+        assert!(vm.check_transaction(&deployment, None, rng).is_ok());
+
+        let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+        assert_eq!(block.transactions().num_accepted(), 1);
+        assert_eq!(block.transactions().num_rejected(), 0);
+        assert_eq!(block.aborted_transaction_ids().len(), 0);
+        vm.add_next_block(&block).unwrap();
+    }
+}
+

--- a/synthesizer/src/vm/tests/test_v14/mod.rs
+++ b/synthesizer/src/vm/tests/test_v14/mod.rs
@@ -301,4 +301,3 @@ constructor:
         vm.add_next_block(&block).unwrap();
     }
 }
-


### PR DESCRIPTION
(Edit: Converted to draft pending investigation on the possibility of bad-circuit construction)

A `Scalar` circuit value is stored as an underlying `Field` (i.e. base-field) element. No range checks (i.e. checks that the bit-decomposition of the `Field` corresponds to the canonical representation of a `Scalar` and not, say, to a larger value) occur upon injection. These checks do happen whenever `Scalar::to_bits` is called in-circuit (which is also triggered by many other circuit operations)

This is not an issue today because the Aleo-instructions language (used to construct transition circuits), record translation and record inclusion all result in circuits satisfying the following: every `Scalar` injected into the circuit is converted `to_bits` (and therefore range-checked) at some later point during synthesis. As an example, private and public transition inputs are wrapped in a `Plaintext` that gets converted `to_bits` when the circuit processes the input, i.e. hashes it (public) or encrypts it (private).

This PR future-proofs synthesis against failure to convert to bits (i.e. to range-check) all `Scalar`s. See also the note at the end of the next section for potential independent uses this PR could have in the future.

### Solution

- Each time a `Scalar` is injected into a circuit, it is added to a tracking set.
- Each time an in-circuit `Scalar` is converted to bits (which might in turn be caused by many higher-level operations), it is removed from the tracking set.
- During synthesis of transition, translation and inclusion (but not: inclusion V0) circuits, right before ejection of the R1CS or assignment (`eject_r1cs_and_reset` / `eject_assignment_and_reset`), all `Scalar`s not yet converted to bits are so (and i.p. are range-checked).

The reason for this flow as opposed to simply range-checking upon injection is that the latter would not be backwards-compatible (right now, many deployed circuits perform some operations between `Scalar` injection and whatever operation it is which triggers `to_bits`), but the implemented flow is (cf. next section).

Going into some more detail, it was not possible to have the tracking set simply contain the variable identifier of still-unconverted `Scalar`s: because tracking occurs at a lower level than most of our Aleo-type-specific circuit machinery, it is not aware of the existence of a `to_bits` function it can call directly. For that reason, when tracking a new `Scalar`, an abstract function is stores alongside it, which is always `to_bits` in the case of interest. This abstract function which the lower-level knows nothing about is what is called in `convert_unconverted_values` before ejection.

**Note:** The `*_unconverted_values` machinery implemented can also be used in the future whenever we need to be able to a) track circuit values, b) untrack circuit values, and c) guarantee that a certain closure is called before the end of synthesis for all still-untracked values.

### Backwards-compatibility

It has been checked that all `mainnet`, test and `canary` circuits in the regressions repository already convert all of their `Scalar`s to bits. In particular, their synthesis remains unaffected after the implemented change, the original certificates also validate and no redeployments are needed.

This means the change does not need to be version guarded.

### Tests

The main checks were carried out in a separate repo and consisted of the aforementioned regression checks that the updated synthesis doesn’t affect existing transition/translation circuits (or the inclusion one).

A new small test has been added: `test_unconverted_scalar_rejection`, which checks `eject_r1cs_and_reset` and `eject_assignment_and_reset` indeed reject circuits with still-unconverted `Scalar`s. This fact was also temporarily tested while running the regression tests.