### PR TITLE
feat(synthesizer): evaluate views against the program edition live at the queried height

### DIFF
--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -38,7 +38,7 @@ mod execute;
 mod finalize;
 mod view;
 #[cfg(feature = "history")]
-pub use view::evaluate_view_at_height;
+pub use view::evaluate_view_with_stack_at_height;
 mod verify_deployment;
 mod verify_execution;
 mod verify_fee;

--- a/synthesizer/process/src/view.rs
+++ b/synthesizer/process/src/view.rs
@@ -13,11 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "history")]
-use crate::Process;
 use crate::{FinalizeRegisters, Stack};
-#[cfg(feature = "history")]
-use console::program::ProgramID;
 use console::{
     network::prelude::*,
     program::{Identifier, Value},
@@ -31,40 +27,6 @@ use snarkvm_synthesizer_program::{
     RegistersTrait,
     StackTrait,
 };
-
-#[cfg(feature = "history")]
-impl<N: Network> Process<N> {
-    /// Evaluates a view function against historic finalize-store state at the given block
-    /// height. Routes mapping reads through the finalize store's historical update map (per-key
-    /// values keyed by `(program, mapping, key, height)`), so all reads in the view body are
-    /// pinned to `height` — block production advancing past `height` during evaluation cannot
-    /// disturb the result. The caller (typically `VM::evaluate_view_at_height`) constructs
-    /// `state` from the historic block at `height` so view operands reading block metadata
-    /// see the historic block's values.
-    ///
-    /// **No transitions are produced and no finalize-store writes occur** — views are
-    /// read-only by construction (`add_command` rejects `set` / `remove` / `async` / `await` /
-    /// `call` / `rand.chacha` / record-touching ops), and the adapter additionally bails on
-    /// every write entry point.
-    ///
-    /// Available only when snarkVM is built with `--features history`. snarkOS calls this with
-    /// `current_block_height()` for "latest", or any earlier height for historic views.
-    #[inline]
-    pub fn evaluate_view_at_height<P: FinalizeStorage<N>>(
-        &self,
-        state: FinalizeGlobalState,
-        store: &FinalizeStore<N, P>,
-        program_id: impl TryInto<ProgramID<N>>,
-        view_name: impl TryInto<Identifier<N>>,
-        inputs: Vec<Value<N>>,
-        height: u32,
-    ) -> Result<Vec<Value<N>>> {
-        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
-        let view_name = view_name.try_into().map_err(|_| anyhow!("Invalid view function name"))?;
-        let stack = self.get_stack(program_id)?;
-        evaluate_view_at_height(state, store, &stack, &view_name, inputs, height)
-    }
-}
 
 /// Evaluates a view function against historic finalize-store state at the given block
 /// `height`. Mapping reads route through `FinalizeStore::get_historical_mapping_value` and

--- a/synthesizer/process/src/view.rs
+++ b/synthesizer/process/src/view.rs
@@ -28,20 +28,14 @@ use snarkvm_synthesizer_program::{
     StackTrait,
 };
 
-/// Evaluates a view function against historic finalize-store state at the given block
-/// `height`. Mapping reads route through `FinalizeStore::get_historical_mapping_value` and
-/// are snapshot-consistent at `height` without contending with block finalization.
+/// Evaluates a view function against finalize-store state pinned to block `height`.
 ///
-/// `state` is supplied by the caller — typically built from the historic block at `height`
-/// so block-metadata operands reflect that block.
-///
-/// Caveat: the live `Stack` has interior mutability, so a concurrent redeploy of the same
-/// program could perturb its structural caches mid-view. Mapping values are pinned at
-/// `height`; program structure is not. Known gap — see `VM::evaluate_view_at_height`.
+/// Evaluates whatever `stack` it is given; the caller must supply the stack for the edition live
+/// at `height`. Prefer `VM::evaluate_view_at_height`, which resolves the edition.
 ///
 /// Available only with `--features history`.
 #[cfg(feature = "history")]
-pub fn evaluate_view_at_height<N: Network, P: FinalizeStorage<N>>(
+pub fn evaluate_view_with_stack_at_height<N: Network, P: FinalizeStorage<N>>(
     state: FinalizeGlobalState,
     store: &FinalizeStore<N, P>,
     stack: &Stack<N>,
@@ -136,7 +130,7 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStoreTrait<N> for HistoricFinali
 }
 
 /// Inner evaluation of a view. Generic over the store; the public path
-/// ([`evaluate_view_at_height`]) wraps the underlying `FinalizeStore` in a
+/// ([`evaluate_view_with_stack_at_height`]) wraps the underlying `FinalizeStore` in a
 /// [`HistoricFinalizeStore`] adapter that pins reads to a fixed height.
 pub(crate) fn evaluate_view_inner<N: Network>(
     state: FinalizeGlobalState,
@@ -238,7 +232,7 @@ pub(crate) fn evaluate_view_inner<N: Network>(
     Ok(outputs)
 }
 
-// All existing view tests exercise the external `evaluate_view_at_height` path, which is
+// All existing view tests exercise the external `evaluate_view_with_stack_at_height` path, which is
 // gated on `--features history`. Tests for the new in-block call path live at the v15 VM-tests
 // level (where deploying a program with a finalize-calling-view function is straightforward).
 #[cfg(all(test, feature = "history"))]
@@ -323,7 +317,7 @@ view total_balance:
 
         // Evaluate the view at height 0 (the default `current_block_height` for the in-memory
         // store; `update_key_value` records the historic entries at that height).
-        let outputs = evaluate_view_at_height(
+        let outputs = evaluate_view_with_stack_at_height(
             sample_finalize_state(0),
             &finalize_store,
             &stack,
@@ -374,7 +368,7 @@ view fetch_balance:
         let address = console::account::Address::try_from(&private_key)?;
         let address_key = Plaintext::from(Literal::Address(address));
 
-        let outputs = evaluate_view_at_height(
+        let outputs = evaluate_view_with_stack_at_height(
             sample_finalize_state(0),
             &finalize_store,
             &stack,
@@ -425,7 +419,7 @@ view fetch_balance:
         let address = console::account::Address::try_from(&private_key)?;
         let address_key = Plaintext::from(Literal::Address(address));
 
-        let result = evaluate_view_at_height(
+        let result = evaluate_view_with_stack_at_height(
             sample_finalize_state(0),
             &finalize_store,
             &stack,
@@ -467,7 +461,7 @@ view echo:
         let future_value =
             Value::Future(console::program::Future::new(*program.id(), Identifier::from_str("noop")?, vec![]));
 
-        let result = evaluate_view_at_height(
+        let result = evaluate_view_with_stack_at_height(
             sample_finalize_state(0),
             &finalize_store,
             &stack,
@@ -537,7 +531,7 @@ view lookup:
         // View with the batch still open: the historic adapter reads from the per-height
         // update map via `get_confirmed`, which skips pending atomic-batch writes. So the
         // view sees the mapping's default (0), not the pending 99.
-        let outputs = evaluate_view_at_height(
+        let outputs = evaluate_view_with_stack_at_height(
             sample_finalize_state(0),
             &finalize_store,
             &stack,
@@ -584,8 +578,14 @@ view reads_ts:
 
         // Build a state with a non-trivial timestamp, mimicking what a real VM would supply.
         let state = FinalizeGlobalState::from(1, 1, Some(1234567890), [0u8; 32]);
-        let outputs =
-            evaluate_view_at_height(state, &finalize_store, &stack, &Identifier::from_str("reads_ts")?, vec![], 1)?;
+        let outputs = evaluate_view_with_stack_at_height(
+            state,
+            &finalize_store,
+            &stack,
+            &Identifier::from_str("reads_ts")?,
+            vec![],
+            1,
+        )?;
 
         assert_eq!(outputs.len(), 1);
         match &outputs[0] {
@@ -596,7 +596,7 @@ view reads_ts:
     }
 
     /// Drives a value through two updates at different block heights and asserts that
-    /// `evaluate_view_at_height` returns the value applicable at each height.
+    /// `evaluate_view_with_stack_at_height` returns the value applicable at each height.
     #[test]
     fn test_evaluate_view_at_height_returns_historic_value() -> Result<()> {
         use std::sync::atomic::Ordering;
@@ -658,7 +658,7 @@ view lookup:
         // Sanity: viewing at the latest height (5) reflects the LAST write (V2 = 55). Historic
         // views below must therefore return 11 (not 55) at heights ≤ 4, distinguishing the
         // historic path from any accidental fall-through to current state.
-        let outputs = evaluate_view_at_height(
+        let outputs = evaluate_view_with_stack_at_height(
             sample_finalize_state(5),
             &finalize_store,
             &stack,
@@ -669,7 +669,7 @@ view lookup:
         assert_eq!(extract(outputs), 55, "current state should reflect the most recent write");
 
         // View at height 1 → V1.
-        let outputs = evaluate_view_at_height(
+        let outputs = evaluate_view_with_stack_at_height(
             sample_finalize_state(1),
             &finalize_store,
             &stack,
@@ -680,7 +680,7 @@ view lookup:
         assert_eq!(extract(outputs), 11, "expected historic value at height 1");
 
         // View at height 5 → V2.
-        let outputs = evaluate_view_at_height(
+        let outputs = evaluate_view_with_stack_at_height(
             sample_finalize_state(5),
             &finalize_store,
             &stack,
@@ -692,7 +692,7 @@ view lookup:
 
         // View at height 3 (between the two updates) → V1, since the binary-search picks
         // the most recent applicable height.
-        let outputs = evaluate_view_at_height(
+        let outputs = evaluate_view_with_stack_at_height(
             sample_finalize_state(3),
             &finalize_store,
             &stack,

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -345,13 +345,55 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// snarkOS calls this with `current_block_height()` for "latest", or any earlier height
     /// for historic views. `height` must satisfy `height <= current_block_height()`.
     ///
-    /// Caveat: the `Stack` itself uses interior mutability, so a concurrent redeploy of the
-    /// same program could perturb its structural caches mid-view. Mapping values are
-    /// snapshot-consistent at `height`; program structure is not. Known gap; a future
-    /// `StackSnapshot`-style fix would close it.
+    /// The view body is taken from the program edition live at `height`. For the latest edition regardless of
+    /// `height`, use [`VM::evaluate_view_at_height_using_latest_edition`].
     #[cfg(feature = "history")]
     #[inline]
-    pub fn evaluate_view_at_height(
+    pub fn evaluate_view_at_height_using_historic_edition(
+        &self,
+        program_id: impl TryInto<ProgramID<N>>,
+        view_name: impl TryInto<Identifier<N>>,
+        inputs: Vec<Value<N>>,
+        height: u32,
+    ) -> Result<Vec<Value<N>>> {
+        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        let view_name = view_name.try_into().map_err(|_| anyhow!("Invalid view function name"))?;
+        let state = self.finalize_state_for_block(height)?;
+        let edition = self.resolve_program_edition_at_height(&program_id, height)?;
+        let latest_stack = self.process.get_stack(program_id)?;
+        let stack = if *latest_stack.program_edition() == edition {
+            // The historic edition is already the loaded one.
+            latest_stack
+        } else {
+            // Build a one-off stack for the historic edition. `new_raw` skips upgrade validation, as the
+            // process holds a newer edition; views can't `call`, so the live (latest) imports resolve
+            // identically (struct, record, and mapping types are frozen across upgrades).
+            let program = self
+                .transaction_store()
+                .deployment_store()
+                .get_program_for_edition(&program_id, edition)?
+                .ok_or_else(|| anyhow!("Program '{program_id}' (edition {edition}) was not found in storage"))?;
+            let stack = Stack::new_raw(&self.process, &program, edition)?;
+            stack.initialize_and_check(&self.process)?;
+            Arc::new(stack)
+        };
+        snarkvm_synthesizer_process::evaluate_view_at_height(
+            state,
+            self.finalize_store(),
+            &stack,
+            &view_name,
+            inputs,
+            height,
+        )
+    }
+
+    /// As [`VM::evaluate_view_at_height_using_historic_edition`], but takes the view body from the latest
+    /// loaded program edition instead of resolving the edition live at `height`. Mapping reads are still
+    /// pinned to `height`. Cheaper (no edition resolution or stack rebuild); after an upgrade the two entry
+    /// points can differ for the same `height`. Available only with `--features history`.
+    #[cfg(feature = "history")]
+    #[inline]
+    pub fn evaluate_view_at_height_using_latest_edition(
         &self,
         program_id: impl TryInto<ProgramID<N>>,
         view_name: impl TryInto<Identifier<N>>,
@@ -360,6 +402,34 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     ) -> Result<Vec<Value<N>>> {
         let state = self.finalize_state_for_block(height)?;
         self.process.evaluate_view_at_height(state, self.finalize_store(), program_id, view_name, inputs, height)
+    }
+
+    /// Returns the program edition live at block `height`: the newest edition whose original
+    /// deployment was confirmed at or before `height`. Editions deploy in increasing block order.
+    #[cfg(feature = "history")]
+    fn resolve_program_edition_at_height(&self, program_id: &ProgramID<N>, height: u32) -> Result<u16> {
+        let deployment_store = self.transaction_store().deployment_store();
+        let block_store = self.block_store();
+        let latest_edition = deployment_store
+            .get_latest_edition_for_program(program_id)?
+            .ok_or_else(|| anyhow!("Program '{program_id}' has not been deployed"))?;
+        for edition in (0..=latest_edition).rev() {
+            let Some(transaction_id) =
+                deployment_store.find_original_transaction_id_from_program_id_and_edition(program_id, edition)?
+            else {
+                continue;
+            };
+            let Some(block_hash) = block_store.find_block_hash(&transaction_id)? else {
+                continue;
+            };
+            let Some(deployment_height) = block_store.get_block_height(&block_hash)? else {
+                continue;
+            };
+            if deployment_height <= height {
+                return Ok(edition);
+            }
+        }
+        bail!("Program '{program_id}' was not deployed at or before height {height}")
     }
 
     /// Returns the transition store.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -376,7 +376,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             stack.initialize_and_check(&self.process)?;
             Arc::new(stack)
         };
-        snarkvm_synthesizer_process::evaluate_view_at_height(
+        snarkvm_synthesizer_process::evaluate_view_with_stack_at_height(
             state,
             self.finalize_store(),
             &stack,

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -345,11 +345,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// snarkOS calls this with `current_block_height()` for "latest", or any earlier height
     /// for historic views. `height` must satisfy `height <= current_block_height()`.
     ///
-    /// The view body is taken from the program edition live at `height`. For the latest edition regardless of
-    /// `height`, use [`VM::evaluate_view_at_height_using_latest_edition`].
+    /// The view body is taken from the program edition live at `height`.
     #[cfg(feature = "history")]
     #[inline]
-    pub fn evaluate_view_at_height_using_historic_edition(
+    pub fn evaluate_view_at_height(
         &self,
         program_id: impl TryInto<ProgramID<N>>,
         view_name: impl TryInto<Identifier<N>>,
@@ -385,23 +384,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             inputs,
             height,
         )
-    }
-
-    /// As [`VM::evaluate_view_at_height_using_historic_edition`], but takes the view body from the latest
-    /// loaded program edition instead of resolving the edition live at `height`. Mapping reads are still
-    /// pinned to `height`. Cheaper (no edition resolution or stack rebuild); after an upgrade the two entry
-    /// points can differ for the same `height`. Available only with `--features history`.
-    #[cfg(feature = "history")]
-    #[inline]
-    pub fn evaluate_view_at_height_using_latest_edition(
-        &self,
-        program_id: impl TryInto<ProgramID<N>>,
-        view_name: impl TryInto<Identifier<N>>,
-        inputs: Vec<Value<N>>,
-        height: u32,
-    ) -> Result<Vec<Value<N>>> {
-        let state = self.finalize_state_for_block(height)?;
-        self.process.evaluate_view_at_height(state, self.finalize_store(), program_id, view_name, inputs, height)
     }
 
     /// Returns the program edition live at block `height`: the newest edition whose original

--- a/synthesizer/src/vm/tests/test_v15/views.rs
+++ b/synthesizer/src/vm/tests/test_v15/views.rs
@@ -86,7 +86,7 @@ fn test_evaluate_view_reflects_finalize_state() -> Result<()> {
 
     // Read against an untouched mapping should return the default (0).
     let height = vm.block_store().current_block_height();
-    let outputs = vm.evaluate_view_at_height(
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
         "vw_lifecycle.aleo",
         "total_balance",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -101,7 +101,7 @@ fn test_evaluate_view_reflects_finalize_state() -> Result<()> {
 
     // Read should now reflect the finalize-set value.
     let height = vm.block_store().current_block_height();
-    let outputs = vm.evaluate_view_at_height(
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
         "vw_lifecycle.aleo",
         "total_balance",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -115,7 +115,7 @@ fn test_evaluate_view_reflects_finalize_state() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
 
     let height = vm.block_store().current_block_height();
-    let outputs = vm.evaluate_view_at_height(
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
         "vw_lifecycle.aleo",
         "total_balance",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -164,7 +164,7 @@ fn test_evaluate_view_multi_output() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs = vm.evaluate_view_at_height(
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
         "vw_multi_output.aleo",
         "summary",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -213,7 +213,7 @@ fn test_evaluate_view_multi_input() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs = vm.evaluate_view_at_height(
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
         "vw_multi_in.aleo",
         "add3",
         vec![Value::from_str("10u64")?, Value::from_str("20u64")?, Value::from_str("12u64")?],
@@ -262,7 +262,7 @@ fn test_evaluate_view_with_branch() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // r0 = 0: branch is taken, doubling is skipped.
-    let outputs = vm.evaluate_view_at_height(
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
         "vw_branch.aleo",
         "maybe_extra",
         vec![Value::from_str("0u64")?],
@@ -271,7 +271,7 @@ fn test_evaluate_view_with_branch() -> Result<()> {
     assert_eq!(expect_u64(&outputs), 10);
 
     // r0 = 5: branch is NOT taken, the unused r2 destination is written but we still output r1.
-    let outputs = vm.evaluate_view_at_height(
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
         "vw_branch.aleo",
         "maybe_extra",
         vec![Value::from_str("5u64")?],
@@ -310,8 +310,12 @@ fn test_evaluate_view_zero_inputs() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs =
-        vm.evaluate_view_at_height("vw_zeroin.aleo", "fixed_value", vec![], vm.block_store().current_block_height())?;
+    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+        "vw_zeroin.aleo",
+        "fixed_value",
+        vec![],
+        vm.block_store().current_block_height(),
+    )?;
     assert_eq!(expect_u64(&outputs), 1234);
     Ok(())
 }
@@ -348,7 +352,7 @@ fn test_evaluate_view_arity_mismatch() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // Too few inputs.
-    let result = vm.evaluate_view_at_height(
+    let result = vm.evaluate_view_at_height_using_historic_edition(
         "vw_arity.aleo",
         "takes_two",
         vec![Value::from_str("1u64")?],
@@ -359,7 +363,7 @@ fn test_evaluate_view_arity_mismatch() -> Result<()> {
     assert!(err.contains("expects 2"), "error should mention input count: {err}");
 
     // Too many inputs.
-    let result = vm.evaluate_view_at_height(
+    let result = vm.evaluate_view_at_height_using_historic_edition(
         "vw_arity.aleo",
         "takes_two",
         vec![Value::from_str("1u64")?, Value::from_str("2u64")?, Value::from_str("3u64")?],
@@ -399,8 +403,12 @@ fn test_evaluate_view_unknown_view() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let result =
-        vm.evaluate_view_at_height("vw_unknown.aleo", "missing", vec![], vm.block_store().current_block_height());
+    let result = vm.evaluate_view_at_height_using_historic_edition(
+        "vw_unknown.aleo",
+        "missing",
+        vec![],
+        vm.block_store().current_block_height(),
+    );
     assert!(result.is_err(), "expected error for unknown view");
     Ok(())
 }
@@ -412,8 +420,12 @@ fn test_evaluate_view_unknown_program() {
     let rng = &mut TestRng::default();
     let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
 
-    let result =
-        vm.evaluate_view_at_height("never_deployed.aleo", "anything", vec![], vm.block_store().current_block_height());
+    let result = vm.evaluate_view_at_height_using_historic_edition(
+        "never_deployed.aleo",
+        "anything",
+        vec![],
+        vm.block_store().current_block_height(),
+    );
     assert!(result.is_err(), "expected error for unknown program");
 }
 
@@ -672,7 +684,7 @@ fn test_finalize_calls_same_program_view() -> Result<()> {
     // Confirm the new mapping value via an external read.
     #[cfg(feature = "history")]
     {
-        let outputs = vm.evaluate_view_at_height(
+        let outputs = vm.evaluate_view_at_height_using_historic_edition(
             "vw_call_same.aleo",
             "lookup",
             vec![Value::from_str(&caller_address.to_string())?],
@@ -985,7 +997,7 @@ fn test_finalize_multiple_calls_and_interleaved_writes() -> Result<()> {
     // Also confirm the final committed balance is 55 (the intervening set landed).
     #[cfg(feature = "history")]
     {
-        let outputs = vm.evaluate_view_at_height(
+        let outputs = vm.evaluate_view_at_height_using_historic_edition(
             "vw_call_seq.aleo",
             "lookup",
             vec![Value::from_str(&caller_address.to_string())?],
@@ -2224,4 +2236,130 @@ fn test_finalize_call_zero_output_view_with_destinations_rejected_at_deploy() {
         let deploy = vm.deploy(&caller_private_key, &program, None, 0, None, rng);
         assert!(deploy.is_err(), "deploy should reject binding destinations to a zero-output view");
     }
+}
+
+/// Three upgrades change a view body. The mapping value is held constant, so each height must resolve to the
+/// edition live then — the middle case (height_v1 -> edition 1) checks that the scan picks the intermediate
+/// edition, not just the newest or oldest.
+#[cfg(feature = "history")]
+#[test]
+fn test_evaluate_view_uses_historic_program_edition() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    // `total_balance` returns `balances[addr] + bump`; only `bump` changes across editions.
+    let program = |bump: u64| -> Result<Program<CurrentNetwork>> {
+        Program::from_str(&format!(
+            r"
+        program vw_upgrade.aleo;
+
+        mapping balances:
+            key as address.public;
+            value as u64.public;
+
+        function increment:
+            input r0 as address.public;
+            input r1 as u64.public;
+            async increment r0 r1 into r2;
+            output r2 as vw_upgrade.aleo/increment.future;
+
+        finalize increment:
+            input r0 as address.public;
+            input r1 as u64.public;
+            get.or_use balances[r0] 0u64 into r2;
+            add r2 r1 into r3;
+            set r3 into balances[r0];
+
+        view total_balance:
+            input r0 as address.public;
+            get.or_use balances[r0] 0u64 into r1;
+            add r1 {bump}u64 into r2;
+            output r2 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        "
+        ))
+    };
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+
+    // Deploy edition 0, then set `balances[addr] = 5`.
+    let tx = vm.deploy(&caller_private_key, &program(0)?, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+    let inputs = [Value::from_str(&caller_address.to_string())?, Value::from_str("5u64")?];
+    let tx = vm.execute(&caller_private_key, ("vw_upgrade.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
+    let height_v0 = vm.block_store().current_block_height();
+
+    // Upgrade to edition 1 (+100), then edition 2 (+1000).
+    let tx = vm.deploy(&caller_private_key, &program(100)?, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+    let height_v1 = vm.block_store().current_block_height();
+    let tx = vm.deploy(&caller_private_key, &program(1000)?, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+    let height_v2 = vm.block_store().current_block_height();
+
+    let total = |height: u32| {
+        vm.evaluate_view_at_height_using_historic_edition(
+            "vw_upgrade.aleo",
+            "total_balance",
+            vec![Value::from_str(&caller_address.to_string()).unwrap()],
+            height,
+        )
+    };
+    assert_eq!(expect_u64(&total(height_v0)?), 5, "edition 0 body at its height");
+    assert_eq!(expect_u64(&total(height_v1)?), 105, "edition 1 body at its height (intermediate)");
+    assert_eq!(expect_u64(&total(height_v2)?), 1005, "edition 2 body at its height");
+
+    // The latest-edition entry point uses the newest body even at the oldest height.
+    let outputs = vm.evaluate_view_at_height_using_latest_edition(
+        "vw_upgrade.aleo",
+        "total_balance",
+        vec![Value::from_str(&caller_address.to_string())?],
+        height_v0,
+    )?;
+    assert_eq!(expect_u64(&outputs), 1005, "latest-edition view uses the newest body at a historic height");
+
+    Ok(())
+}
+
+/// Querying a view at a height before the program was deployed returns an error.
+#[cfg(feature = "history")]
+#[test]
+fn test_evaluate_view_before_deployment_height_errors() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    let program = Program::from_str(
+        r"
+        program vw_predeploy.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        view fixed:
+            add 0u64 7u64 into r0;
+            output r0 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    // A valid block height that predates the program's deployment.
+    let before = vm.block_store().current_block_height();
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+
+    let err = vm
+        .evaluate_view_at_height_using_historic_edition("vw_predeploy.aleo", "fixed", vec![], before)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("was not deployed at or before height"), "unexpected error: {err}");
+    Ok(())
 }

--- a/synthesizer/src/vm/tests/test_v15/views.rs
+++ b/synthesizer/src/vm/tests/test_v15/views.rs
@@ -86,7 +86,7 @@ fn test_evaluate_view_reflects_finalize_state() -> Result<()> {
 
     // Read against an untouched mapping should return the default (0).
     let height = vm.block_store().current_block_height();
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+    let outputs = vm.evaluate_view_at_height(
         "vw_lifecycle.aleo",
         "total_balance",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -101,7 +101,7 @@ fn test_evaluate_view_reflects_finalize_state() -> Result<()> {
 
     // Read should now reflect the finalize-set value.
     let height = vm.block_store().current_block_height();
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+    let outputs = vm.evaluate_view_at_height(
         "vw_lifecycle.aleo",
         "total_balance",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -115,7 +115,7 @@ fn test_evaluate_view_reflects_finalize_state() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
 
     let height = vm.block_store().current_block_height();
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+    let outputs = vm.evaluate_view_at_height(
         "vw_lifecycle.aleo",
         "total_balance",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -164,7 +164,7 @@ fn test_evaluate_view_multi_output() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+    let outputs = vm.evaluate_view_at_height(
         "vw_multi_output.aleo",
         "summary",
         vec![Value::from_str(&caller_address.to_string())?],
@@ -213,7 +213,7 @@ fn test_evaluate_view_multi_input() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+    let outputs = vm.evaluate_view_at_height(
         "vw_multi_in.aleo",
         "add3",
         vec![Value::from_str("10u64")?, Value::from_str("20u64")?, Value::from_str("12u64")?],
@@ -262,7 +262,7 @@ fn test_evaluate_view_with_branch() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // r0 = 0: branch is taken, doubling is skipped.
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+    let outputs = vm.evaluate_view_at_height(
         "vw_branch.aleo",
         "maybe_extra",
         vec![Value::from_str("0u64")?],
@@ -271,7 +271,7 @@ fn test_evaluate_view_with_branch() -> Result<()> {
     assert_eq!(expect_u64(&outputs), 10);
 
     // r0 = 5: branch is NOT taken, the unused r2 destination is written but we still output r1.
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
+    let outputs = vm.evaluate_view_at_height(
         "vw_branch.aleo",
         "maybe_extra",
         vec![Value::from_str("5u64")?],
@@ -310,12 +310,8 @@ fn test_evaluate_view_zero_inputs() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let outputs = vm.evaluate_view_at_height_using_historic_edition(
-        "vw_zeroin.aleo",
-        "fixed_value",
-        vec![],
-        vm.block_store().current_block_height(),
-    )?;
+    let outputs =
+        vm.evaluate_view_at_height("vw_zeroin.aleo", "fixed_value", vec![], vm.block_store().current_block_height())?;
     assert_eq!(expect_u64(&outputs), 1234);
     Ok(())
 }
@@ -352,7 +348,7 @@ fn test_evaluate_view_arity_mismatch() -> Result<()> {
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
     // Too few inputs.
-    let result = vm.evaluate_view_at_height_using_historic_edition(
+    let result = vm.evaluate_view_at_height(
         "vw_arity.aleo",
         "takes_two",
         vec![Value::from_str("1u64")?],
@@ -363,7 +359,7 @@ fn test_evaluate_view_arity_mismatch() -> Result<()> {
     assert!(err.contains("expects 2"), "error should mention input count: {err}");
 
     // Too many inputs.
-    let result = vm.evaluate_view_at_height_using_historic_edition(
+    let result = vm.evaluate_view_at_height(
         "vw_arity.aleo",
         "takes_two",
         vec![Value::from_str("1u64")?, Value::from_str("2u64")?, Value::from_str("3u64")?],
@@ -403,12 +399,8 @@ fn test_evaluate_view_unknown_view() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let result = vm.evaluate_view_at_height_using_historic_edition(
-        "vw_unknown.aleo",
-        "missing",
-        vec![],
-        vm.block_store().current_block_height(),
-    );
+    let result =
+        vm.evaluate_view_at_height("vw_unknown.aleo", "missing", vec![], vm.block_store().current_block_height());
     assert!(result.is_err(), "expected error for unknown view");
     Ok(())
 }
@@ -420,12 +412,8 @@ fn test_evaluate_view_unknown_program() {
     let rng = &mut TestRng::default();
     let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
 
-    let result = vm.evaluate_view_at_height_using_historic_edition(
-        "never_deployed.aleo",
-        "anything",
-        vec![],
-        vm.block_store().current_block_height(),
-    );
+    let result =
+        vm.evaluate_view_at_height("never_deployed.aleo", "anything", vec![], vm.block_store().current_block_height());
     assert!(result.is_err(), "expected error for unknown program");
 }
 
@@ -684,7 +672,7 @@ fn test_finalize_calls_same_program_view() -> Result<()> {
     // Confirm the new mapping value via an external read.
     #[cfg(feature = "history")]
     {
-        let outputs = vm.evaluate_view_at_height_using_historic_edition(
+        let outputs = vm.evaluate_view_at_height(
             "vw_call_same.aleo",
             "lookup",
             vec![Value::from_str(&caller_address.to_string())?],
@@ -997,7 +985,7 @@ fn test_finalize_multiple_calls_and_interleaved_writes() -> Result<()> {
     // Also confirm the final committed balance is 55 (the intervening set landed).
     #[cfg(feature = "history")]
     {
-        let outputs = vm.evaluate_view_at_height_using_historic_edition(
+        let outputs = vm.evaluate_view_at_height(
             "vw_call_seq.aleo",
             "lookup",
             vec![Value::from_str(&caller_address.to_string())?],
@@ -2302,7 +2290,7 @@ fn test_evaluate_view_uses_historic_program_edition() -> Result<()> {
     let height_v2 = vm.block_store().current_block_height();
 
     let total = |height: u32| {
-        vm.evaluate_view_at_height_using_historic_edition(
+        vm.evaluate_view_at_height(
             "vw_upgrade.aleo",
             "total_balance",
             vec![Value::from_str(&caller_address.to_string()).unwrap()],
@@ -2312,15 +2300,6 @@ fn test_evaluate_view_uses_historic_program_edition() -> Result<()> {
     assert_eq!(expect_u64(&total(height_v0)?), 5, "edition 0 body at its height");
     assert_eq!(expect_u64(&total(height_v1)?), 105, "edition 1 body at its height (intermediate)");
     assert_eq!(expect_u64(&total(height_v2)?), 1005, "edition 2 body at its height");
-
-    // The latest-edition entry point uses the newest body even at the oldest height.
-    let outputs = vm.evaluate_view_at_height_using_latest_edition(
-        "vw_upgrade.aleo",
-        "total_balance",
-        vec![Value::from_str(&caller_address.to_string())?],
-        height_v0,
-    )?;
-    assert_eq!(expect_u64(&outputs), 1005, "latest-edition view uses the newest body at a historic height");
 
     Ok(())
 }
@@ -2356,10 +2335,7 @@ fn test_evaluate_view_before_deployment_height_errors() -> Result<()> {
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
     add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
 
-    let err = vm
-        .evaluate_view_at_height_using_historic_edition("vw_predeploy.aleo", "fixed", vec![], before)
-        .unwrap_err()
-        .to_string();
+    let err = vm.evaluate_view_at_height("vw_predeploy.aleo", "fixed", vec![], before).unwrap_err().to_string();
     assert!(err.contains("was not deployed at or before height"), "unexpected error: {err}");
     Ok(())
 }


### PR DESCRIPTION
Historic view queries (`--features history`) evaluated against the *latest* program edition, so after a program upgrade a view at an earlier height ran against the wrong body.

`VM::evaluate_view_at_height` now resolves the program edition that was live at the queried `height` and evaluates the view against that body. Mapping reads were already pinned to `height`; this closes the remaining gap where the body always came from the latest edition. All view-query entry points now behave consistently: they query against the historic program version.

**Breaking change:** removes the lower-level `Process::evaluate_view_at_height`. Resolving the edition live at a height requires the deployment and block stores, which only the `VM` has — so a `Process`-level entry point can't produce a correct historic result. Callers that already hold a resolved `Stack` can use the free `evaluate_view_at_height` function, which is unchanged.

Closes #3292