### PR TITLE
Export RocksDB internal metrics via caller-driven…

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -80,7 +80,7 @@ locktick = [
   "snarkvm-ledger-store/locktick",
   "snarkvm-synthesizer/locktick"
 ]
-metrics = [ "snarkvm-ledger-committee/metrics" ]
+metrics = [ "snarkvm-ledger-committee/metrics", "snarkvm-ledger-store/metrics" ]
 prop-tests = [ "snarkvm-ledger-committee/prop-tests" ]
 rocks = [ "snarkvm-ledger-store/rocks" ]
 serial = [

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -22,6 +22,7 @@ history = [ ]
 history-staking-rewards = [ ]
 slipstream-plugins = [ "dep:snarkvm-slipstream-plugin-manager" ]
 locktick = [ "dep:locktick", "snarkvm-ledger-puzzle/locktick" ]
+metrics = [ "dep:snarkvm-metrics" ]
 rocks = [ "rocksdb", "smallvec" ]
 serial = [
   "snarkvm-console/serial",
@@ -42,6 +43,10 @@ wasm = [
   "snarkvm-synthesizer-snark/wasm"
 ]
 test = [ ]
+
+[dependencies.snarkvm-metrics]
+workspace = true
+optional = true
 
 [dependencies.snarkvm-slipstream-plugin-manager]
 workspace = true

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1559,6 +1559,15 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
     }
 }
 
+#[cfg(all(feature = "rocks", feature = "metrics"))]
+impl<N: Network> BlockStore<N, crate::helpers::rocksdb::BlockDB<N>> {
+    /// Reads RocksDB internal properties and publishes them to the metrics registry.
+    /// This is a cheap, synchronous call — properties come from in-memory counters with no I/O.
+    pub fn export_rocksdb_metrics(&self) {
+        self.storage.export_rocksdb_metrics();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ledger/store/src/helpers/rocksdb/block.rs
+++ b/ledger/store/src/helpers/rocksdb/block.rs
@@ -268,3 +268,12 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
         }
     }
 }
+
+#[cfg(all(feature = "rocks", feature = "metrics"))]
+impl<N: Network> BlockDB<N> {
+    /// Reads RocksDB internal properties and publishes them to the metrics registry.
+    /// Any map can be used since they all share the same underlying RocksDB instance.
+    pub fn export_rocksdb_metrics(&self) {
+        self.id_map.export_rocksdb_metrics();
+    }
+}

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -55,6 +55,13 @@ impl<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> InnerData
         let checkpoint = rocksdb::checkpoint::Checkpoint::new(&self.database)?;
         checkpoint.create_checkpoint(path).map_err(|e| e.into_string())
     }
+
+    /// Reads RocksDB internal properties and publishes them to the metrics registry.
+    /// Any map can be used since they all share the same underlying `RocksDB` instance.
+    #[cfg(feature = "metrics")]
+    pub fn export_rocksdb_metrics(&self) {
+        self.database.export_rocksdb_metrics();
+    }
 }
 
 impl<

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -297,6 +297,64 @@ impl RocksDB {
     fn are_atomic_writes_paused(&self) -> bool {
         self.atomic_writes_paused.load(Ordering::SeqCst)
     }
+
+    /// Reads key RocksDB internal properties and publishes them to the metrics registry.
+    ///
+    /// This is a lightweight, synchronous call — properties are read from RocksDB's in-memory
+    /// counters with no disk I/O.  Call it from an existing background loop (e.g. the
+    /// auto-checkpoint polling loop in snarkOS); there is no need to spawn a dedicated thread.
+    #[cfg(feature = "metrics")]
+    pub fn export_rocksdb_metrics(&self) {
+        use snarkvm_metrics::rocksdb as names;
+
+        /// Read a single integer property; silently skip on error (DB may be closing).
+        fn prop(db: &rocksdb::DB, key: &str) -> Option<u64> {
+            db.property_int_value(key).ok().flatten()
+        }
+
+        let db = &self.rocksdb;
+
+        // Compaction pressure
+        if let Some(v) = prop(db, "rocksdb.compaction-pending") {
+            snarkvm_metrics::gauge(names::COMPACTION_PENDING, v as f64);
+        }
+        if let Some(v) = prop(db, "rocksdb.estimate-pending-compaction-bytes") {
+            snarkvm_metrics::gauge(names::ESTIMATE_PENDING_COMPACTION_BYTES, v as f64);
+        }
+        if let Some(v) = prop(db, "rocksdb.num-running-compactions") {
+            snarkvm_metrics::gauge(names::NUM_RUNNING_COMPACTIONS, v as f64);
+        }
+        if let Some(v) = prop(db, "rocksdb.num-running-flushes") {
+            snarkvm_metrics::gauge(names::NUM_RUNNING_FLUSHES, v as f64);
+        }
+        if let Some(v) = prop(db, "rocksdb.mem-table-flush-pending") {
+            snarkvm_metrics::gauge(names::MEM_TABLE_FLUSH_PENDING, v as f64);
+        }
+
+        // Disk footprint
+        if let Some(v) = prop(db, "rocksdb.total-sst-files-size") {
+            snarkvm_metrics::gauge(names::TOTAL_SST_FILES_SIZE, v as f64);
+        }
+        if let Some(v) = prop(db, "rocksdb.live-sst-files-size") {
+            snarkvm_metrics::gauge(names::LIVE_SST_FILES_SIZE, v as f64);
+        }
+
+        // General state
+        if let Some(v) = prop(db, "rocksdb.estimate-num-keys") {
+            snarkvm_metrics::gauge(names::ESTIMATE_NUM_KEYS, v as f64);
+        }
+        if let Some(v) = prop(db, "rocksdb.num-snapshots") {
+            snarkvm_metrics::gauge(names::NUM_SNAPSHOTS, v as f64);
+        }
+
+        // Per-level SST file counts (levels 0–6)
+        for (level, &name) in names::NUM_FILES_AT_LEVEL.iter().enumerate() {
+            let key = format!("rocksdb.num-files-at-level{level}");
+            if let Some(v) = prop(db, &key) {
+                snarkvm_metrics::gauge(name, v as f64);
+            }
+        }
+    }
 }
 
 // impl RocksDB {

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -15,10 +15,65 @@
 
 #![forbid(unsafe_code)]
 
-const GAUGE_NAMES: [&str; 1] = [committee::TOTAL_STAKE];
+const GAUGE_NAMES: &[&str] = &[
+    committee::TOTAL_STAKE,
+    rocksdb::COMPACTION_PENDING,
+    rocksdb::ESTIMATE_PENDING_COMPACTION_BYTES,
+    rocksdb::NUM_RUNNING_COMPACTIONS,
+    rocksdb::NUM_RUNNING_FLUSHES,
+    rocksdb::MEM_TABLE_FLUSH_PENDING,
+    rocksdb::TOTAL_SST_FILES_SIZE,
+    rocksdb::LIVE_SST_FILES_SIZE,
+    rocksdb::ESTIMATE_NUM_KEYS,
+    rocksdb::NUM_SNAPSHOTS,
+    rocksdb::NUM_FILES_AT_LEVEL[0],
+    rocksdb::NUM_FILES_AT_LEVEL[1],
+    rocksdb::NUM_FILES_AT_LEVEL[2],
+    rocksdb::NUM_FILES_AT_LEVEL[3],
+    rocksdb::NUM_FILES_AT_LEVEL[4],
+    rocksdb::NUM_FILES_AT_LEVEL[5],
+    rocksdb::NUM_FILES_AT_LEVEL[6],
+];
 
 pub mod committee {
     pub const TOTAL_STAKE: &str = "snarkvm_ledger_committee_total_stake";
+}
+
+/// RocksDB internal database metrics.
+///
+/// Polled and published by calling `BlockStore::export_rocksdb_metrics()` from an existing
+/// background loop (e.g. the auto-checkpoint task in snarkOS). All sizes are in bytes;
+/// counts are dimensionless. Requires the `rocks` and `metrics` features on `snarkvm-ledger-store`.
+pub mod rocksdb {
+    /// 1 if a compaction is pending (background compaction requested but not yet running), else 0.
+    pub const COMPACTION_PENDING: &str = "snarkvm_rocksdb_compaction_pending";
+    /// Estimated total bytes of data to be compacted. A sustained non-zero value signals backpressure.
+    pub const ESTIMATE_PENDING_COMPACTION_BYTES: &str =
+        "snarkvm_rocksdb_estimate_pending_compaction_bytes";
+    /// Number of compactions currently running in the background.
+    pub const NUM_RUNNING_COMPACTIONS: &str = "snarkvm_rocksdb_num_running_compactions";
+    /// Number of memtable flushes currently running.
+    pub const NUM_RUNNING_FLUSHES: &str = "snarkvm_rocksdb_num_running_flushes";
+    /// 1 if a memtable flush is pending (memtable full but flush not yet started), else 0.
+    pub const MEM_TABLE_FLUSH_PENDING: &str = "snarkvm_rocksdb_mem_table_flush_pending";
+    /// Total size of all SST files on disk (includes files pending deletion).
+    pub const TOTAL_SST_FILES_SIZE: &str = "snarkvm_rocksdb_total_sst_files_size_bytes";
+    /// Size of live (referenced) SST files only.
+    pub const LIVE_SST_FILES_SIZE: &str = "snarkvm_rocksdb_live_sst_files_size_bytes";
+    /// Estimated number of keys in the database.
+    pub const ESTIMATE_NUM_KEYS: &str = "snarkvm_rocksdb_estimate_num_keys";
+    /// Number of snapshots currently held (non-zero blocks deletion of old SST files).
+    pub const NUM_SNAPSHOTS: &str = "snarkvm_rocksdb_num_snapshots";
+    /// Number of SST files per LSM level (levels 0–6).
+    pub const NUM_FILES_AT_LEVEL: [&str; 7] = [
+        "snarkvm_rocksdb_num_files_at_level0",
+        "snarkvm_rocksdb_num_files_at_level1",
+        "snarkvm_rocksdb_num_files_at_level2",
+        "snarkvm_rocksdb_num_files_at_level3",
+        "snarkvm_rocksdb_num_files_at_level4",
+        "snarkvm_rocksdb_num_files_at_level5",
+        "snarkvm_rocksdb_num_files_at_level6",
+    ];
 }
 
 /// Registers all snarkVM metrics.

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -48,8 +48,7 @@ pub mod rocksdb {
     /// 1 if a compaction is pending (background compaction requested but not yet running), else 0.
     pub const COMPACTION_PENDING: &str = "snarkvm_rocksdb_compaction_pending";
     /// Estimated total bytes of data to be compacted. A sustained non-zero value signals backpressure.
-    pub const ESTIMATE_PENDING_COMPACTION_BYTES: &str =
-        "snarkvm_rocksdb_estimate_pending_compaction_bytes";
+    pub const ESTIMATE_PENDING_COMPACTION_BYTES: &str = "snarkvm_rocksdb_estimate_pending_compaction_bytes";
     /// Number of compactions currently running in the background.
     pub const NUM_RUNNING_COMPACTIONS: &str = "snarkvm_rocksdb_num_running_compactions";
     /// Number of memtable flushes currently running.


### PR DESCRIPTION
## Motivation

RocksDB internals are currently invisible to operators. This became apparent during a recent incident where a major compaction caused a ~1 TB disk spike over two hours — with no metrics to explain what was happening in real time.

This PR adds the key RocksDB properties to Prometheus, gated behind the existing `metrics` feature with zero overhead when disabled.

## What's added

**Compaction pressure** — early warning for write stalls:

| Metric | Description |
|--------|-------------|
| `snarkvm_rocksdb_compaction_pending` | 1 if compaction is queued but not yet running |
| `snarkvm_rocksdb_estimate_pending_compaction_bytes` | Bytes waiting to be compacted; a rising trend signals backpressure before a stall hits |
| `snarkvm_rocksdb_num_running_compactions` | Active background compaction threads |
| `snarkvm_rocksdb_num_running_flushes` | Active memtable flushes |
| `snarkvm_rocksdb_mem_table_flush_pending` | 1 if a flush is queued but not yet started |

**Disk footprint** — explains why disk grows unexpectedly:

| Metric | Description |
|--------|-------------|
| `snarkvm_rocksdb_total_sst_files_size_bytes` | All SST files on disk, including those pending deletion |
| `snarkvm_rocksdb_live_sst_files_size_bytes` | Live (referenced) SST files only |

The gap between `total` and `live` is disk held by open snapshots or checkpoints blocking file deletion. This gap is what caused the recent disk spike.

**General state:**

| Metric | Description |
|--------|-------------|
| `snarkvm_rocksdb_num_snapshots` | Open snapshots — non-zero is what causes the `total - live` gap |
| `snarkvm_rocksdb_estimate_num_keys` | Estimated key count |

**Per-level SST file counts** (`snarkvm_rocksdb_num_files_at_level0` … `level6`):

L0 is the critical one — writes land here first. When L0 file count climbs RocksDB throttles writes and eventually stalls. Levels 1–6 confirm compaction is draining the LSM tree normally.

## Implementation

All values come from RocksDB's in-memory property counters (`DB::property_int_value`) — no disk I/O, no `Statistics` overhead.

Rather than spawning a background thread inside library code, `RocksDB::export_rocksdb_metrics()` is a plain public method. The caller decides when to poll. The delegation chain follows the same pattern as `backup_database`:

```
RocksDB::export_rocksdb_metrics()
  ↑ InnerDataMap::export_rocksdb_metrics()
    ↑ BlockDB::export_rocksdb_metrics()
      ↑ BlockStore<N, BlockDB<N>>::export_rocksdb_metrics()   ← called by snarkOS
```

Feature propagation: `snarkvm/metrics` → `snarkvm-ledger/metrics` → `snarkvm-ledger-store/metrics`.

A companion snarkOS PR calls `export_rocksdb_metrics()` every ~15 s from the existing auto-checkpoint polling loop (no new thread).

## Test Plan

```
cargo check -p snarkvm-ledger-store --features rocks,metrics
```