### PR TITLE
Add `Operand::ComponentChecksum`

### DIFF
--- a/synthesizer/process/src/stack/evaluate.rs
+++ b/synthesizer/process/src/stack/evaluate.rs
@@ -112,6 +112,10 @@ impl<N: Network> Stack<N> {
                     Operand::Edition(_) => bail!("Cannot retrieve the edition from a closure scope."),
                     // If the operand is the program owner, throw an error.
                     Operand::ProgramOwner(_) => bail!("Cannot retrieve the program owner from a closure scope."),
+                    // If the operand is the component checksum, throw an error.
+                    Operand::ComponentChecksum(..) => {
+                        bail!("Cannot retrieve the component checksum from a closure scope.")
+                    }
                 }
             })
             .map(|res| res.map_err(StackEvalError::from))
@@ -294,6 +298,10 @@ impl<N: Network> Stack<N> {
                     Operand::Edition(_) => bail!("Cannot retrieve the edition from a function scope."),
                     // If the operand is the program owner, throw an error.
                     Operand::ProgramOwner(_) => bail!("Cannot retrieve the program owner from a function scope."),
+                    // If the operand is the component checksum, throw an error.
+                    Operand::ComponentChecksum(..) => {
+                        bail!("Cannot retrieve the component checksum from a function scope.")
+                    }
                 }
             })
             .collect::<Result<Vec<_>>>()?;

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -174,6 +174,10 @@ impl<N: Network> Stack<N> {
                     Operand::ProgramOwner(_) => {
                         bail!("Illegal operation: cannot retrieve the program owner in a closure scope")
                     }
+                    // If the operand is the component checksum, throw an error.
+                    Operand::ComponentChecksum(..) => {
+                        bail!("Illegal operation: cannot retrieve the component checksum in a closure scope")
+                    }
                 }
             })
             .map(|res| res.map_err(StackExecError::Anyhow))
@@ -491,6 +495,10 @@ impl<N: Network> Stack<N> {
                     // If the operand is the program owner, throw an error.
                     Operand::ProgramOwner(_) => {
                         bail!("Illegal operation: cannot retrieve the program owner in a function scope")
+                    }
+                    // If the operand is the component checksum, throw an error.
+                    Operand::ComponentChecksum(..) => {
+                        bail!("Illegal operation: cannot retrieve the component checksum in a function scope")
                     }
                 }
             })

--- a/synthesizer/process/src/stack/finalize_registers/registers_trait.rs
+++ b/synthesizer/process/src/stack/finalize_registers/registers_trait.rs
@@ -106,6 +106,14 @@ impl<N: Network> RegistersTrait<N> for FinalizeRegisters<N> {
                 };
                 return Ok(Value::Plaintext(Plaintext::from(Literal::Address(address))));
             }
+            // If the operand is a component checksum, load the checksum of the named component.
+            Operand::ComponentChecksum(program_id, name) => {
+                let checksum = match program_id {
+                    Some(program_id) => *stack.get_external_stack(program_id)?.component_checksum(name)?,
+                    None => *stack.component_checksum(name)?,
+                };
+                return Ok(Value::Plaintext(Plaintext::from(checksum)));
+            }
         };
 
         // Retrieve the value.

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -67,6 +67,8 @@ impl<N: Network> FinalizeTypes<N> {
         }
 
         // Type-check the outputs: each output operand must resolve and match the declared type.
+        // Output operands do not flow through `check_command`, so the component checksum check is repeated here.
+        // Only views have outputs; finalize and constructor scopes have none.
         for output in view.outputs() {
             // If the operand is `Operand::ComponentChecksum`, ensure the referenced component exists.
             if let Operand::ComponentChecksum(program_id, name) = output.operand() {

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -68,6 +68,10 @@ impl<N: Network> FinalizeTypes<N> {
 
         // Type-check the outputs: each output operand must resolve and match the declared type.
         for output in view.outputs() {
+            // If the operand is `Operand::ComponentChecksum`, ensure the referenced component exists.
+            if let Operand::ComponentChecksum(program_id, name) = output.operand() {
+                Self::check_component_checksum(stack, program_id, name)?;
+            }
             let actual = finalize_types.get_type_from_operand(stack, output.operand())?;
             if &actual != output.finalize_type() {
                 bail!(
@@ -228,8 +232,8 @@ impl<N: Network> FinalizeTypes<N> {
     ) -> Result<()> {
         // Check the operands.
         for operand in command.operands() {
-            // If the operand is `Operand::Checksum`, `Operand::Edition`, or `Operand::ProgramOwner` and it contains a program ID,
-            // ensure that the program ID is imported by the current program.
+            // If the operand is `Operand::Checksum`, `Operand::Edition`, or `Operand::ProgramOwner` and it contains a
+            // program ID, ensure that the program ID is imported by the current program.
             match operand {
                 Operand::Checksum(program_id) | Operand::Edition(program_id) | Operand::ProgramOwner(program_id) => {
                     if let Some(program_id) = program_id {
@@ -237,6 +241,10 @@ impl<N: Network> FinalizeTypes<N> {
                             bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
                         }
                     }
+                }
+                // If the operand is `Operand::ComponentChecksum`, ensure the referenced component exists.
+                Operand::ComponentChecksum(program_id, name) => {
+                    Self::check_component_checksum(stack, program_id, name)?
                 }
                 _ => {}
             }
@@ -257,6 +265,32 @@ impl<N: Network> FinalizeTypes<N> {
             Command::BranchNeq(branch_neq) => self.check_branch(stack, positions, branch_neq)?,
             // Note that the `Position`s are checked for uniqueness when constructing `Finalize` or `Constructor`.
             Command::Position(_) => (),
+        }
+        Ok(())
+    }
+
+    /// Ensures the program referenced by a component checksum operand is imported (if external) and that the
+    /// named component exists as a function, closure, or view in the target program, so a dangling reference
+    /// is rejected at deployment instead of failing on every execution.
+    fn check_component_checksum(
+        stack: &Stack<N>,
+        program_id: &Option<ProgramID<N>>,
+        name: &Identifier<N>,
+    ) -> Result<()> {
+        // Returns `true` if `name` is a function, closure, or view in the given program.
+        let is_component = |program: &Program<N>| {
+            program.contains_function(name) || program.contains_closure(name) || program.contains_view(name)
+        };
+        let exists = match program_id {
+            Some(program_id) => match stack.get_external_stack(program_id) {
+                Ok(external_stack) => is_component(external_stack.program()),
+                Err(_) => bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id()),
+            },
+            None => is_component(stack.program()),
+        };
+        if !exists {
+            let program_id = (*program_id).unwrap_or(*stack.program_id());
+            bail!("'{name}' in a component checksum operand is not a function, closure, or view in '{program_id}'.");
         }
         Ok(())
     }

--- a/synthesizer/process/src/stack/finalize_types/matches.rs
+++ b/synthesizer/process/src/stack/finalize_types/matches.rs
@@ -67,7 +67,7 @@ impl<N: Network> FinalizeTypes<N> {
                         "Struct member '{struct_name}.{member_name}' expects {member_type}, but found '{plaintext_type}' in the operand '{operand}'.",
                     )
                 }
-                // Ensure the program ID, block height, block timestamp, network ID, generator, checksum, edition, and program owner types matches the member type.
+                // Ensure the program ID, block height, block timestamp, network ID, generator, checksum, edition, program owner, and component checksum types matches the member type.
                 Operand::ProgramID(..)
                 | Operand::BlockHeight
                 | Operand::BlockTimestamp
@@ -76,7 +76,8 @@ impl<N: Network> FinalizeTypes<N> {
                 | Operand::AleoGeneratorPowers(_)
                 | Operand::Checksum(_)
                 | Operand::Edition(_)
-                | Operand::ProgramOwner(_) => {
+                | Operand::ProgramOwner(_)
+                | Operand::ComponentChecksum(..) => {
                     // Retrieve the operand type.
                     let FinalizeType::Plaintext(program_ref_type) = self.get_type_from_operand(stack, operand)? else {
                         bail!(
@@ -160,7 +161,8 @@ impl<N: Network> FinalizeTypes<N> {
                 | Operand::AleoGeneratorPowers(_)
                 | Operand::Checksum(_)
                 | Operand::Edition(_)
-                | Operand::ProgramOwner(_) => {
+                | Operand::ProgramOwner(_)
+                | Operand::ComponentChecksum(..) => {
                     // Retrieve the operand type.
                     let FinalizeType::Plaintext(program_ref_type) = self.get_type_from_operand(stack, operand)? else {
                         bail!("Expected a plaintext type for the operand '{operand}' in array element '{array_type}'")

--- a/synthesizer/process/src/stack/finalize_types/mod.rs
+++ b/synthesizer/process/src/stack/finalize_types/mod.rs
@@ -27,6 +27,7 @@ use console::{
         Identifier,
         LiteralType,
         PlaintextType,
+        ProgramID,
         Register,
         RegisterType,
         StructType,
@@ -133,6 +134,10 @@ impl<N: Network> FinalizeTypes<N> {
             )?)),
             Operand::Edition(_) => FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::U16)),
             Operand::ProgramOwner(_) => FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::Address)),
+            Operand::ComponentChecksum(..) => FinalizeType::Plaintext(PlaintextType::Array(ArrayType::new(
+                PlaintextType::Literal(LiteralType::U8),
+                vec![U32::new(32)],
+            )?)),
         })
     }
 

--- a/synthesizer/process/src/stack/helpers/initialize.rs
+++ b/synthesizer/process/src/stack/helpers/initialize.rs
@@ -58,6 +58,14 @@ impl<N: Network> Stack<N> {
             verifying_keys: Default::default(),
             program_address: program.id().to_address()?,
             program_checksum: program.to_checksum(),
+            // Component names are unique within a program, so functions, closures, and views never collide here.
+            component_checksums: program
+                .functions()
+                .iter()
+                .map(|(name, function)| (*name, function.to_checksum()))
+                .chain(program.closures().iter().map(|(name, closure)| (*name, closure.to_checksum())))
+                .chain(program.views().iter().map(|(name, view)| (*name, view.to_checksum())))
+                .collect(),
             program_edition: U16::new(edition),
             program_amendment_count: 0,
             program_owner: None,

--- a/synthesizer/process/src/stack/helpers/stack_trait.rs
+++ b/synthesizer/process/src/stack/helpers/stack_trait.rs
@@ -218,6 +218,13 @@ impl<N: Network> StackTrait<N> for Stack<N> {
         Field::from_bits_le(&bits)
     }
 
+    /// Returns the checksum of the program component (function, closure, or view) with the given name.
+    fn component_checksum(&self, name: &Identifier<N>) -> Result<&[U8<N>; 32]> {
+        self.component_checksums
+            .get(name)
+            .ok_or_else(|| anyhow!("'{name}' is not a function, closure, or view in '{}'.", self.program_id()))
+    }
+
     /// Returns the program edition.
     #[inline]
     fn program_edition(&self) -> U16<N> {

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -273,6 +273,8 @@ pub struct Stack<N: Network> {
     program_address: Address<N>,
     /// The program checksum.
     program_checksum: [U8<N>; 32],
+    /// The checksum of each component (function, closure, or view) in the program.
+    component_checksums: IndexMap<Identifier<N>, [U8<N>; 32]>,
     /// The program edition.
     program_edition: U16<N>,
     /// The number of amendments applied to the current program edition.

--- a/synthesizer/process/src/stack/register_types/matches.rs
+++ b/synthesizer/process/src/stack/register_types/matches.rs
@@ -140,6 +140,12 @@ impl<N: Network> RegisterTypes<N> {
                         "Struct member '{struct_name}.{member_name}' cannot be from a program owner in a non-finalize scope"
                     )
                 }
+                // If the operand is a component checksum type, throw an error.
+                Operand::ComponentChecksum(..) => {
+                    bail!(
+                        "Struct member '{struct_name}.{member_name}' cannot be from a component checksum in a non-finalize scope"
+                    )
+                }
             }
         }
         Ok(())
@@ -245,6 +251,10 @@ impl<N: Network> RegisterTypes<N> {
                 Operand::ProgramOwner(_) => {
                     bail!("Array element cannot be from a program owner in a non-finalize scope")
                 }
+                // If the operand is a component checksum type, throw an error.
+                Operand::ComponentChecksum(..) => {
+                    bail!("Array element cannot be from a component checksum in a non-finalize scope")
+                }
             }
         }
         Ok(())
@@ -322,6 +332,9 @@ impl<N: Network> RegisterTypes<N> {
             }
             Operand::ProgramOwner(_) => {
                 bail!("Forbidden operation: Cannot cast a program owner as a record owner")
+            }
+            Operand::ComponentChecksum(..) => {
+                bail!("Forbidden operation: Cannot cast a component checksum as a record owner")
             }
         }
 
@@ -431,6 +444,12 @@ impl<N: Network> RegisterTypes<N> {
                         Operand::ProgramOwner(_) => {
                             bail!(
                                 "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found a program owner in the operand '{operand}'."
+                            )
+                        }
+                        // Fail if the operand is a component checksum.
+                        Operand::ComponentChecksum(..) => {
+                            bail!(
+                                "Record entry '{record_name}.{entry_name}' expects a '{plaintext_type}', but found a component checksum in the operand '{operand}'."
                             )
                         }
                     }

--- a/synthesizer/process/src/stack/register_types/mod.rs
+++ b/synthesizer/process/src/stack/register_types/mod.rs
@@ -115,6 +115,9 @@ impl<N: Network> RegisterTypes<N> {
             Operand::Checksum(_) => bail!("'checksum' is not a valid operand in a non-finalize context."),
             Operand::Edition(_) => bail!("'edition' is not a valid operand in a non-finalize context."),
             Operand::ProgramOwner(_) => bail!("'program_owner' is not a valid operand in a non-finalize context."),
+            Operand::ComponentChecksum(..) => {
+                bail!("a component checksum is not a valid operand in a non-finalize context.")
+            }
         })
     }
 

--- a/synthesizer/process/src/stack/registers/registers_circuit.rs
+++ b/synthesizer/process/src/stack/registers/registers_circuit.rs
@@ -143,6 +143,8 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersCircuit<N, A> for Regis
             Operand::Edition(_) => bail!("Cannot load the edition in a non-finalize context"),
             // If the operand is the program owner, throw an error.
             Operand::ProgramOwner(_) => bail!("Cannot load the program owner in a non-finalize context"),
+            // If the operand is the component checksum, throw an error.
+            Operand::ComponentChecksum(..) => bail!("Cannot load the component checksum in a non-finalize context"),
         };
 
         // Retrieve the circuit value.

--- a/synthesizer/process/src/stack/registers/registers_trait.rs
+++ b/synthesizer/process/src/stack/registers/registers_trait.rs
@@ -132,6 +132,8 @@ impl<N: Network, A: circuit::Aleo<Network = N>> RegistersTrait<N> for Registers<
             Operand::Edition(_) => bail!("Cannot load the edition in a non-finalize context"),
             // If the operand is the program owner, throw an error.
             Operand::ProgramOwner(_) => bail!("Cannot load the program owner in a non-finalize context"),
+            // If the operand is the component checksum, throw an error.
+            Operand::ComponentChecksum(..) => bail!("Cannot load the component checksum in a non-finalize context"),
         };
 
         // Retrieve the stack value.

--- a/synthesizer/program/src/closure/mod.rs
+++ b/synthesizer/program/src/closure/mod.rs
@@ -55,6 +55,14 @@ impl<N: Network> ClosureCore<N> {
         &self.name
     }
 
+    /// Returns the checksum of the closure.
+    ///
+    /// The checksum is a 32-byte hash of the closure's source code in string format.
+    /// This ensures a strict definition of closure equivalence, useful for program upgradability.
+    pub fn to_checksum(&self) -> [console::types::U8<N>; 32] {
+        crate::to_checksum::source_code_checksum(&self.to_string())
+    }
+
     /// Returns the closure inputs.
     pub const fn inputs(&self) -> &IndexSet<Input<N>> {
         &self.inputs

--- a/synthesizer/program/src/function/mod.rs
+++ b/synthesizer/program/src/function/mod.rs
@@ -26,6 +26,7 @@ use crate::{Instruction, finalize::FinalizeCore};
 use console::{
     network::prelude::*,
     program::{Identifier, Register, ValueType},
+    types::U8,
 };
 
 use indexmap::IndexSet;
@@ -237,6 +238,14 @@ impl<N: Network> FunctionCore<N> {
         // Insert the finalize scope.
         self.finalize_logic = Some(finalize);
         Ok(())
+    }
+
+    /// Returns the checksum of the function.
+    ///
+    /// The checksum is a 32-byte hash of the function's source code in string format.
+    /// This ensures a strict definition of function equivalence, useful for program upgradability.
+    pub fn to_checksum(&self) -> [U8<N>; 32] {
+        crate::to_checksum::source_code_checksum(&self.to_string())
     }
 }
 

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -1437,6 +1437,32 @@ impl<N: Network> ProgramCore<N> {
         function_contains || closure_contains || command_contains || finalize_has_call || !self.views.is_empty()
     }
 
+    /// Returns `true` if a program contains any V16 syntax.
+    /// This includes the `Operand::ComponentChecksum` operand.
+    /// This is enforced to be `false` for programs before `ConsensusVersion::V16`.
+    #[inline]
+    pub fn contains_v16_syntax(&self) -> bool {
+        // Check each command operand in every finalize and constructor scope for `Operand::ComponentChecksum`.
+        let command_contains = cfg_iter!(self.functions())
+            .flat_map(|(_, function)| function.finalize_logic().map(|finalize| finalize.commands()))
+            .flatten()
+            .chain(cfg_iter!(self.constructor).flat_map(|constructor| constructor.commands()))
+            .flat_map(|command| command.operands())
+            .any(|operand| matches!(operand, Operand::ComponentChecksum(..)));
+
+        // Check each view command operand and view output operand, since views (allowed since V15) also
+        // accept finalize-context operands.
+        let view_contains = self.views.values().any(|view| {
+            view.commands()
+                .iter()
+                .flat_map(|command| command.operands())
+                .any(|operand| matches!(operand, Operand::ComponentChecksum(..)))
+                || view.outputs().iter().any(|output| matches!(output.operand(), Operand::ComponentChecksum(..)))
+        });
+
+        command_contains || view_contains
+    }
+
     /// Returns `true` if a program contains any string type.
     /// Before ConsensusVersion::V12, variable-length string sampling when using them as inputs caused deployment synthesis to be inconsistent and abort with probability 63/64.
     /// After ConsensusVersion::V12, string types are disallowed.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -1442,25 +1442,22 @@ impl<N: Network> ProgramCore<N> {
     /// This is enforced to be `false` for programs before `ConsensusVersion::V16`.
     #[inline]
     pub fn contains_v16_syntax(&self) -> bool {
-        // Check each command operand in every finalize and constructor scope for `Operand::ComponentChecksum`.
+        // Check each command operand in every finalize, constructor, and view scope for `Operand::ComponentChecksum`.
         let command_contains = cfg_iter!(self.functions())
             .flat_map(|(_, function)| function.finalize_logic().map(|finalize| finalize.commands()))
             .flatten()
             .chain(cfg_iter!(self.constructor).flat_map(|constructor| constructor.commands()))
+            .chain(cfg_iter!(self.views).flat_map(|(_, view)| view.commands()))
             .flat_map(|command| command.operands())
             .any(|operand| matches!(operand, Operand::ComponentChecksum(..)));
 
-        // Check each view command operand and view output operand, since views (allowed since V15) also
-        // accept finalize-context operands.
-        let view_contains = self.views.values().any(|view| {
-            view.commands()
-                .iter()
-                .flat_map(|command| command.operands())
-                .any(|operand| matches!(operand, Operand::ComponentChecksum(..)))
-                || view.outputs().iter().any(|output| matches!(output.operand(), Operand::ComponentChecksum(..)))
-        });
+        // Views additionally have output operands, which are not commands and so are checked separately.
+        let view_output_contains = self
+            .views
+            .values()
+            .any(|view| view.outputs().iter().any(|output| matches!(output.operand(), Operand::ComponentChecksum(..))));
 
-        command_contains || view_contains
+        command_contains || view_output_contains
     }
 
     /// Returns `true` if a program contains any string type.

--- a/synthesizer/program/src/logic/instruction/operand/bytes.rs
+++ b/synthesizer/program/src/logic/instruction/operand/bytes.rs
@@ -64,6 +64,21 @@ impl<N: Network> FromBytes for Operand<N> {
                     false => Ok(Self::AleoGeneratorPowers(None)),
                 }
             }
+            13 => {
+                // Read the program ID.
+                let program_id = match u8::read_le(&mut reader)? {
+                    0 => None,
+                    1 => Some(ProgramID::read_le(&mut reader)?),
+                    variant => {
+                        return Err(error(format!(
+                            "Invalid program ID variant '{variant}' for the component checksum"
+                        )));
+                    }
+                };
+                // Read the component name.
+                let name = Identifier::read_le(&mut reader)?;
+                Ok(Self::ComponentChecksum(program_id, name))
+            }
             variant => Err(error(format!("Failed to deserialize operand variant {variant}"))),
         }
     }
@@ -133,6 +148,19 @@ impl<N: Network> ToBytes for Operand<N> {
                     }
                     None => false.write_le(&mut writer),
                 }
+            }
+            Self::ComponentChecksum(program_id, name) => {
+                13u8.write_le(&mut writer)?;
+                // Write the program ID.
+                match program_id {
+                    None => 0u8.write_le(&mut writer)?,
+                    Some(program_id) => {
+                        1u8.write_le(&mut writer)?;
+                        program_id.write_le(&mut writer)?;
+                    }
+                }
+                // Write the component name.
+                name.write_le(&mut writer)
             }
         }
     }

--- a/synthesizer/program/src/logic/instruction/operand/mod.rs
+++ b/synthesizer/program/src/logic/instruction/operand/mod.rs
@@ -18,7 +18,7 @@ mod parse;
 
 use console::{
     network::prelude::*,
-    program::{Literal, ProgramID, Register},
+    program::{Identifier, Literal, ProgramID, Register},
     types::{Group, U32},
 };
 
@@ -63,6 +63,10 @@ pub enum Operand<N: Network> {
     /// If no program ID is specified, the owner is for the current program.
     /// If a program ID is specified, the owner is for an external program.
     ProgramOwner(Option<ProgramID<N>>),
+    /// The operand is the checksum of a named program component (a function, closure, or view).
+    /// If no program ID is specified, the component is in the current program.
+    /// If a program ID is specified, the component is in an external program.
+    ComponentChecksum(Option<ProgramID<N>>, Identifier<N>),
 }
 
 impl<N: Network> From<Literal<N>> for Operand<N> {

--- a/synthesizer/program/src/logic/instruction/operand/parse.rs
+++ b/synthesizer/program/src/logic/instruction/operand/parse.rs
@@ -34,10 +34,10 @@ impl<N: Network> Parser for Operand<N> {
                 |(_, index)| Self::AleoGeneratorPowers(index),
             ),
             map(tag("aleo::GENERATOR"), |_| Self::AleoGenerator),
-            // Note that `Operand::ComponentChecksum` (`<name>/checksum`) must be parsed before `Operand::Checksum`,
-            // `Operand::Edition`, `Operand::ProgramOwner`, and `Operand::ProgramID`s, since a component name may
-            // collide with those keywords and may be prefixed with a program ID. This is unambiguous since a program
-            // ID always carries a network suffix (e.g. `.aleo`) while an identifier never does.
+            // Parse `Operand::ComponentChecksum` (`<name>/checksum`) before `Operand::Checksum`, since a component
+            // may be named after a keyword. For example, a function named `checksum` is referenced as
+            // `checksum/checksum`: if `Operand::Checksum` were tried first, it would match the leading `checksum`
+            // and misparse it as the program checksum, leaving `/checksum` unconsumed.
             map(
                 pair(
                     pair(opt(terminated(ProgramID::parse, tag("/"))), terminated(Identifier::parse, tag("/"))),

--- a/synthesizer/program/src/logic/instruction/operand/parse.rs
+++ b/synthesizer/program/src/logic/instruction/operand/parse.rs
@@ -34,6 +34,17 @@ impl<N: Network> Parser for Operand<N> {
                 |(_, index)| Self::AleoGeneratorPowers(index),
             ),
             map(tag("aleo::GENERATOR"), |_| Self::AleoGenerator),
+            // Note that `Operand::ComponentChecksum` (`<name>/checksum`) must be parsed before `Operand::Checksum`,
+            // `Operand::Edition`, `Operand::ProgramOwner`, and `Operand::ProgramID`s, since a component name may
+            // collide with those keywords and may be prefixed with a program ID. This is unambiguous since a program
+            // ID always carries a network suffix (e.g. `.aleo`) while an identifier never does.
+            map(
+                pair(
+                    pair(opt(terminated(ProgramID::parse, tag("/"))), terminated(Identifier::parse, tag("/"))),
+                    tag("checksum"),
+                ),
+                |((program_id, name), _)| Self::ComponentChecksum(program_id, name),
+            ),
             // Note that `Operand::Checksum` and `Operand::Edition` must be parsed before `Operand::ProgramID`s, since an edition or checksum may be prefixed with a program ID.
             map(pair(opt(terminated(ProgramID::parse, tag("/"))), tag("checksum")), |(program_id, _)| {
                 Self::Checksum(program_id)
@@ -121,6 +132,11 @@ impl<N: Network> Display for Operand<N> {
                 Some(program_id) => write!(f, "{program_id}/program_owner"),
                 None => write!(f, "program_owner"),
             },
+            // Prints the optional program ID with the component name and the checksum keyword, i.e. `transfer/checksum` or `token.aleo/transfer/checksum`
+            Self::ComponentChecksum(program_id, name) => match program_id {
+                Some(program_id) => write!(f, "{program_id}/{name}/checksum"),
+                None => write!(f, "{name}/checksum"),
+            },
         }
     }
 }
@@ -191,6 +207,28 @@ mod tests {
         let operand = Operand::<CurrentNetwork>::parse("token.aleo/program_owner").unwrap().1;
         assert_eq!(Operand::ProgramOwner(Some(ProgramID::from_str("token.aleo")?)), operand);
 
+        let operand = Operand::<CurrentNetwork>::parse("transfer/checksum").unwrap().1;
+        assert_eq!(Operand::ComponentChecksum(None, Identifier::from_str("transfer")?), operand);
+
+        let operand = Operand::<CurrentNetwork>::parse("token.aleo/transfer/checksum").unwrap().1;
+        assert_eq!(
+            Operand::ComponentChecksum(Some(ProgramID::from_str("token.aleo")?), Identifier::from_str("transfer")?),
+            operand
+        );
+
+        // Ensure a bare `checksum` (and `program/checksum`) still parses as the program checksum, not a component.
+        let operand = Operand::<CurrentNetwork>::parse("checksum").unwrap().1;
+        assert_eq!(Operand::Checksum(None), operand);
+        let operand = Operand::<CurrentNetwork>::parse("token.aleo/checksum").unwrap().1;
+        assert_eq!(Operand::Checksum(Some(ProgramID::from_str("token.aleo")?)), operand);
+
+        // Ensure component names that collide with operand keywords still parse as a component checksum and roundtrip.
+        for name in ["checksum", "edition", "program_owner", "edition_v2", "checksums", "program_owner_x"] {
+            let operand = Operand::<CurrentNetwork>::parse(&format!("{name}/checksum")).unwrap().1;
+            assert_eq!(Operand::ComponentChecksum(None, Identifier::from_str(name)?), operand);
+            assert_eq!(format!("{operand}"), format!("{name}/checksum"));
+        }
+
         // Sanity check a failure case.
         let (remainder, operand) = Operand::<CurrentNetwork>::parse("1field.private").unwrap();
         assert_eq!(Operand::Literal(Literal::from_str("1field")?), operand);
@@ -245,6 +283,12 @@ mod tests {
 
         let operand = Operand::<CurrentNetwork>::parse("foo.aleo/program_owner").unwrap().1;
         assert_eq!(format!("{operand}"), "foo.aleo/program_owner");
+
+        let operand = Operand::<CurrentNetwork>::parse("transfer/checksum").unwrap().1;
+        assert_eq!(format!("{operand}"), "transfer/checksum");
+
+        let operand = Operand::<CurrentNetwork>::parse("foo.aleo/transfer/checksum").unwrap().1;
+        assert_eq!(format!("{operand}"), "foo.aleo/transfer/checksum");
 
         let operand = Operand::<CurrentNetwork>::parse("group::GEN").unwrap().1;
         assert_eq!(

--- a/synthesizer/program/src/to_checksum.rs
+++ b/synthesizer/program/src/to_checksum.rs
@@ -15,17 +15,22 @@
 
 use super::*;
 
+/// Returns the 32-byte SHA3-256 checksum of the given source code in string format.
+pub(crate) fn source_code_checksum<N: Network>(source: &str) -> [U8<N>; 32] {
+    let mut keccak = TinySha3::v256();
+    keccak.update(source.as_bytes());
+
+    let mut hash = [0u8; 32];
+    keccak.finalize(&mut hash);
+    hash.map(U8::new)
+}
+
 impl<N: Network> ProgramCore<N> {
     /// Returns the checksum of the program.
     ///
     /// The checksum is a 32-byte hash of the program's source code in string format.
     /// This ensures a strict definition of program equivalence, useful for program upgradability.
     pub fn to_checksum(&self) -> [U8<N>; 32] {
-        let mut keccak = TinySha3::v256();
-        keccak.update(self.to_string().as_bytes());
-
-        let mut hash = [0u8; 32];
-        keccak.finalize(&mut hash);
-        hash.map(U8::new)
+        source_code_checksum(&self.to_string())
     }
 }

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -114,6 +114,9 @@ pub trait StackTrait<N: Network> {
     /// Returns the program checksum as a field element.
     fn program_checksum_as_field(&self) -> Result<Field<N>>;
 
+    /// Returns the checksum of the program component (function, closure, or view) with the given name.
+    fn component_checksum(&self, name: &Identifier<N>) -> Result<&[U8<N>; 32]>;
+
     /// Returns the program edition.
     fn program_edition(&self) -> U16<N>;
 

--- a/synthesizer/program/src/view/mod.rs
+++ b/synthesizer/program/src/view/mod.rs
@@ -67,6 +67,14 @@ impl<N: Network> ViewCore<N> {
         &self.name
     }
 
+    /// Returns the checksum of the view.
+    ///
+    /// The checksum is a 32-byte hash of the view's source code in string format.
+    /// This ensures a strict definition of view equivalence, useful for program upgradability.
+    pub fn to_checksum(&self) -> [console::types::U8<N>; 32] {
+        crate::to_checksum::source_code_checksum(&self.to_string())
+    }
+
     /// Returns the view inputs.
     pub const fn inputs(&self) -> &IndexSet<Input<N>> {
         &self.inputs

--- a/synthesizer/src/vm/tests/test_v15/views.rs
+++ b/synthesizer/src/vm/tests/test_v15/views.rs
@@ -2268,18 +2268,18 @@ fn test_evaluate_view_uses_historic_program_edition() -> Result<()> {
 
     // Deploy edition 0, then set `balances[addr] = 5`.
     let tx = vm.deploy(&caller_private_key, &program(0)?, None, 0, None, rng)?;
-    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, None, &[tx], rng);
     let inputs = [Value::from_str(&caller_address.to_string())?, Value::from_str("5u64")?];
     let tx = vm.execute(&caller_private_key, ("vw_upgrade.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
-    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, Some(&[&inputs]), &[tx], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), &[tx], rng);
     let height_v0 = vm.block_store().current_block_height();
 
     // Upgrade to edition 1 (+100), then edition 2 (+1000).
     let tx = vm.deploy(&caller_private_key, &program(100)?, None, 0, None, rng)?;
-    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, None, &[tx], rng);
     let height_v1 = vm.block_store().current_block_height();
     let tx = vm.deploy(&caller_private_key, &program(1000)?, None, 0, None, rng)?;
-    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, None, &[tx], rng);
     let height_v2 = vm.block_store().current_block_height();
 
     let total = |height: u32| {
@@ -2303,7 +2303,6 @@ fn test_evaluate_view_uses_historic_program_edition() -> Result<()> {
 fn test_evaluate_view_before_deployment_height_errors() -> Result<()> {
     let rng = &mut TestRng::default();
     let caller_private_key = sample_genesis_private_key(rng);
-    let caller_address = Address::try_from(&caller_private_key)?;
 
     let program = Program::from_str(
         r"
@@ -2326,7 +2325,7 @@ fn test_evaluate_view_before_deployment_height_errors() -> Result<()> {
     // A valid block height that predates the program's deployment.
     let before = vm.block_store().current_block_height();
     let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
-    add_and_test_with_costs(&vm, &caller_private_key, &caller_address, None, &[tx], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, None, &[tx], rng);
 
     let err = vm.evaluate_view_at_height("vw_predeploy.aleo", "fixed", vec![], before).unwrap_err().to_string();
     assert!(err.contains("was not deployed at or before height"), "unexpected error: {err}");

--- a/synthesizer/src/vm/tests/test_v16/component_checksum.rs
+++ b/synthesizer/src/vm/tests/test_v16/component_checksum.rs
@@ -1,0 +1,425 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+use console::program::{Identifier, Plaintext, ProgramID, Value};
+
+// The constructor pins the checksum of `foo`: on the first deploy it records `foo/checksum` in a
+// mapping, and on every subsequent upgrade it asserts that the (immutable) recorded checksum still
+// matches the current `foo`. Because the constructor cannot change after the first deploy, this
+// freezes `foo` for the lifetime of the program even as other functions are added or changed.
+const PINNED_CONSTRUCTOR: &str = r"
+constructor:
+    branch.neq edition 0u16 to rest;
+    set foo/checksum into pinned[true];
+    branch.eq true true to end;
+    position rest;
+    get pinned[true] into r0;
+    assert.eq r0 foo/checksum;
+    position end;";
+
+// The body of `foo` shared by `program_v0` and `program_v1`: a simple passthrough.
+const FOO_UNCHANGED: &str = r"    input r0 as u64.public;
+    output r0 as u64.public;";
+
+// A different body for `foo` (its input and output types are preserved so the upgrade still passes the
+// structural checks), so its checksum no longer matches the pinned value.
+const FOO_CHANGED: &str = r"    input r0 as u64.public;
+    add r0 r0 into r1;
+    output r1 as u64.public;";
+
+// Builds `test_checksum.aleo` with the given `foo` body, optionally adding a second function `bar`.
+fn program(foo: &str, include_bar: bool) -> Program<CurrentNetwork> {
+    let bar = if include_bar {
+        r"
+function bar:
+    input r0 as u64.public;
+    output r0 as u64.public;
+"
+    } else {
+        ""
+    };
+    Program::from_str(&format!(
+        r"
+program test_checksum.aleo;
+
+mapping pinned:
+    key as boolean.public;
+    value as [u8; 32u32].public;
+
+function foo:
+{foo}
+{bar}{PINNED_CONSTRUCTOR}"
+    ))
+    .unwrap()
+}
+
+// Returns the checksum of `foo` within the given program.
+fn foo_checksum(program: &Program<CurrentNetwork>) -> [console::types::U8<CurrentNetwork>; 32] {
+    program.get_function(&Identifier::from_str("foo").unwrap()).unwrap().to_checksum()
+}
+
+// A simple positive check of the checksum's semantics, without a VM: it is deterministic, ignores
+// other functions in the program, and changes when the function's body changes.
+#[test]
+fn test_checksum_is_deterministic_and_body_sensitive() {
+    let v0 = program(FOO_UNCHANGED, false);
+    let v1 = program(FOO_UNCHANGED, true);
+    let v2 = program(FOO_CHANGED, true);
+
+    // The checksum is deterministic.
+    assert_eq!(foo_checksum(&v0), foo_checksum(&v0));
+    // Adding an unrelated function (`bar`) does not change `foo`'s checksum.
+    assert_eq!(foo_checksum(&v0), foo_checksum(&v1));
+    // Changing `foo`'s body changes its checksum.
+    assert_ne!(foo_checksum(&v0), foo_checksum(&v2));
+}
+
+// A program that records the checksum of a function, a closure, and a view, to verify that
+// `<name>/checksum` resolves each component kind by name and loads exactly its `to_checksum`.
+fn all_kinds_program() -> Program<CurrentNetwork> {
+    Program::from_str(
+        r"
+program test_checksum_kinds.aleo;
+
+mapping checksums:
+    key as u8.public;
+    value as [u8; 32u32].public;
+
+closure cls:
+    input r0 as u64;
+    add r0 r0 into r1;
+    output r1 as u64;
+
+function foo:
+    input r0 as u64.public;
+    output r0 as u64.public;
+
+view vw:
+    output 0u64 as u64.public;
+
+constructor:
+    set foo/checksum into checksums[0u8];
+    set cls/checksum into checksums[1u8];
+    set vw/checksum into checksums[2u8];
+",
+    )
+    .unwrap()
+}
+
+// This test verifies that `<name>/checksum` works for a function, a closure, and a view, and that
+// each recorded value equals the corresponding component's `to_checksum`.
+#[test]
+fn test_checksum_resolves_function_closure_and_view() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V16 height.
+    let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v16_height, rng);
+
+    // Deploy the program, whose constructor records all three checksums.
+    let program = all_kinds_program();
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    vm.add_next_block(&block).unwrap();
+
+    // The expected checksum of each component.
+    let expected_fn = program.get_function(&Identifier::from_str("foo").unwrap()).unwrap().to_checksum();
+    let expected_cls = program.closures().get(&Identifier::from_str("cls").unwrap()).unwrap().to_checksum();
+    let expected_view = program.views().get(&Identifier::from_str("vw").unwrap()).unwrap().to_checksum();
+
+    // Verify each recorded value matches.
+    for (key, expected) in [(0u8, expected_fn), (1u8, expected_cls), (2u8, expected_view)] {
+        let stored = vm
+            .finalize_store()
+            .get_value_confirmed(
+                ProgramID::from_str("test_checksum_kinds.aleo").unwrap(),
+                Identifier::from_str("checksums").unwrap(),
+                &Plaintext::from_str(&format!("{key}u8")).unwrap(),
+            )
+            .unwrap();
+        let Some(Value::Plaintext(stored)) = stored else {
+            panic!("Expected a plaintext value in 'checksums[{key}u8]'");
+        };
+        assert_eq!(Plaintext::from(expected), stored, "checksum mismatch for key {key}");
+    }
+}
+
+// This test verifies that `<name>/checksum` pins a function across upgrades: the program may grow
+// (adding `bar`) as long as `foo` is unchanged, but an upgrade that changes `foo` is rejected.
+#[test]
+fn test_checksum_pin_across_upgrade() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V16 height.
+    let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v16_height, rng);
+
+    // Deploy v0, which records `foo`'s checksum on first deploy.
+    let v0 = program(FOO_UNCHANGED, false);
+    let deployment = vm.deploy(&caller_private_key, &v0, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    vm.add_next_block(&block).unwrap();
+
+    // Verify the pinned checksum matches `foo`'s actual checksum.
+    let expected = Plaintext::from(foo_checksum(&v0));
+    let stored = vm
+        .finalize_store()
+        .get_value_confirmed(
+            ProgramID::from_str("test_checksum.aleo").unwrap(),
+            Identifier::from_str("pinned").unwrap(),
+            &Plaintext::from_str("true").unwrap(),
+        )
+        .unwrap();
+    let Some(Value::Plaintext(stored)) = stored else {
+        panic!("Expected a plaintext value in 'pinned'");
+    };
+    assert_eq!(expected, stored);
+
+    // Upgrade with `foo` unchanged (adding `bar`). The pinned checksum still matches, so it is accepted.
+    let v1 = program(FOO_UNCHANGED, true);
+    let deployment = vm.deploy(&caller_private_key, &v1, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    vm.add_next_block(&block).unwrap();
+
+    // Upgrade with `foo` changed. The pinned checksum no longer matches, so the constructor's
+    // assertion fails and the upgrade is rejected.
+    let v2 = program(FOO_CHANGED, true);
+    let deployment = vm.deploy(&caller_private_key, &v2, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.transactions().num_rejected(), 1);
+    vm.add_next_block(&block).unwrap();
+}
+
+// A minimal program that uses `<name>/checksum` in its constructor.
+fn simple_checksum_program() -> Program<CurrentNetwork> {
+    Program::from_str(
+        r"
+program test_checksum_gate.aleo;
+
+mapping checksums:
+    key as u8.public;
+    value as [u8; 32u32].public;
+
+function foo:
+    input r0 as u64.public;
+    output r0 as u64.public;
+
+constructor:
+    set foo/checksum into checksums[0u8];
+",
+    )
+    .unwrap()
+}
+
+// This test verifies that a program using `<name>/checksum` cannot be deployed before V16.
+#[test]
+fn test_checksum_rejected_pre_v16() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    let program = simple_checksum_program();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V15 height (pre-V16).
+    let v15_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v15_height, rng);
+
+    // The deployment is rejected by verification because the component checksum is not allowed before V16.
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let deployment_id = deployment.id();
+    assert!(vm.check_transaction(&deployment, None, rng).is_err());
+
+    // The transaction is aborted when included in a block.
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids(), &[deployment_id]);
+}
+
+// A program that references `<name>/checksum` from inside a view's output operand. Views are a V15
+// feature, so the pre-V16 gate must look inside them too, otherwise this would bypass it.
+fn view_checksum_program() -> Program<CurrentNetwork> {
+    Program::from_str(
+        r"
+program test_checksum_view.aleo;
+
+function foo:
+    input r0 as u64.public;
+    output r0 as u64.public;
+
+view foo_checksum:
+    output foo/checksum as [u8; 32u32].public;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .unwrap()
+}
+
+// This test verifies that a component checksum hidden in a view is still rejected before V16, i.e. the
+// pre-V16 gate scans view commands and outputs (regression test for the view-scan gap).
+#[test]
+fn test_checksum_in_view_rejected_pre_v16() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    let program = view_checksum_program();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V15 height (pre-V16, but views are allowed).
+    let v15_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v15_height, rng);
+
+    // The deployment is rejected by verification, since the view carries a V16-only operand.
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let deployment_id = deployment.id();
+    assert!(vm.check_transaction(&deployment, None, rng).is_err());
+
+    // The transaction is aborted when included in a block.
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 0);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    assert_eq!(block.aborted_transaction_ids(), &[deployment_id]);
+}
+
+// This test verifies that the same view-based program is accepted at V16.
+#[test]
+fn test_checksum_in_view_accepted_at_v16() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    let program = view_checksum_program();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V16 height.
+    let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v16_height, rng);
+
+    // The deployment is accepted.
+    let deployment = vm.deploy(&caller_private_key, &program, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    vm.add_next_block(&block).unwrap();
+}
+
+// A program whose constructor references a `<name>/checksum` for a name that is not a component.
+fn dangling_checksum_program() -> Program<CurrentNetwork> {
+    Program::from_str(
+        r"
+program test_checksum_dangling.aleo;
+
+mapping checksums:
+    key as u8.public;
+    value as [u8; 32u32].public;
+
+function foo:
+    input r0 as u64.public;
+    output r0 as u64.public;
+
+constructor:
+    set nonexistent/checksum into checksums[0u8];
+",
+    )
+    .unwrap()
+}
+
+// This test verifies that a component checksum referencing a name that is not a function, closure, or
+// view is rejected at deployment, rather than deploying successfully and failing on every execution.
+#[test]
+fn test_checksum_dangling_reference_rejected() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    let program = dangling_checksum_program();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V16 height.
+    let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v16_height, rng);
+
+    // The dangling reference is caught during deployment (at synthesis) or, failing that, by verification.
+    if let Ok(deployment) = vm.deploy(&caller_private_key, &program, None, 0, None, rng) {
+        assert!(vm.check_transaction(&deployment, None, rng).is_err());
+    }
+}
+
+// A program whose view output references a `<name>/checksum` for a name that is not a component.
+fn dangling_view_checksum_program() -> Program<CurrentNetwork> {
+    Program::from_str(
+        r"
+program test_checksum_dangling_view.aleo;
+
+function foo:
+    input r0 as u64.public;
+    output r0 as u64.public;
+
+view bad:
+    output nonexistent/checksum as [u8; 32u32].public;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .unwrap()
+}
+
+// This test verifies that a dangling component checksum in a view output operand is also rejected at
+// deployment, not just one in a command operand.
+#[test]
+fn test_checksum_dangling_reference_in_view_output_rejected() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    let program = dangling_view_checksum_program();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V16 height.
+    let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v16_height, rng);
+
+    // The dangling reference is caught during deployment (at synthesis) or, failing that, by verification.
+    if let Ok(deployment) = vm.deploy(&caller_private_key, &program, None, 0, None, rng) {
+        assert!(vm.check_transaction(&deployment, None, rng).is_err());
+    }
+}

--- a/synthesizer/src/vm/tests/test_v16/component_checksum.rs
+++ b/synthesizer/src/vm/tests/test_v16/component_checksum.rs
@@ -41,16 +41,21 @@ const FOO_CHANGED: &str = r"    input r0 as u64.public;
     add r0 r0 into r1;
     output r1 as u64.public;";
 
-// Builds `test_checksum.aleo` with the given `foo` body, optionally adding a second function `bar`.
-fn program(foo: &str, include_bar: bool) -> Program<CurrentNetwork> {
-    let bar = if include_bar {
-        r"
-function bar:
-    input r0 as u64.public;
-    output r0 as u64.public;
-"
-    } else {
-        ""
+// The body of `bar`: a simple passthrough.
+const BAR_UNCHANGED: &str = r"    input r0 as u64.public;
+    output r0 as u64.public;";
+
+// A different body for `bar` (its input and output types are preserved), so its checksum changes.
+const BAR_CHANGED: &str = r"    input r0 as u64.public;
+    add r0 r0 into r1;
+    output r1 as u64.public;";
+
+// Builds `test_checksum.aleo` with the given `foo` body, optionally adding a second function `bar` with
+// the given body.
+fn program(foo: &str, bar: Option<&str>) -> Program<CurrentNetwork> {
+    let bar = match bar {
+        Some(bar) => format!("\nfunction bar:\n{bar}\n"),
+        None => String::new(),
     };
     Program::from_str(&format!(
         r"
@@ -72,13 +77,18 @@ fn foo_checksum(program: &Program<CurrentNetwork>) -> [console::types::U8<Curren
     program.get_function(&Identifier::from_str("foo").unwrap()).unwrap().to_checksum()
 }
 
+// Returns the checksum of `bar` within the given program.
+fn bar_checksum(program: &Program<CurrentNetwork>) -> [console::types::U8<CurrentNetwork>; 32] {
+    program.get_function(&Identifier::from_str("bar").unwrap()).unwrap().to_checksum()
+}
+
 // A simple positive check of the checksum's semantics, without a VM: it is deterministic, ignores
 // other functions in the program, and changes when the function's body changes.
 #[test]
 fn test_checksum_is_deterministic_and_body_sensitive() {
-    let v0 = program(FOO_UNCHANGED, false);
-    let v1 = program(FOO_UNCHANGED, true);
-    let v2 = program(FOO_CHANGED, true);
+    let v0 = program(FOO_UNCHANGED, None);
+    let v1 = program(FOO_UNCHANGED, Some(BAR_UNCHANGED));
+    let v2 = program(FOO_CHANGED, Some(BAR_UNCHANGED));
 
     // The checksum is deterministic.
     assert_eq!(foo_checksum(&v0), foo_checksum(&v0));
@@ -179,7 +189,7 @@ fn test_checksum_pin_across_upgrade() {
     let vm = crate::vm::test_helpers::sample_vm_at_height(v16_height, rng);
 
     // Deploy v0, which records `foo`'s checksum on first deploy.
-    let v0 = program(FOO_UNCHANGED, false);
+    let v0 = program(FOO_UNCHANGED, None);
     let deployment = vm.deploy(&caller_private_key, &v0, None, 0, None, rng).unwrap();
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
@@ -201,22 +211,71 @@ fn test_checksum_pin_across_upgrade() {
     };
     assert_eq!(expected, stored);
 
+    // `bar` does not exist in v0, so its checksum is absent from the program's Stack.
+    let bar = Identifier::from_str("bar").unwrap();
+    assert!(vm.process().get_stack("test_checksum.aleo").unwrap().component_checksum(&bar).is_err());
+
     // Upgrade with `foo` unchanged (adding `bar`). The pinned checksum still matches, so it is accepted.
-    let v1 = program(FOO_UNCHANGED, true);
+    let v1 = program(FOO_UNCHANGED, Some(BAR_UNCHANGED));
     let deployment = vm.deploy(&caller_private_key, &v1, None, 0, None, rng).unwrap();
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
     vm.add_next_block(&block).unwrap();
 
+    // After the upgrade, `bar`'s checksum is present in the program's Stack and matches `bar`'s checksum.
+    let stack = vm.process().get_stack("test_checksum.aleo").unwrap();
+    assert_eq!(stack.component_checksum(&bar).unwrap(), &bar_checksum(&v1));
+
     // Upgrade with `foo` changed. The pinned checksum no longer matches, so the constructor's
     // assertion fails and the upgrade is rejected.
-    let v2 = program(FOO_CHANGED, true);
+    let v2 = program(FOO_CHANGED, Some(BAR_UNCHANGED));
     let deployment = vm.deploy(&caller_private_key, &v2, None, 0, None, rng).unwrap();
     let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
     assert_eq!(block.transactions().num_accepted(), 0);
     assert_eq!(block.transactions().num_rejected(), 1);
     vm.add_next_block(&block).unwrap();
+}
+
+// This test verifies that when `bar` is changed across an upgrade, its checksum is updated in the
+// program's Stack. `foo` is left unchanged so the constructor's pin still holds and the upgrade is accepted.
+#[test]
+fn test_checksum_bar_updated_in_stack_on_upgrade() {
+    // Initialize an RNG.
+    let rng = &mut TestRng::default();
+
+    // Initialize a new caller.
+    let caller_private_key = crate::vm::test_helpers::sample_genesis_private_key(rng);
+
+    // Initialize the VM at the V16 height.
+    let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+    let vm = crate::vm::test_helpers::sample_vm_at_height(v16_height, rng);
+
+    // Deploy v0 with `bar`.
+    let v0 = program(FOO_UNCHANGED, Some(BAR_UNCHANGED));
+    let deployment = vm.deploy(&caller_private_key, &v0, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    vm.add_next_block(&block).unwrap();
+
+    // The Stack records `bar`'s original checksum.
+    let bar = Identifier::from_str("bar").unwrap();
+    let stack = vm.process().get_stack("test_checksum.aleo").unwrap();
+    assert_eq!(stack.component_checksum(&bar).unwrap(), &bar_checksum(&v0));
+
+    // Upgrade with `bar` changed (and `foo` unchanged, so the pin still holds).
+    let v1 = program(FOO_UNCHANGED, Some(BAR_CHANGED));
+    let deployment = vm.deploy(&caller_private_key, &v1, None, 0, None, rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, &[deployment], rng).unwrap();
+    assert_eq!(block.transactions().num_accepted(), 1);
+    assert_eq!(block.transactions().num_rejected(), 0);
+    vm.add_next_block(&block).unwrap();
+
+    // The Stack now records `bar`'s new checksum, which differs from the original.
+    let stack = vm.process().get_stack("test_checksum.aleo").unwrap();
+    assert_eq!(stack.component_checksum(&bar).unwrap(), &bar_checksum(&v1));
+    assert_ne!(bar_checksum(&v0), bar_checksum(&v1));
 }
 
 // A minimal program that uses `<name>/checksum` in its constructor.

--- a/synthesizer/src/vm/tests/test_v16/mod.rs
+++ b/synthesizer/src/vm/tests/test_v16/mod.rs
@@ -16,6 +16,9 @@
 // Tests for increased program size limits.
 mod program_size;
 
+// Tests for the `<name>/checksum` component checksum operand.
+mod component_checksum;
+
 use super::*;
 
 use crate::vm::test_helpers::*;

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -355,6 +355,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         "Invalid deployment transaction '{id}' - program uses syntax that is not allowed before `ConsensusVersion::V15`"
                     );
                 }
+                if consensus_version < ConsensusVersion::V16 {
+                    ensure!(
+                        !deployment.program().contains_v16_syntax(),
+                        "Invalid deployment transaction '{id}' - program uses syntax that is not allowed before `ConsensusVersion::V16`"
+                    );
+                }
 
                 // Checks required for current and future consensus versions (>= V9).
                 //


### PR DESCRIPTION
## Summary

Adds a new `Operand::ComponentChecksum(Option<ProgramID>, Identifier)` that resolves to the SHA3-256 checksum of a single named program component's source — a **function, closure, or view** — mirroring the existing whole-program `Operand::Checksum`. This enables pinning the behavior of an individual component (e.g. in a constructor) within an otherwise upgradable program.

The keyword is just `checksum`; the kind is resolved by name, since component names are unique within a program:

- `foo/checksum` — the component `foo` (function/closure/view) in the current program
- `token.aleo/transfer/checksum` — the component `transfer` in an external program

Parsing is unambiguous against the whole-program checksum because a `ProgramID` always carries a network suffix (`.aleo`) and an `Identifier` never does: `foo/checksum` is a component, `token.aleo/checksum` is a program checksum, `token.aleo/foo/checksum` is an external component.

Usable in finalize / constructor / view scope only; rejected in all non-finalize scopes and as struct/array/record members, matching `Checksum`. Gated at `ConsensusVersion::V16`.

## Changes

- `Operand::ComponentChecksum` variant: parse, display, and byte (de)serialization (discriminant 13).
- `to_checksum()` on `FunctionCore`, `ClosureCore`, and `ViewCore`, all delegating to a shared `source_code_checksum` helper alongside `ProgramCore::to_checksum`.
- Resolution in the finalize register loader via a per-`Stack` `component_checksums` cache (computed once at initialization from all functions, closures, and views — no per-load re-hash).
- Deploy-time validation: a `<name>/checksum` whose name is not a function, closure, or view in the target program (or whose external program is not imported) is rejected at deployment instead of failing on every execution.
- `contains_v16_syntax` scans finalize, constructor, **and view** command + output operands, so the operand cannot bypass the pre-V16 deploy gate via a view.

## Tests

`test_v16/component_checksum.rs`:
- Resolves function, closure, and view: constructor records all three `<name>/checksum` values, each verified against the component's `to_checksum()`.
- Checksum is deterministic, ignores unrelated functions, and changes when the component body changes.
- Pin across upgrade: an upgrade that leaves `foo` unchanged is accepted; one that changes `foo` is rejected by the constructor's pinned-checksum assertion.
- Rejected pre-V16 (V15), including when hidden inside a view; accepted at V16.
- Dangling reference (name that is not a component) is rejected at deployment.
