### PR TITLE
Include the ConsensusVersion in the cache key

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -20,7 +20,7 @@ use std::io;
 
 /// The different consensus versions.
 /// If you need the version active for a specific height, see: `N::CONSENSUS_VERSION`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Sequence)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Sequence)]
 #[repr(u16)]
 pub enum ConsensusVersion {
     /// V1: The initial genesis consensus version.

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -80,7 +80,9 @@ fn create_cache_key(
     for transition in transaction.transitions() {
         execution_stacks.insert(*transition.program_id(), vm.process().get_stack(transition.program_id())?);
     }
-    VM::<CurrentNetwork, LedgerType>::create_cache_key_with_stacks(transaction, &execution_stacks)
+    let current_block_height = vm.block_store().current_block_height();
+    let consensus_version = CurrentNetwork::CONSENSUS_VERSION(current_block_height)?;
+    VM::<CurrentNetwork, LedgerType>::create_cache_key_with_stacks(transaction, &execution_stacks, consensus_version)
 }
 
 #[test]

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -117,10 +117,9 @@ use std::{
 use rayon::prelude::*;
 
 // The key for the partially-verified transactions cache.
-// The key is a tuple of the transaction ID and a list of `(program checksum, edition, amendment count)` for each transition.
-// Note: Program upgrades and amendments can change verification behavior without changing the transaction ID, so the cache key
-// must include program metadata in addition to the checksum.
-pub type TransactionCacheKey<N> = (<N as Network>::TransactionID, Vec<([U8<N>; 32], u16, u64)>);
+// The key is a tuple of the transaction ID and a list of `(program checksum, edition, amendment count, consensus version)` for each transition.
+// This is because program upgrades, amendments and consensus version changes can change verification behavior.
+pub type TransactionCacheKey<N> = (<N as Network>::TransactionID, Vec<([U8<N>; 32], u16, u64, ConsensusVersion)>);
 
 #[derive(Clone)]
 pub struct VM<N: Network, C: ConsensusStorage<N>> {

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -688,6 +688,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             .transitions()
             .map(|t| Ok((*t.program_id(), self.process.get_stack(t.program_id())?)))
             .collect::<Result<IndexMap<_, _>>>()?;
+        let current_block_height = self.block_store().current_block_height();
+        let consensus_version = N::CONSENSUS_VERSION(current_block_height).unwrap();
         let new_cache_key = Self::create_cache_key_with_stacks(transaction, &execution_stacks, consensus_version)?;
         let cache_key_unchanged = cache_key == new_cache_key;
 

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -47,6 +47,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     pub fn create_cache_key_with_stacks(
         transaction: &Transaction<N>,
         execution_stacks: &IndexMap<ProgramID<N>, Arc<Stack<N>>>,
+        consensus_version: ConsensusVersion,
     ) -> Result<TransactionCacheKey<N>> {
         // Get the program checksums.
         let program_checksums = transaction
@@ -57,7 +58,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                     .ok_or_else(|| anyhow!("Missing stack for transition program '{}'", transition.program_id()))?;
                 let edition = *stack.program_edition();
                 let amendment_count = stack.program_amendment_count();
-                Ok((*stack.program_checksum(), edition, amendment_count))
+                Ok((*stack.program_checksum(), edition, amendment_count, consensus_version))
             })
             .collect::<Result<Vec<_>>>()?;
         // Return the cache key.
@@ -202,7 +203,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let checksum = Data::<Transaction<N>>::Buffer(transaction.to_bytes_le()?.into()).to_checksum::<N>()?;
 
         // Prepare the cache key.
-        let cache_key = Self::create_cache_key_with_stacks(transaction, &execution_stacks)?;
+        let cache_key = Self::create_cache_key_with_stacks(transaction, &execution_stacks, consensus_version)?;
 
         // Check if the transaction exists in the partially-verified cache.
         let is_partially_verified = self.partially_verified_transactions.read().peek(&cache_key) == Some(&checksum)
@@ -687,7 +688,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             .transitions()
             .map(|t| Ok((*t.program_id(), self.process.get_stack(t.program_id())?)))
             .collect::<Result<IndexMap<_, _>>>()?;
-        let new_cache_key = Self::create_cache_key_with_stacks(transaction, &execution_stacks)?;
+        let new_cache_key = Self::create_cache_key_with_stacks(transaction, &execution_stacks, consensus_version)?;
         let cache_key_unchanged = cache_key == new_cache_key;
 
         // If the above checks have passed, against the same cache key, and this
@@ -1012,7 +1013,9 @@ mod tests {
         for transition in transaction.transitions() {
             execution_stacks.insert(*transition.program_id(), vm.process().get_stack(transition.program_id()).unwrap());
         }
-        VM::<N, C>::create_cache_key_with_stacks(transaction, &execution_stacks).unwrap()
+        let current_block_height = vm.block_store().current_block_height();
+        let consensus_version = N::CONSENSUS_VERSION(current_block_height).unwrap();
+        VM::<N, C>::create_cache_key_with_stacks(transaction, &execution_stacks, consensus_version).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Closes https://github.com/ProvableHQ/snarkOS/issues/4315

I think it was because we generate background transaction while incrementing consensus versions. Transaction verification which starts before incrementing a backwards-incompatible ConsensusVersion with block creation, and which ends after, will be wrongly populated in the cache.

## Test Plan

The above test failure was spurious on weak hardware, but we'll see if it happens again.
This particular fix is trivial and it doesn't feel like adding a unit test for it's behaviour.

## Backwards compatibility

This PR is fully backwards compatible, on restart the partially_verified_transactions cache clears anyway.
