### PR TITLE
feat(synthesizer): add VM::evaluate_view for latest-height view queries

### DIFF
--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -37,6 +37,7 @@ mod evaluate;
 mod execute;
 mod finalize;
 mod view;
+pub use view::evaluate_view_with_stack;
 #[cfg(feature = "history")]
 pub use view::evaluate_view_with_stack_at_height;
 mod verify_deployment;

--- a/synthesizer/process/src/view.rs
+++ b/synthesizer/process/src/view.rs
@@ -18,7 +18,6 @@ use console::{
     network::prelude::*,
     program::{Identifier, Value},
 };
-#[cfg(feature = "history")]
 use snarkvm_ledger_store::{FinalizeStorage, FinalizeStore};
 use snarkvm_synthesizer_program::{
     FinalizeGlobalState,
@@ -45,6 +44,20 @@ pub fn evaluate_view_with_stack_at_height<N: Network, P: FinalizeStorage<N>>(
 ) -> Result<Vec<Value<N>>> {
     let historic = HistoricFinalizeStore { store, height };
     evaluate_view_inner(state, &historic, stack, view_name, inputs)
+}
+
+/// Evaluates a view function against the latest confirmed finalize-store state, reading through
+/// [`LatestFinalizeStore`]. Prefer `VM::evaluate_view`, which resolves the stack and serializes
+/// against block commits.
+pub fn evaluate_view_with_stack<N: Network, P: FinalizeStorage<N>>(
+    state: FinalizeGlobalState,
+    store: &FinalizeStore<N, P>,
+    stack: &Stack<N>,
+    view_name: &Identifier<N>,
+    inputs: Vec<Value<N>>,
+) -> Result<Vec<Value<N>>> {
+    let latest = LatestFinalizeStore { store };
+    evaluate_view_inner(state, &latest, stack, view_name, inputs)
 }
 
 /// Read-only `FinalizeStoreTrait` adapter that routes mapping reads through the finalize
@@ -97,6 +110,78 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStoreTrait<N> for HistoricFinali
             .store
             .get_historical_mapping_value(program_id, mapping_name, key.clone(), self.height)?
             .map(|cow| cow.into_owned()))
+    }
+
+    fn insert_key_value(
+        &self,
+        _program_id: console::program::ProgramID<N>,
+        _mapping_name: Identifier<N>,
+        _key: console::program::Plaintext<N>,
+        _value: Value<N>,
+    ) -> Result<snarkvm_synthesizer_program::FinalizeOperation<N>> {
+        bail!("Forbidden operation: view path cannot write to the finalize store ('insert_key_value')")
+    }
+
+    fn update_key_value(
+        &self,
+        _program_id: console::program::ProgramID<N>,
+        _mapping_name: Identifier<N>,
+        _key: console::program::Plaintext<N>,
+        _value: Value<N>,
+    ) -> Result<snarkvm_synthesizer_program::FinalizeOperation<N>> {
+        bail!("Forbidden operation: view path cannot write to the finalize store ('update_key_value')")
+    }
+
+    fn remove_key_value(
+        &self,
+        _program_id: console::program::ProgramID<N>,
+        _mapping_name: Identifier<N>,
+        _key: &console::program::Plaintext<N>,
+    ) -> Result<Option<snarkvm_synthesizer_program::FinalizeOperation<N>>> {
+        bail!("Forbidden operation: view path cannot write to the finalize store ('remove_key_value')")
+    }
+}
+
+/// Read-only `FinalizeStoreTrait` adapter that routes every mapping read to the store's
+/// *confirmed* values, so a concurrent speculation's uncommitted atomic batch is never observed.
+/// Writes bail, as in [`HistoricFinalizeStore`].
+struct LatestFinalizeStore<'a, N: Network, P: FinalizeStorage<N>> {
+    store: &'a FinalizeStore<N, P>,
+}
+
+impl<N: Network, P: FinalizeStorage<N>> FinalizeStoreTrait<N> for LatestFinalizeStore<'_, N, P> {
+    fn contains_mapping_confirmed(
+        &self,
+        program_id: &console::program::ProgramID<N>,
+        mapping_name: &Identifier<N>,
+    ) -> Result<bool> {
+        self.store.contains_mapping_confirmed(program_id, mapping_name)
+    }
+
+    fn contains_mapping_speculative(
+        &self,
+        program_id: &console::program::ProgramID<N>,
+        mapping_name: &Identifier<N>,
+    ) -> Result<bool> {
+        self.store.contains_mapping_confirmed(program_id, mapping_name)
+    }
+
+    fn contains_key_speculative(
+        &self,
+        program_id: console::program::ProgramID<N>,
+        mapping_name: Identifier<N>,
+        key: &console::program::Plaintext<N>,
+    ) -> Result<bool> {
+        self.store.contains_key_confirmed(program_id, mapping_name, key)
+    }
+
+    fn get_value_speculative(
+        &self,
+        program_id: console::program::ProgramID<N>,
+        mapping_name: Identifier<N>,
+        key: &console::program::Plaintext<N>,
+    ) -> Result<Option<Value<N>>> {
+        self.store.get_value_confirmed(program_id, mapping_name, key)
     }
 
     fn insert_key_value(

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -145,6 +145,19 @@ impl<N: Network> Command<N> {
         matches!(self, Command::Set(_) | Command::Remove(_))
     }
 
+    /// Returns `true` if the command reads from the finalize store.
+    pub fn reads_finalize_store(&self) -> bool {
+        matches!(
+            self,
+            Command::Contains(_)
+                | Command::ContainsDynamic(_)
+                | Command::Get(_)
+                | Command::GetDynamic(_)
+                | Command::GetOrUse(_)
+                | Command::GetOrUseDynamic(_)
+        )
+    }
+
     /// Returns the branch target, if the command is a branch command.
     /// Otherwise, returns `None`.
     pub fn branch_to(&self) -> Option<&Identifier<N>> {

--- a/synthesizer/program/src/view/mod.rs
+++ b/synthesizer/program/src/view/mod.rs
@@ -105,6 +105,11 @@ impl<N: Network> ViewCore<N> {
         &self.positions
     }
 
+    /// Returns `true` if any command in the view reads from the finalize store.
+    pub fn reads_finalize_store(&self) -> bool {
+        self.commands.iter().any(Command::reads_finalize_store)
+    }
+
     /// Returns `true` if the view contains an array type with a size that exceeds the given maximum.
     /// Mirrors `Finalize::exceeds_max_array_size` and additionally walks `outputs`, since views
     /// declare typed outputs.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -141,6 +141,9 @@ pub struct VM<N: Network, C: ConsensusStorage<N>> {
     sequential_ops_tx: Arc<RwLock<Option<mpsc::Sender<SequentialOperationRequest<N>>>>>,
     /// The handle to the thread which processes operations sequentially.
     sequential_ops_thread: Arc<Mutex<Option<thread::JoinHandle<()>>>>,
+    /// Serializes block commits against latest-view evaluation: a commit takes the write lock,
+    /// a mapping-reading view takes the read lock so it cannot straddle a commit.
+    finalize_lock: Arc<RwLock<()>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
@@ -241,6 +244,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             sequential_ops_tx: Default::default(),
             pending_rejected_reasons: Default::default(),
             sequential_ops_thread: Default::default(),
+            finalize_lock: Default::default(),
         };
 
         // Spawn a thread for sequential operations.
@@ -314,7 +318,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// cumulative weights, and the previous-block hash from the actual block — so any
     /// operand or opcode that reads from `FinalizeGlobalState` (block.height,
     /// block.timestamp, random_seed via rand.chacha, etc.) sees real values.
-    #[cfg(feature = "history")]
     fn finalize_state_for_block(&self, height: u32) -> Result<FinalizeGlobalState> {
         let block_hash =
             self.block_store().get_block_hash(height)?.ok_or_else(|| anyhow!("No block exists at height {height}"))?;
@@ -333,6 +336,27 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             block.cumulative_proof_target(),
             block.previous_hash(),
         )
+    }
+
+    /// Evaluates a view function against the latest confirmed finalize-store state, against the
+    /// latest program edition. Unlike `evaluate_view_at_height`, this does not require
+    /// `--features history`.
+    ///
+    /// A view that reads mappings holds the finalize lock for its evaluation so it cannot straddle
+    /// a block commit; a view that reads none skips the lock.
+    pub fn evaluate_view(
+        &self,
+        program_id: impl TryInto<ProgramID<N>>,
+        view_name: impl TryInto<Identifier<N>>,
+        inputs: Vec<Value<N>>,
+    ) -> Result<Vec<Value<N>>> {
+        let program_id = program_id.try_into().map_err(|_| anyhow!("Invalid program ID"))?;
+        let view_name = view_name.try_into().map_err(|_| anyhow!("Invalid view function name"))?;
+        let stack = self.process.get_stack(program_id)?;
+        let reads_store = stack.program().get_view_ref(&view_name)?.reads_finalize_store();
+        let _finalize_guard = reads_store.then(|| self.finalize_lock.read());
+        let state = self.finalize_state_for_block(self.block_store().current_block_height())?;
+        snarkvm_synthesizer_process::evaluate_view_with_stack(state, self.finalize_store(), &stack, &view_name, inputs)
     }
 
     /// Evaluates a view function against finalize-store state at the given block `height`.
@@ -601,6 +625,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     #[inline]
     pub(crate) fn add_next_block_inner(&self, block: Block<N>) -> Result<()> {
         self.ensure_sequential_processing();
+
+        // Hold the finalize lock for the commit, excluding concurrent latest-view evaluation.
+        let _finalize_guard = self.finalize_lock.write();
 
         // Determine if the block timestamp should be included.
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())

--- a/synthesizer/src/vm/tests/test_v15/views.rs
+++ b/synthesizer/src/vm/tests/test_v15/views.rs
@@ -21,11 +21,9 @@
 
 use super::*;
 
-#[cfg(feature = "history")]
 use console::program::{Literal, Plaintext};
 
 /// Convenience: extract a single `u64` from a single-output view result.
-#[cfg(feature = "history")]
 fn expect_u64(outputs: &[Value<CurrentNetwork>]) -> u64 {
     assert_eq!(outputs.len(), 1, "expected exactly one output, got {}", outputs.len());
     match &outputs[0] {
@@ -2330,4 +2328,178 @@ fn test_evaluate_view_before_deployment_height_errors() -> Result<()> {
     let err = vm.evaluate_view_at_height("vw_predeploy.aleo", "fixed", vec![], before).unwrap_err().to_string();
     assert!(err.contains("was not deployed at or before height"), "unexpected error: {err}");
     Ok(())
+}
+
+// `VM::evaluate_view` (latest-height) tests. These do not require `--features history`.
+
+/// The latest-height view reflects the committed mapping value after each block.
+#[test]
+fn test_evaluate_view_latest_reflects_finalize_state() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+    let caller_address = Address::try_from(&caller_private_key)?;
+
+    let program = Program::from_str(
+        r"
+        program vw_latest_lifecycle.aleo;
+
+        mapping balances:
+            key as address.public;
+            value as u64.public;
+
+        function increment:
+            input r0 as address.public;
+            input r1 as u64.public;
+            async increment r0 r1 into r2;
+            output r2 as vw_latest_lifecycle.aleo/increment.future;
+
+        finalize increment:
+            input r0 as address.public;
+            input r1 as u64.public;
+            get.or_use balances[r0] 0u64 into r2;
+            add r2 r1 into r3;
+            set r3 into balances[r0];
+
+        view total_balance:
+            input r0 as address.public;
+            get.or_use balances[r0] 0u64 into r1;
+            output r1 as u64.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+
+    // Deploy.
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, None, &[tx], rng);
+
+    // Untouched mapping returns the default (0).
+    let outputs = vm.evaluate_view("vw_latest_lifecycle.aleo", "total_balance", vec![Value::from_str(
+        &caller_address.to_string(),
+    )?])?;
+    assert_eq!(expect_u64(&outputs), 0);
+
+    // Execute increment(addr, 10).
+    let inputs = [Value::from_str(&caller_address.to_string())?, Value::from_str("10u64")?];
+    let tx =
+        vm.execute(&caller_private_key, ("vw_latest_lifecycle.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), &[tx], rng);
+
+    // The latest view reflects the finalize-set value.
+    let outputs = vm.evaluate_view("vw_latest_lifecycle.aleo", "total_balance", vec![Value::from_str(
+        &caller_address.to_string(),
+    )?])?;
+    assert_eq!(expect_u64(&outputs), 10);
+
+    // Increment again by 32. New total: 42.
+    let inputs = [Value::from_str(&caller_address.to_string())?, Value::from_str("32u64")?];
+    let tx =
+        vm.execute(&caller_private_key, ("vw_latest_lifecycle.aleo", "increment"), inputs.iter(), None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), &[tx], rng);
+
+    let outputs = vm.evaluate_view("vw_latest_lifecycle.aleo", "total_balance", vec![Value::from_str(
+        &caller_address.to_string(),
+    )?])?;
+    assert_eq!(expect_u64(&outputs), 42);
+
+    Ok(())
+}
+
+/// A view that reads no mappings is not flagged as reading the store (the lock-skip condition)
+/// and still evaluates correctly.
+#[test]
+fn test_evaluate_view_latest_stateless_skips_lock() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    let program = Program::from_str(
+        r"
+        program vw_latest_stateless.aleo;
+
+        mapping balances:
+            key as address.public;
+            value as u64.public;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        view add3:
+            input r0 as u64.public;
+            input r1 as u64.public;
+            input r2 as u64.public;
+            add r0 r1 into r3;
+            add r3 r2 into r4;
+            output r4 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, None, &[tx], rng);
+
+    // Confirm the view is detected as not reading the store (the lock-skip condition).
+    let stack = vm.process().get_stack("vw_latest_stateless.aleo")?;
+    assert!(
+        !stack.program().get_view_ref(&Identifier::from_str("add3")?)?.reads_finalize_store(),
+        "a view with no get/contains commands must not be flagged as reading the finalize store"
+    );
+
+    let outputs = vm.evaluate_view("vw_latest_stateless.aleo", "add3", vec![
+        Value::from_str("10u64")?,
+        Value::from_str("20u64")?,
+        Value::from_str("12u64")?,
+    ])?;
+    assert_eq!(expect_u64(&outputs), 42);
+    Ok(())
+}
+
+/// Calling `evaluate_view` with the wrong input arity returns an error.
+#[test]
+fn test_evaluate_view_latest_arity_mismatch() -> Result<()> {
+    let rng = &mut TestRng::default();
+    let caller_private_key = sample_genesis_private_key(rng);
+
+    let program = Program::from_str(
+        r"
+        program vw_latest_arity.aleo;
+
+        function noop:
+            input r0 as u64.private;
+            output r0 as u64.private;
+
+        constructor:
+            assert.eq true true;
+
+        view takes_two:
+            input r0 as u64.public;
+            input r1 as u64.public;
+            add r0 r1 into r2;
+            output r2 as u64.public;
+        ",
+    )?;
+
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15)?, rng);
+    let tx = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    add_and_test_with_costs(&vm, &caller_private_key, None, &[tx], rng);
+
+    let result = vm.evaluate_view("vw_latest_arity.aleo", "takes_two", vec![Value::from_str("1u64")?]);
+    assert!(result.is_err(), "expected error for too few inputs");
+    assert!(result.unwrap_err().to_string().contains("expects 2"));
+    Ok(())
+}
+
+/// Calling `evaluate_view` against a program that was never deployed returns an error.
+#[test]
+fn test_evaluate_view_latest_unknown_program() {
+    let rng = &mut TestRng::default();
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V15).unwrap(), rng);
+    let result = vm.evaluate_view("never_deployed.aleo", "anything", vec![]);
+    assert!(result.is_err(), "expected error for unknown program");
 }


### PR DESCRIPTION
Adds `VM::evaluate_view`, a latest-height view evaluator that does not require `--features history` (unlike `evaluate_view_at_height`).

Reads route through `LatestFinalizeStore`, which reads confirmed values, so a concurrent speculation's uncommitted batch is never observed. A view that reads mappings holds a new `finalize_lock` (read) for its evaluation while block commits hold it (write), so it cannot straddle a commit and observe a torn snapshot across reads. A view that reads no mappings skips the lock.

Performance: a minor slow down only happens on if a stateful view (a view that reads mappings) is mid-evaluation at the exact moment a block commits. Otherwise, there should be no impact.