### PR TITLE
ci: automate crates.io + GitHub release publishing via release-plz

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,6 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
       id-token: write
     steps:
       - name: Checkout

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -79,6 +79,12 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install lld
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lld
+
       - name: Publish With release-plz
         uses: release-plz/action@v0.5
         with:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,85 @@
+name: Publish Crates
+
+on:
+  push:
+    branches: [staging]
+    paths:
+      - Cargo.toml
+      - '**/Cargo.toml'
+      - release-plz.toml
+      - .github/workflows/publish-crates.yml
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Check what release-plz would publish without publishing or tagging.
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-crates-staging
+  cancel-in-progress: false
+
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
+jobs:
+  dry-run:
+    name: Dry Run
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Dry Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require Staging For Manual Publish
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          if [ "${{ github.ref_name }}" != "staging" ]; then
+            echo "::error::Manual crate publishing must run from staging."
+            exit 1
+          fi
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Publish With release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,42 @@
+# Releasing
+
+snarkVM releases are crates.io first. Merging a workspace version-bump PR into `staging` runs `.github/workflows/publish-crates.yml`, publishes unpublished lockstep snarkVM crate versions to crates.io, and creates one GitHub tag and release named `v{version}` from the umbrella `snarkvm` crate.
+
+Do not publish normal releases with manual `cargo publish`. The workflow uses crates.io Trusted Publishing through GitHub OIDC, so it does not require a long-lived crates.io token.
+
+This flow is based on ProvableHQ/leo's release-plz publishing flow, with Leo's binary release artifact dispatch removed.
+
+## Normal Release Flow
+
+1. Open a PR that bumps the workspace version across all lockstep snarkVM crates.
+2. Confirm the version bump is consistent across the lockstep crate set.
+3. Merge the PR to `staging`.
+4. Let `.github/workflows/publish-crates.yml` publish the crates and create the single `v{version}` tag and GitHub release.
+
+The `snarkvm-testchain-generator` binary helper is not part of the lockstep release set.
+
+## Dry Run
+
+Use the Actions tab to run `Publish Crates` manually with `dry_run` set to `true`.
+
+The dry run checks what release-plz would publish and reports the planned single tag without publishing crates, creating tags, or creating GitHub releases.
+
+## Trusted Publishing Setup
+
+Trusted Publishing is a one-time crates.io setup for each published crate. Configure it for `snarkvm` and each already-published `snarkvm-*` crate:
+
+1. Open the crate on crates.io.
+2. Go to Settings, then Trusted Publishing.
+3. Select Add.
+4. Set Owner to `ProvableHQ`.
+5. Set Repository to `snarkVM`.
+6. Set Workflow filename to `publish-crates.yml`.
+7. Leave Environment blank.
+
+This setup is inherently per crate and should be scripted across the crate set. It does not mean release-plz creates per-crate tags at release time; `release-plz.toml` keeps GitHub tags and releases on the umbrella `snarkvm` crate only.
+
+## New Crate Bootstrap
+
+Trusted Publishing cannot reserve a brand-new crate name. A new `snarkvm-*` crate needs one initial manual `cargo publish` with a crates.io token before Trusted Publishing can be enabled for that crate.
+
+After the first publish and Trusted Publishing setup, the normal workflow takes over for later versions.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,6 +35,10 @@ Trusted Publishing is a one-time crates.io setup for each published crate. Confi
 
 This setup is inherently per crate and should be scripted across the crate set. It does not mean release-plz creates per-crate tags at release time; `release-plz.toml` keeps GitHub tags and releases on the umbrella `snarkvm` crate only.
 
+## Tag Collisions
+
+`release-plz release` treats an existing `v{version}` git tag as already released and will skip publishing the umbrella `snarkvm` crate and creating its release for that version, even if crates.io has not yet received it. Before enabling this flow, make sure the next workspace version does not already have a matching upstream tag. If a stale or pre-created `v{version}` tag exists for a version that was never published, remove or migrate it first.
+
 ## New Crate Bootstrap
 
 Trusted Publishing cannot reserve a brand-new crate name. A new `snarkvm-*` crate needs one initial manual `cargo publish` with a crates.io token before Trusted Publishing can be enabled for that crate.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,274 @@
+[workspace]
+# release-plz defaults to one tag/release per package in a multi-crate workspace.
+# snarkVM is lockstep-versioned, so disable tags/releases workspace-wide and
+# re-enable them only on the umbrella `snarkvm` crate to get exactly one tag
+# and one GitHub release per workspace version.
+git_tag_enable = false
+git_release_enable = false
+
+# `version_group` is a package-level release-plz key in action v0.5.
+# Assign every lockstep crate to the same group so they always bump together.
+[[package]]
+name = "snarkvm"
+version_group = "snarkvm"
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+git_release_enable = true
+git_release_name = "v{{ version }}"
+
+[[package]]
+name = "snarkvm-algorithms"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-algorithms-cuda"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-account"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-algorithms"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-collections"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-environment"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-environment-witness"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-network"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-program"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types-address"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types-boolean"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types-field"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types-group"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types-integers"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types-scalar"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-circuit-types-string"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-account"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-collections"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-network"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-program"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types-address"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types-field"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types-group"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-console-types-string"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-curves"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-fields"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-authority"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-block"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-committee"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-narwhal"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-certificate"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-header"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-narwhal-data"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-narwhal-subdag"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission-id"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-puzzle"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-puzzle-epoch"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-query"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-store"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-ledger-test-helpers"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-metrics"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-parameters"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-synthesizer"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-synthesizer-error"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-synthesizer-process"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-synthesizer-program"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-synthesizer-snark"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-utilities"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-wasm"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-slipstream-plugin-interface"
+version_group = "snarkvm"
+
+[[package]]
+name = "snarkvm-slipstream-plugin-manager"
+version_group = "snarkvm"
+
+# This 0.1.0 binary helper is not part of the lockstep release set.
+[[package]]
+name = "snarkvm-testchain-generator"
+release = false


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Closes #3291. Ports Leo's automated crates.io-first publishing flow to snarkVM so that merging a workspace version-bump PR into `staging` publishes all `snarkvm-*` crates to crates.io and cuts a single GitHub release, with no manual `cargo publish` and no long-lived crates.io tokens (uses GitHub OIDC Trusted Publishing).

This covers the in-repo pieces of the issue (steps 1, 2, 6):

- `release-plz.toml`: disables tags/releases workspace-wide and re-enables them only on the umbrella `snarkvm` crate (`git_tag_name = "v{{ version }}"`), so there is exactly one git tag and one GitHub release per workspace version rather than release-plz's default per-crate tags. Every lockstep crate is assigned to a shared `version_group` so they bump together. `snarkvm-testchain-generator` is the one workspace member not on the lockstep `4.7.3` line (it is at `0.1.0`), so it is set to `release = false` and kept out of the version group; please confirm that matches your intent.
- `.github/workflows/publish-crates.yml`: triggers on push to `staging` (path-filtered to `Cargo.toml`, `**/Cargo.toml`, `release-plz.toml`, and the workflow itself) plus `workflow_dispatch` with a `dry_run` input, a `concurrency` group, a dry-run job (`release-plz/action@v0.5`, `command: release`, `dry_run: true`), and a publish job with `contents: write` + `id-token: write` for OIDC Trusted Publishing. Leo's binary-release dispatch is dropped (library workspace), and manual dispatch is guarded to `staging` only.
- `RELEASING.md`: documents the normal flow, dry-run, the one-time crates.io Trusted Publishing setup, the new-crate bootstrap, and the tag-collision caveat.

The crates.io per-crate Trusted Publishing enrollment and new-crate bootstrap (issue steps 3-4) are operator-side on crates.io and cannot live in a PR; `RELEASING.md` documents them.

## Test Plan

- `actionlint .github/workflows/publish-crates.yml` passes.
- `release-plz.toml` parses as valid TOML; all 65 referenced crate names were cross-checked against the actual workspace `Cargo.toml` files (exact match, none missing, none invented).
- `publish-crates.yml` parses as valid YAML.
- The publish job installs `lld` before publishing, because `cargo publish` runs verification builds that honor `.cargo/config.toml`, which forces `-fuse-ld=lld` on `x86_64-unknown-linux-gnu` (matching the existing `benchmarks.yml`).
- End-to-end dry run via `workflow_dispatch` with `dry_run: true` is the recommended next validation step once the workflow is on `staging`; it reports the planned single `v{version}` tag and the crates release-plz would publish, without publishing.

## Documentation

`RELEASING.md` is added in this PR. No `AleoNet/welcome` docs changes are needed.

## Backwards compatibility

No runtime or consensus behavior changes. This PR only adds release/CI configuration and docs; no Rust code is touched, so no `ConsensusVersion` guarding is required.

Fixes #3291
