### PR TITLE
Fix history indexing performance

### DIFF
--- a/ledger/store/src/helpers/memory/internal/map.rs
+++ b/ledger/store/src/helpers/memory/internal/map.rs
@@ -380,6 +380,29 @@ impl<
     fn values_confirmed(&'a self) -> Self::Values {
         self.map.read().clone().into_values().map(Cow::Owned)
     }
+
+    ///
+    /// Returns the confirmed keys whose serialized form begins with the serialized `prefix`.
+    ///
+    fn get_keys_confirmed_with_prefix<Q>(&'a self, prefix: &Q) -> Result<Vec<K>>
+    where
+        Q: Serialize,
+    {
+        // Serialize the prefix; the BTreeMap keys are sorted by their serialized bytes.
+        let prefix = bincode::serialize(prefix)?;
+
+        // Seek to the prefix and collect every key sharing it.
+        // Note: The 'unwrap' is safe here, because the keys are defined by us.
+        let map = self.map.read();
+        let mut keys = Vec::new();
+        for (key, _) in map.range(prefix.clone()..) {
+            if !key.starts_with(&prefix) {
+                break;
+            }
+            keys.push(unchecked_deserialize(key)?);
+        }
+        Ok(keys)
+    }
 }
 
 impl<

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -419,6 +419,34 @@ impl<
     fn values_confirmed(&'a self) -> Self::Values {
         Values::new(self.database.prefix_iterator(&self.context))
     }
+
+    ///
+    /// Returns the confirmed keys whose serialized form begins with the serialized `prefix`.
+    ///
+    fn get_keys_confirmed_with_prefix<Q>(&'a self, prefix: &Q) -> Result<Vec<K>>
+    where
+        Q: Serialize,
+    {
+        // Build the raw prefix: the map context (network ID + map ID) followed by the serialized prefix.
+        let mut raw_prefix = self.context.clone();
+        bincode::serialize_into(&mut raw_prefix, prefix)?;
+
+        // Seek to the prefix and collect every key sharing it. The fixed-prefix extractor only spans
+        // the map context, so the boundary of the longer prefix is checked explicitly.
+        let mut iter = self.database.raw_iterator();
+        iter.seek(&raw_prefix);
+
+        let mut keys = Vec::new();
+        while iter.valid() {
+            let Some(key) = iter.key() else { break };
+            if !key.starts_with(&raw_prefix) {
+                break;
+            }
+            keys.push(unchecked_deserialize(&key[PREFIX_LEN..])?);
+            iter.next();
+        }
+        Ok(keys)
+    }
 }
 
 /// An iterator over all key-value pairs in a data map.

--- a/ledger/store/src/helpers/traits/map.rs
+++ b/ledger/store/src/helpers/traits/map.rs
@@ -187,4 +187,27 @@ pub trait MapRead<
     /// Returns an iterator over each value in the map.
     ///
     fn values_confirmed(&'a self) -> Self::Values;
+
+    ///
+    /// Returns the confirmed keys whose serialized form begins with the serialized `prefix`.
+    ///
+    /// This enables prefix range scans over composite keys (e.g. retrieving every `height` recorded
+    /// for a given `(program ID, mapping name, key)`) without scanning the entire map. The `prefix`
+    /// must serialize to a byte-prefix of the stored keys, which holds for a leading sub-tuple of a
+    /// tuple key, since `bincode` serializes tuple fields in order.
+    ///
+    fn get_keys_confirmed_with_prefix<Q>(&'a self, prefix: &Q) -> Result<Vec<K>>
+    where
+        Q: Serialize,
+    {
+        // Default implementation: scan every confirmed key and filter by the serialized prefix.
+        let prefix = bincode::serialize(prefix)?;
+        let mut keys = Vec::new();
+        for key in self.keys_confirmed() {
+            if bincode::serialize(key.as_ref())?.starts_with(&prefix) {
+                keys.push(key.into_owned());
+            }
+        }
+        Ok(keys)
+    }
 }

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -302,18 +302,14 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         let value_id = N::hash_bhp1024(&(key_id, N::hash_bhp1024(&value.to_bits_le())?).to_bits_le())?;
 
         atomic_batch_scope!(self, {
-            // Update the historical maps.
+            // Record the value at the current height in the historical map.
+            // The update heights are reconstructed on read by scanning this map's height suffix,
+            // so no separate (and ever-growing) per-key heights vector is maintained here.
             #[cfg(feature = "history")]
             {
                 let current_height = self.current_block_height().load(Ordering::SeqCst);
-
-                // Insert the initial value as the first historical update.
                 self.mapping_update_map()
                     .insert((program_id, mapping_name, key.clone(), current_height), value.clone())?;
-
-                // Insert the first historical update height.
-                let height_update_key = (program_id, mapping_name, key.clone());
-                self.mapping_update_heights_map().insert(height_update_key, vec![current_height])?;
             }
 
             // Update the key-value map with the new key-value.
@@ -348,23 +344,14 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         let value_id = N::hash_bhp1024(&(key_id, N::hash_bhp1024(&value.to_bits_le())?).to_bits_le())?;
 
         atomic_batch_scope!(self, {
-            // Update the historical maps.
+            // Record the updated value at the current height in the historical map.
+            // The update heights are reconstructed on read by scanning this map's height suffix,
+            // so no separate (and ever-growing) per-key heights vector is maintained here.
             #[cfg(feature = "history")]
             {
                 let current_height = self.current_block_height().load(Ordering::SeqCst);
-
-                // Register the updated value at the current height.
                 self.mapping_update_map()
                     .insert((program_id, mapping_name, key.clone(), current_height), value.clone())?;
-
-                // Obtain the list of past update heights.
-                let key = (program_id, mapping_name, key.clone());
-                let update_heights =
-                    self.mapping_update_heights_map().get_confirmed(&key)?.map(|list| list.into_owned());
-                let mut update_heights = update_heights.unwrap_or_default();
-                // Extend the historical update heights with the current height.
-                update_heights.push(current_height);
-                self.mapping_update_heights_map().insert(key, update_heights)?;
             }
 
             // Update the key-value map with the new key-value.
@@ -427,23 +414,14 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
 
             // Insert the new key-value entries.
             for (key, value) in entries {
-                // Update the historical maps.
+                // Record the updated value at the current height in the historical map.
+                // The update heights are reconstructed on read by scanning this map's height suffix,
+                // so no separate (and ever-growing) per-key heights vector is maintained here.
                 #[cfg(feature = "history")]
                 {
                     let current_height = self.current_block_height().load(Ordering::SeqCst);
-
-                    // Register the updated value at the current height.
                     self.mapping_update_map()
                         .insert((program_id, mapping_name, key.clone(), current_height), value.clone())?;
-
-                    // Obtain the list of past update heights.
-                    let key = (program_id, mapping_name, key.clone());
-                    let update_heights =
-                        self.mapping_update_heights_map().get_confirmed(&key)?.map(|list| list.into_owned());
-                    let mut update_heights = update_heights.unwrap_or_default();
-                    // Extend the historical update heights with the current height.
-                    update_heights.push(current_height);
-                    self.mapping_update_heights_map().insert(key, update_heights)?;
                 }
 
                 // Insert the key-value entry.
@@ -868,7 +846,27 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
         mapping_name: Identifier<N>,
         mapping_key: Plaintext<N>,
     ) -> Result<Option<Cow<'_, Vec<u32>>>, Error> {
-        self.storage.mapping_update_heights_map().get_confirmed(&(program_id, mapping_name, mapping_key))
+        // Reconstruct the update heights from the historical value map, which is keyed by
+        // `(program ID, mapping name, key, height)`. Scanning the `(program ID, mapping name, key)`
+        // prefix yields one entry per recorded height, avoiding a separate per-key heights vector.
+        let mut heights = self
+            .storage
+            .mapping_update_map()
+            .get_keys_confirmed_with_prefix(&(program_id, mapping_name, mapping_key))?
+            .into_iter()
+            .map(|(_, _, _, height)| height)
+            .collect::<Vec<_>>();
+
+        // Return nothing if the key has never been updated.
+        if heights.is_empty() {
+            return Ok(None);
+        }
+
+        // The keys encode the height as little-endian bytes, so the scan order does not match
+        // numerical order; sort ascending so that `binary_search` is valid in lookups.
+        heights.sort_unstable();
+
+        Ok(Some(Cow::Owned(heights)))
     }
 
     /// Returns the historical staking rewards map.


### PR DESCRIPTION
## Motivation

My apologies, I did not manually review any of this. Various node operators reported that the history feature was very slow: 
```
Over hours:we see exactly therocksdb compaction backlogEdgardo reported (0.5 → 0.35, L0 piling up).
Not I/O-bound at steady state:disk ~12% util, sub-ms latency; the finalize thread is inR(notD) — CPU-bound.
Tried, no steady-state gain:RocksDB parallelism patch (increase_parallelism→cores,max_subcompactions,max_open_files=-1),performance governor + EPP, exclusive best-core pinning, CCD cache locality.
```

AI analysis, this PR implements option A:
```
Root cause: O(n) read-modify-write of a growing per-key heights vector
The history feature keeps two maps. The expensive one is MappingUpdateHeightsMap, which stores a Vec<u32> of every height at which a key was ever updated. On every mapping write during finalize, the code does a full read-modify-write of that whole vector.
For any key updated frequently, that vector grows by one u32 per update. Each update then costs, where n = number of prior updates to that key:

get_confirmed → bincode-deserialize the entire vector (O(n))
.into_owned() → clone the whole vector (O(n))
insert → on finish_atomic, bincode-serialize the entire vector again into the shared WriteBatch (O(n) CPU + O(n) bytes written)
So each write is O(n), and cumulatively O(n²) over the life of the chain. n grows with every block, which is exactly why it degrades over hours rather than being bad from cold start.
The smoking gun is that the MappingUpdateMap already stores (program, mapping, key, height) -> value for each update. The heights vector is redundant — it exists only because bincode-encoded keys aren't byte-order-preserving by height (integers are little-endian, confirmed in map.rs create_prefixed_key + bincode::serialize), so you can't cheaply range-scan to find "latest height ≤ target." So the fix is to make appends O(1) and recover the lookup a different way.

Option A — backward compatible, no migration (recommended): Stop writing/reading MappingUpdateHeightsMap entirely. On read, derive the update heights by prefix-scanning the existing MappingUpdateMap ((program, mapping, key, *)) and sorting in memory, then do the same binary-search. Writes drop to O(1) (one insert, no RMW, no growing blob) — kills the CPU blowup and the write amplification immediately. Existing data already has all the per-height entries, so old history DBs keep working with no migration. Cost: view queries get an O(n) prefix scan (rare path, acceptable). The stale heights map is just ignored/lazily dropped.

Option B — optimal reads, needs migration: Drop the heights map and re-encode the height suffix of MappingUpdateMap keys as big-endian so RocksDB key order is numeric, enabling seek_for_prev for O(log n) reads. Best of both (O(1) write, O(log n) read, no write-amp growth), but requires a custom key-encoding helper (new abstraction → approval) and a one-time migration of existing history DBs.


```


## Test Plan

- [ ] We will ask a party to test in production

## Backwards compatibility

This is supposed to be backwards compatible.