### PR TITLE
Revert anchor times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1324,8 +1324,7 @@ workflows:
       or pipeline.git.branch == "canary"
       or pipeline.git.branch == "testnet"
       or pipeline.git.branch == "mainnet"
-      or pipeline.git.branch == "move_spend_limits"
-      or pipeline.git.branch == "blockwide-deployment-limit"
+      or pipeline.git.branch == "revert_anchor_times"
     jobs:
       - check-unused-dependencies # This can be cleaned up before releases
       - check-cargo-semver-checks # This can be cleaned up before releases

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -62,7 +62,7 @@ pub enum ConsensusVersion {
     ///      Increase the program size limit to 2048 kB and the transaction size limit to 2304 kB.
     ///      Update the deployment storage cost for programs exceeding 512 kB.
     V16 = 16,
-    /// V17: Introduces block-wide deployment limits.
+    /// V17: Introduces block-wide deployment limits, reverts the anchor time to 25.
     V17 = 17,
 }
 

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -185,8 +185,11 @@ pub trait Network:
     /// A list of (consensus_version, anchor_time_in_seconds) pairs (sparse).
     /// Each entry takes effect at the specified version and remains active until the next entry.
     /// The anchor time, defined as the expected time in seconds to reach the coinbase target.
-    const ANCHOR_TIMES: [(ConsensusVersion, u16); 2] =
-        [(ConsensusVersion::V1, Self::REWARD_ANCHOR_TIME), (ConsensusVersion::V15, 35)];
+    const ANCHOR_TIMES: [(ConsensusVersion, u16); 3] = [
+        (ConsensusVersion::V1, Self::REWARD_ANCHOR_TIME),
+        (ConsensusVersion::V15, 35),
+        (ConsensusVersion::V17, Self::REWARD_ANCHOR_TIME),
+    ];
     /// The expected time per block in seconds.
     const BLOCK_TIME: u16 = 10;
     /// The number of blocks per epoch.


### PR DESCRIPTION
## Motivation

From activation of ConsensusVersion::V15 June 15th, the cumulative daily total_reward from Solutions dropped by 10x. The PR which influenced the puzzle logic was was https://github.com/ProvableHQ/snarkVM/pull/3194 

Without understanding any of the underlying logic, the only thing we should worry about in this PR is that it won't have unintended side effects, that it "simply" reverts reward logic to what it was before. Sometimes, **lowering** a value in our software is very dangerous and is harder than **increasing** a value.

## Test Plan

I hope it's trivial enough that we don't need extra tests

## Backwards compatibility

Guarded the revert by a consensus version