### PR TITLE
Extract transaction compute spend helper

### DIFF
--- a/synthesizer/process/src/cost.rs
+++ b/synthesizer/process/src/cost.rs
@@ -212,6 +212,27 @@ pub fn execute_compute_cost_in_microcredits(
     }
 }
 
+/// Returns the compute spend for a transaction in microcredits.
+/// This is used to limit the amount of single-threaded compute in block generation and finalization hot paths.
+/// This does NOT represent the full cost which a user has to pay.
+pub fn transaction_compute_spend_in_microcredits<N: Network>(
+    process: &Process<N>,
+    transaction: &Transaction<N>,
+    consensus_version: ConsensusVersion,
+) -> Result<u64> {
+    match transaction {
+        Transaction::Deploy(_, _, _, deployment, _) => {
+            let (_, cost_details) = deployment_cost(process, deployment, consensus_version)?;
+            Ok(deploy_compute_cost_in_microcredits(cost_details, consensus_version))
+        }
+        Transaction::Execute(_, _, execution, _) => {
+            let (_, cost_details) = execution_cost(process, execution, consensus_version)?;
+            Ok(execute_compute_cost_in_microcredits(cost_details, consensus_version))
+        }
+        Transaction::Fee(id, _) => bail!("Fee transaction '{id}' does not have deployment or execution spend"),
+    }
+}
+
 /// Returns the minimum cost in microcredits to publish the given deployment (V4).
 ///
 /// Identical to V3 except in that it replaces the factor (`num_combined_variables` + `num_combined_constraints`)

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -1103,26 +1103,11 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             ShouldAbortResult::Finalize(0)
         // If the consensus version is >= V16, ensure that the transaction is not exceeding spend or deployment limits.
         } else {
-            // Compute microcredit spend from deployment or execution cost details.
-            let compute_spend = match transaction {
-                Transaction::Deploy(_, _, _, deployment, _) => {
-                    match deployment_cost(self.process(), deployment, consensus_version) {
-                        Ok((_, cost_details)) => deploy_compute_cost_in_microcredits(cost_details, consensus_version),
-                        Err(e) => {
-                            return ShouldAbortResult::Abort(format!("Failed to compute the deployment cost: {e}"));
-                        }
-                    }
-                }
-                Transaction::Execute(_, _, execution, _) => {
-                    match execution_cost(self.process(), execution, consensus_version) {
-                        Ok((_, cost_details)) => execute_compute_cost_in_microcredits(cost_details, consensus_version),
-                        Err(e) => {
-                            return ShouldAbortResult::Abort(format!("Failed to compute the execution cost: {e}"));
-                        }
-                    }
-                }
-                Transaction::Fee(..) => 0, // Fee transactions are already aborted above and don't contribute compute spend.
-            };
+            let compute_spend =
+                match transaction_compute_spend_in_microcredits(self.process(), transaction, consensus_version) {
+                    Ok(compute_spend) => compute_spend,
+                    Err(e) => return ShouldAbortResult::Abort(format!("Failed to compute transaction spend: {e}")),
+                };
 
             if compute_spend > transaction_spend_limit {
                 return ShouldAbortResult::Abort(format!(

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -86,6 +86,7 @@ use snarkvm_synthesizer_process::{
     deployment_cost,
     execute_compute_cost_in_microcredits,
     execution_cost,
+    transaction_compute_spend_in_microcredits,
 };
 use snarkvm_synthesizer_program::{
     FinalizeCore,


### PR DESCRIPTION
## Motivation

This will allow us to fix https://github.com/ProvableHQ/snarkOS/issues/4253 - specifically, it will let us replace the contents of https://github.com/ProvableHQ/snarkOS/blob/9570c83cda99b268a4e05c1f5f58911b05e53fa3/node/bft/ledger-service/src/ledger.rs#L538-L572 with something as simple as:
```
        let compute_spend = transaction_compute_spend_in_microcredits(self.ledger.vm().process(), transaction, consensus_version)?;    
        ensure!(                                                                                                                       
            compute_spend <= transaction_spend_limit,                                                                                  
            "Transaction '{id}' exceeds the transaction spend limit with compute_spend: '{compute_spend}'"                             
        );                                                                                                                                                                                                                        
        Ok(compute_spend) 
```

## Test Plan

I haven't added unit tests for the new `transaction_compute_spend_in_microcredits` since it is a trivial change, but happy to do that if desired.

## Documentation

N/A

## Backwards compatibility

No backwards compatibility issues are expected.