### PR TITLE
[Release] Mainnet v4.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms-cuda"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "blst",
  "cc",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-network",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-types",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-algorithms",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3308,11 +3308,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.7.3"
+version = "4.8.1"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "criterion",
  "snarkvm-circuit-environment",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "paste",
  "snarkvm-circuit-environment",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "rand 0.10.1",
  "snarkvm-circuit-environment",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "blake2s_simd",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "criterion",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "criterion",
  "snarkvm-console-network",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "aleo-std-storage",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "snarkvm-ledger-narwhal",
  "snarkvm-ledger-narwhal-batch-certificate",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "indexmap 2.14.0",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "indexmap 2.14.0",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "indexmap 2.14.0",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "aleo-std-storage",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-test-helpers"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3982,14 +3982,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-metrics"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "metrics",
 ]
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4021,14 +4021,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "json5",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-error"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "bincode",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-wasm"
-version = "4.7.3"
+version = "4.8.1"
 dependencies = [
  "getrandom 0.4.2",
  "snarkvm-console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,263 +189,263 @@ test_consensus_heights = [ "snarkvm-console/test_consensus_heights", "snarkvm-sy
 
 [workspace.dependencies.snarkvm-algorithms]
 path = "algorithms"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-algorithms-cuda]
 path = "algorithms/cuda"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit]
 path = "circuit"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-account]
 path = "circuit/account"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-algorithms]
 path = "circuit/algorithms"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-collections]
 path = "circuit/collections"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-environment]
 path = "circuit/environment"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-environment-witness]
 path = "circuit/environment/witness"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-circuit-network]
 path = "circuit/network"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-program]
 path = "circuit/program"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types]
 path = "circuit/types"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types-address]
 path = "circuit/types/address"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types-boolean]
 path = "circuit/types/boolean"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types-field]
 path = "circuit/types/field"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types-scalar]
 path = "circuit/types/scalar"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types-string]
 path = "circuit/types/string"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console]
 path = "console"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-console-account]
 path = "console/account"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-algorithms]
 path = "console/algorithms"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-collections]
 path = "console/collections"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-network]
 path = "console/network"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-network-environment]
 path = "console/network/environment"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-program]
 path = "console/program"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-types]
 path = "console/types"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-console-types-address]
 path = "console/types/address"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-types-boolean]
 path = "console/types/boolean"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-types-field]
 path = "console/types/field"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-types-group]
 path = "console/types/group"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-types-integers]
 path = "console/types/integers"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-types-scalar]
 path = "console/types/scalar"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-console-types-string]
 path = "console/types/string"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types-group]
 path = "circuit/types/group"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-circuit-types-integers]
 path = "circuit/types/integers"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-curves]
 path = "curves"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-fields]
 path = "fields"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-ledger]
 path = "ledger"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-authority]
 path = "ledger/authority"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-block]
 path = "ledger/block"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-committee]
 path = "ledger/committee"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-ledger-narwhal]
 path = "ledger/narwhal"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-data]
 path = "ledger/narwhal/data"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-batch-header]
 path = "ledger/narwhal/batch-header"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-batch-certificate]
 path = "ledger/narwhal/batch-certificate"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-subdag]
 path = "ledger/narwhal/subdag"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-transmission]
 path = "ledger/narwhal/transmission"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-narwhal-transmission-id]
 path = "ledger/narwhal/transmission-id"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-puzzle]
 path = "ledger/puzzle"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-puzzle-epoch]
 path = "ledger/puzzle/epoch"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-query]
 path = "ledger/query"
-version = "=4.7.3"
+version = "=4.8.1"
 default-features = false
 
 [workspace.dependencies.snarkvm-ledger-store]
 path = "ledger/store"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-slipstream-plugin-interface]
 path = "plugins/slipstream_plugin_interface"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 path = "plugins/slipstream_plugin_manager"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-ledger-test-helpers]
 path = "ledger/test-helpers"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-metrics]
 path = "metrics"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-parameters]
 path = "parameters"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-synthesizer]
 path = "synthesizer"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-synthesizer-error]
 path = "synthesizer/error"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-synthesizer-process]
 path = "synthesizer/process"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-synthesizer-program]
 path = "synthesizer/program"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-synthesizer-snark]
 path = "synthesizer/snark"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-utilities]
 path = "utilities"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-utilities-derives]
 path = "utilities/derives"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.snarkvm-wasm]
 path = "wasm"
-version = "=4.7.3"
+version = "=4.8.1"
 
 [workspace.dependencies.aleo-std]
 version = "1.0.1"

--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-algorithms"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Algorithms for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/algorithms/cuda/Cargo.toml
+++ b/algorithms/cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-algorithms-cuda"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Cuda optimizations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/Cargo.toml
+++ b/circuit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Circuits for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/account/Cargo.toml
+++ b/circuit/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-account"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Account circuit library for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/algorithms/Cargo.toml
+++ b/circuit/algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-algorithms"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Algorithm circuit library for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/collections/Cargo.toml
+++ b/circuit/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-collections"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Collections circuit library for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/environment/Cargo.toml
+++ b/circuit/environment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-environment"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Circuit environment for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/environment/witness/Cargo.toml
+++ b/circuit/environment/witness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-environment-witness"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A procedural macro to construct a witness in an environment"
 homepage = "https://aleo.org"

--- a/circuit/network/Cargo.toml
+++ b/circuit/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-network"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Network circuit library for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/program/Cargo.toml
+++ b/circuit/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-program"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Program circuit library for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/Cargo.toml
+++ b/circuit/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Primitive circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/address/Cargo.toml
+++ b/circuit/types/address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types-address"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Address circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/boolean/Cargo.toml
+++ b/circuit/types/boolean/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types-boolean"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Boolean circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/field/Cargo.toml
+++ b/circuit/types/field/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types-field"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Field circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/group/Cargo.toml
+++ b/circuit/types/group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types-group"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Group circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/integers/Cargo.toml
+++ b/circuit/types/integers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types-integers"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Integer circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/scalar/Cargo.toml
+++ b/circuit/types/scalar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types-scalar"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Scalar circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/circuit/types/string/Cargo.toml
+++ b/circuit/types/string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-circuit-types-string"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "String circuit for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Console environment for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/account/Cargo.toml
+++ b/console/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-account"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Account operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/algorithms/Cargo.toml
+++ b/console/algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-algorithms"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Console algorithms for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/collections/Cargo.toml
+++ b/console/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-collections"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Collections for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/network/Cargo.toml
+++ b/console/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-network"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Network console library for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/network/environment/Cargo.toml
+++ b/console/network/environment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-network-environment"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Environment console library for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/program/Cargo.toml
+++ b/console/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-program"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Program operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/Cargo.toml
+++ b/console/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Console types for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/address/Cargo.toml
+++ b/console/types/address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types-address"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Type operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/boolean/Cargo.toml
+++ b/console/types/boolean/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types-boolean"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Type operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/field/Cargo.toml
+++ b/console/types/field/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types-field"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Type operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/group/Cargo.toml
+++ b/console/types/group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types-group"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Type operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/integers/Cargo.toml
+++ b/console/types/integers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types-integers"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Type operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/scalar/Cargo.toml
+++ b/console/types/scalar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types-scalar"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Type operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/console/types/string/Cargo.toml
+++ b/console/types/string/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-console-types-string"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Type operations for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-curves"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Curves for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/fields/Cargo.toml
+++ b/fields/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-fields"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Fields for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A node ledger for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/authority/Cargo.toml
+++ b/ledger/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-authority"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Data structures for a block authority in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/block/Cargo.toml
+++ b/ledger/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-block"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A block for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/committee/Cargo.toml
+++ b/ledger/committee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-committee"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A committee for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/Cargo.toml
+++ b/ledger/narwhal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Data structures for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/batch-certificate/Cargo.toml
+++ b/ledger/narwhal/batch-certificate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A batch certificate for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/batch-header/Cargo.toml
+++ b/ledger/narwhal/batch-header/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A batch header for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/data/Cargo.toml
+++ b/ledger/narwhal/data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A batch certificate for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/subdag/Cargo.toml
+++ b/ledger/narwhal/subdag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A subdag for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/transmission-id/Cargo.toml
+++ b/ledger/narwhal/transmission-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A transmission ID for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/narwhal/transmission/Cargo.toml
+++ b/ledger/narwhal/transmission/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A transmission for a Narwhal-style memory pool in a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/puzzle/Cargo.toml
+++ b/ledger/puzzle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-puzzle"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Puzzle for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/puzzle/epoch/Cargo.toml
+++ b/ledger/puzzle/epoch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Epoch puzzle for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/query/Cargo.toml
+++ b/ledger/query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-query"
-version = "4.7.3"
+version = "4.8.1"
 authors = ["The Aleo Team <hello@aleo.org>"]
 description = "A query for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-store"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A data store for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/ledger/test-helpers/Cargo.toml
+++ b/ledger/test-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-ledger-test-helpers"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Test helpers for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-metrics"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Metrics for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-parameters"
-version = "4.7.3"
+version = "4.8.1"
 authors = ["The Aleo Team <hello@aleo.org>"]
 description = "Parameters for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/plugins/slipstream_plugin_interface/Cargo.toml
+++ b/plugins/slipstream_plugin_interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-slipstream-plugin-interface"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "The SnarkVM Slipstream plugin interface."
 homepage = "https://aleo.org"

--- a/plugins/slipstream_plugin_manager/Cargo.toml
+++ b/plugins/slipstream_plugin_manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-slipstream-plugin-manager"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "The SnarkVM Slipstream plugin manager."
 homepage = "https://aleo.org"

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-synthesizer"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Synthesizer for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/synthesizer/error/Cargo.toml
+++ b/synthesizer/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-synthesizer-error"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/synthesizer/process/Cargo.toml
+++ b/synthesizer/process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-synthesizer-process"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A process for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/synthesizer/program/Cargo.toml
+++ b/synthesizer/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-synthesizer-program"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Program for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/synthesizer/snark/Cargo.toml
+++ b/synthesizer/snark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-synthesizer-snark"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "SNARK wrappers for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-utilities"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Utilities for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/utilities/derives/Cargo.toml
+++ b/utilities/derives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-utilities-derives"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Canonical serialization for a decentralized virtual machine"
 homepage = "https://aleo.org"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkvm-wasm"
-version = "4.7.3"
+version = "4.8.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "WASM for a decentralized virtual machine"
 homepage = "https://aleo.org"


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR updates snarkVM version to `v4.8.1`.

This corresponds with the latest crates.io release - https://crates.io/crates/snarkvm.
