### PR TITLE
Load the credits record translation verifying key

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -66,7 +66,8 @@ pub enum ConsensusVersion {
     /// V17: NOTE: V17 landed chronologically on mainnet before it landed on testnet.
     ///      Reverts the anchor time to 25.
     V17 = 17,
-    /// V18: Introduces block-wide deployment limits and enforces canonical subDAG certificate ordering.
+    /// V18: Enables native credits record translation, introduces block-wide deployment limits,
+    ///      and enforces canonical subDAG certificate ordering.
     V18 = 18,
 }
 

--- a/ledger/store/src/transaction/deployment.rs
+++ b/ledger/store/src/transaction/deployment.rs
@@ -730,7 +730,11 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
         if program_id == &ProgramID::from_str("credits.aleo")? {
             // Load the verifying key.
-            let verifying_key = N::get_credits_verifying_key(resource_name.to_string())?;
+            let verifying_key = if resource_name == &Identifier::from_str("credits")? {
+                N::translation_credits_verifying_key()
+            } else {
+                N::get_credits_verifying_key(resource_name.to_string())?
+            };
             // Retrieve the number of public and private variables.
             // Note: This number does *NOT* include the number of constants. This is safe because
             // this program is never deployed, as it is a first-class citizen of the protocol.
@@ -783,7 +787,11 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
         if program_id == &ProgramID::from_str("credits.aleo")? {
             // Load the verifying key.
-            let verifying_key = N::get_credits_verifying_key(resource_name.to_string())?;
+            let verifying_key = if resource_name == &Identifier::from_str("credits")? {
+                N::translation_credits_verifying_key()
+            } else {
+                N::get_credits_verifying_key(resource_name.to_string())?
+            };
             // Retrieve the number of public and private variables.
             // Note: This number does *NOT* include the number of constants. This is safe because
             // this program is never deployed, as it is a first-class citizen of the protocol.
@@ -829,7 +837,11 @@ pub trait DeploymentStorage<N: Network>: Clone + Send + Sync {
         // This case is handled separately, as it is a default program of the VM.
         if program_id == &ProgramID::from_str("credits.aleo")? {
             // Load the verifying key.
-            let verifying_key = N::get_credits_verifying_key(resource_name.to_string())?;
+            let verifying_key = if resource_name == &Identifier::from_str("credits")? {
+                N::translation_credits_verifying_key()
+            } else {
+                N::get_credits_verifying_key(resource_name.to_string())?
+            };
             // Retrieve the number of public and private variables.
             let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
             // Return the verifying key.
@@ -1798,6 +1810,31 @@ impl<N: Network, D: DeploymentStorage<N>> DeploymentStore<N, D> {
 mod tests {
     use super::*;
     use crate::{TransitionStore, helpers::memory::DeploymentMemory};
+    use console::network::MainnetV0;
+
+    #[test]
+    fn test_get_credits_translation_verifying_key() -> Result<()> {
+        let transition_store = TransitionStore::open(StorageMode::Test(None))?;
+        let fee_store = FeeStore::open(transition_store)?;
+        let deployment_store = DeploymentMemory::<MainnetV0>::open(fee_store)?;
+        let credits_id = ProgramID::from_str("credits.aleo")?;
+        let credits_record_name = Identifier::from_str("credits")?;
+
+        let raw_verifying_key = MainnetV0::translation_credits_verifying_key();
+        let num_variables = raw_verifying_key.circuit_info.num_public_and_private_variables as u64;
+        let expected = VerifyingKey::new(raw_verifying_key.clone(), num_variables);
+
+        assert_eq!(
+            Some(expected.clone()),
+            deployment_store.get_latest_verifying_key(&credits_id, &credits_record_name)?
+        );
+        assert_eq!(
+            Some(expected.clone()),
+            deployment_store.get_latest_verifying_key_with_edition(&credits_id, &credits_record_name, 0)?
+        );
+        assert_eq!(Some(expected), deployment_store.get_original_verifying_key(&credits_id, &credits_record_name, 0)?);
+        Ok(())
+    }
 
     #[test]
     #[ignore]

--- a/synthesizer/process/src/lib.rs
+++ b/synthesizer/process/src/lib.rs
@@ -280,6 +280,16 @@ impl<'a, N: Network> ProcessExclusiveGuard<'a, N> {
             )?;
         }
 
+        // Load the verifying key for translating the native credits record.
+        let record_name = Identifier::from_str("credits")?;
+        let verifying_key = N::translation_credits_verifying_key();
+        let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
+        self.process.insert_verifying_key(
+            credits.id(),
+            &record_name,
+            VerifyingKey::new(verifying_key.clone(), num_variables),
+        )?;
+
         Ok(())
     }
 }
@@ -402,6 +412,12 @@ impl<N: Network> Process<N> {
             stack.insert_verifying_key(function_name, VerifyingKey::new(verifying_key.clone(), num_variables))?;
             lap!(timer, "Load verifying key for {function_name}");
         }
+
+        // Load the verifying key for translating the native credits record.
+        let record_name = Identifier::from_str("credits")?;
+        let verifying_key = N::translation_credits_verifying_key();
+        let num_variables = verifying_key.circuit_info.num_public_and_private_variables as u64;
+        stack.insert_verifying_key(&record_name, VerifyingKey::new(verifying_key.clone(), num_variables))?;
         lap!(timer, "Load circuit keys");
 
         // Add the stack to the process.

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -33,6 +33,7 @@ use snarkvm_ledger_store::{
     helpers::memory::{BlockMemory, FinalizeMemory},
 };
 use snarkvm_synthesizer_program::{FinalizeGlobalState, FinalizeStoreTrait, Program};
+use snarkvm_synthesizer_snark::VerifyingKey;
 
 use aleo_std::StorageMode;
 use indexmap::IndexMap;
@@ -47,15 +48,18 @@ const TEST_COMMISSION: u8 = 5;
 fn test_credits_translation_verifying_key_is_loaded_and_updated() -> Result<()> {
     let credits_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo")?;
     let credits_record_name = Identifier::from_str("credits")?;
+    let raw_verifying_key = CurrentNetwork::translation_credits_verifying_key();
+    let num_variables = raw_verifying_key.circuit_info.num_public_and_private_variables as u64;
+    let expected = VerifyingKey::new(raw_verifying_key.clone(), num_variables);
     let process = Process::<CurrentNetwork>::load()?;
 
-    assert!(process.get_verifying_key(credits_id, credits_record_name).is_ok());
+    assert_eq!(expected, process.get_verifying_key(credits_id, credits_record_name)?);
 
     process.remove_verifying_key(&credits_id, &credits_record_name)?;
     assert!(process.get_verifying_key(credits_id, credits_record_name).is_err());
 
     process.lock().update_credits_verifying_keys()?;
-    assert!(process.get_verifying_key(credits_id, credits_record_name).is_ok());
+    assert_eq!(expected, process.get_verifying_key(credits_id, credits_record_name)?);
     Ok(())
 }
 

--- a/synthesizer/process/src/tests/test_credits.rs
+++ b/synthesizer/process/src/tests/test_credits.rs
@@ -43,6 +43,22 @@ type CurrentAleo = AleoV0;
 const NUM_BLOCKS_TO_UNLOCK: u32 = 360;
 const TEST_COMMISSION: u8 = 5;
 
+#[test]
+fn test_credits_translation_verifying_key_is_loaded_and_updated() -> Result<()> {
+    let credits_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo")?;
+    let credits_record_name = Identifier::from_str("credits")?;
+    let process = Process::<CurrentNetwork>::load()?;
+
+    assert!(process.get_verifying_key(credits_id, credits_record_name).is_ok());
+
+    process.remove_verifying_key(&credits_id, &credits_record_name)?;
+    assert!(process.get_verifying_key(credits_id, credits_record_name).is_err());
+
+    process.lock().update_credits_verifying_keys()?;
+    assert!(process.get_verifying_key(credits_id, credits_record_name).is_ok());
+    Ok(())
+}
+
 /// Samples a new finalize store.
 macro_rules! sample_finalize_store {
     () => {{

--- a/synthesizer/process/src/verify_execution/mod.rs
+++ b/synthesizer/process/src/verify_execution/mod.rs
@@ -252,11 +252,21 @@ impl<N: Network> Process<N> {
         // Construct the list of verifier inputs.
         let mut verifier_inputs: Vec<_> = verifier_inputs.values().cloned().collect();
 
+        // Prepare the native credits record identifiers for the V18 activation check.
+        let credits_program_id = ProgramID::from_str("credits.aleo")?;
+        let credits_record_name = Identifier::from_str("credits")?;
+
         // Construct the batch of translation verifier inputs.
         let batch_translation_inputs = Translation::prepare_verifier_inputs(
             execution.transitions(),
             &transition_map,
             &|(program_id, record_name)| {
+                ensure!(
+                    consensus_version >= ConsensusVersion::V18
+                        || program_id != &credits_program_id
+                        || record_name != &credits_record_name,
+                    "The credits record translation is not enabled before ConsensusVersion::V18"
+                );
                 execution_stacks
                     .get(program_id)
                     .ok_or_else(|| anyhow!("Missing stack for program '{program_id}'"))

--- a/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
+++ b/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
@@ -92,8 +92,8 @@ fn test_dynamic_calls_to_credits_aleo() -> Result<()> {
                 ",
     )?;
 
-    // Initialize the VM.
-    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V14)?, rng);
+    // Initialize the VM at V18, when native credits record translation is enabled.
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V18)?, rng);
 
     // Deploy the program.
     println!("Deploying program: {}", program.id());
@@ -174,9 +174,21 @@ fn test_dynamic_calls_to_credits_aleo() -> Result<()> {
     verifier.load_deployment(&deployment)?;
     let execution = transaction.execution().ok_or_else(|| anyhow!("Expected an execution transaction"))?;
     let execution_stacks = verifier.get_stacks(execution.transitions(), false)?;
+    let error = Process::verify_execution(
+        ConsensusVersion::V17,
+        varuna_version_from_consensus(ConsensusVersion::V17),
+        InclusionVersion::V1,
+        execution,
+        &execution_stacks,
+    )
+    .expect_err("Native credits record translation must not verify before V18");
+    assert!(
+        error.to_string().contains("credits record translation is not enabled before ConsensusVersion::V18"),
+        "Unexpected V17 verification error: {error}"
+    );
     Process::verify_execution(
-        ConsensusVersion::V14,
-        varuna_version_from_consensus(ConsensusVersion::V14),
+        ConsensusVersion::V18,
+        varuna_version_from_consensus(ConsensusVersion::V18),
         InclusionVersion::V1,
         execution,
         &execution_stacks,

--- a/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
+++ b/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
@@ -15,6 +15,8 @@
 
 use super::*;
 
+use console::network::varuna_version_from_consensus;
+
 // Tests `call.dynamic` to `credits.aleo` functions including `transfer_public_as_signer`, `transfer_public_to_private`, and `transfer_private`.
 #[test]
 fn test_dynamic_calls_to_credits_aleo() -> Result<()> {
@@ -96,6 +98,7 @@ fn test_dynamic_calls_to_credits_aleo() -> Result<()> {
     // Deploy the program.
     println!("Deploying program: {}", program.id());
     let transaction = vm.deploy(&caller_private_key, &program, None, 0, None, rng)?;
+    let deployment = transaction.deployment().ok_or_else(|| anyhow!("Expected a deployment transaction"))?.clone();
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);
@@ -165,6 +168,20 @@ fn test_dynamic_calls_to_credits_aleo() -> Result<()> {
         rng,
     )?;
     vm.check_transaction(&transaction, None, rng)?;
+
+    // Verify the proof in a fresh process that did not synthesize the credits translation key while proving.
+    let verifier = Process::<CurrentNetwork>::load()?;
+    verifier.load_deployment(&deployment)?;
+    let execution = transaction.execution().ok_or_else(|| anyhow!("Expected an execution transaction"))?;
+    let execution_stacks = verifier.get_stacks(execution.transitions(), false)?;
+    Process::verify_execution(
+        ConsensusVersion::V14,
+        varuna_version_from_consensus(ConsensusVersion::V14),
+        InclusionVersion::V1,
+        execution,
+        &execution_stacks,
+    )?;
+
     let block = sample_next_block(&vm, &caller_private_key, &[transaction], rng)?;
     assert_eq!(block.transactions().num_accepted(), 1);
     assert_eq!(block.transactions().num_rejected(), 0);


### PR DESCRIPTION
Dynamic calls can translate the native `credits.aleo/credits` record, but fresh verifiers previously lacked its translation key. This loads the existing network key and enables verification at Consensus V18.

## Changes

- Load the native credits translation key during `Process::load` and credits-key refreshes.
- Return the same key from the deployment-store lookup paths.
- Reject native credits record translation before V18 and allow it from V18 onward.
- Cover fresh-process verification and key load, lookup, and refresh behavior.

The translation circuit, key bytes, and record encoding are unchanged. Ordinary credits calls and other record translations are unaffected.

## Verification

- Focused process, ledger-store, and dynamic credits regressions pass.
- Workspace Clippy and nightly formatting pass.

This is the node-side dependency for ProvableHQ/amm-v3#58.