### PR TITLE
Make synthesis limit tracking robust against function calls

### DIFF
--- a/circuit/environment/src/canary_circuit.rs
+++ b/circuit/environment/src/canary_circuit.rs
@@ -296,8 +296,9 @@ impl Environment for CanaryCircuit {
         panic!("{}", &error)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
+    /// Injects the ejected R1CS circuit and restores the preserved environment state.
+    fn inject_r1cs(ejected: EjectedR1cs<Self::BaseField>) {
+        let EjectedR1cs { r1cs, variable_limit, constraint_limit, non_zero_limit, in_witness } = ejected;
         CANARY_CIRCUIT.with(|circuit| {
             // Ensure the circuit is empty before injecting.
             assert_eq!(0, circuit.borrow().num_constants());
@@ -313,19 +314,31 @@ impl Environment for CanaryCircuit {
             assert_eq!(0, r1cs.num_private());
             assert_eq!(1, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
-        })
+        });
+        // Restore the preserved limits.
+        Self::set_variable_limit(variable_limit);
+        Self::set_constraint_limit(constraint_limit);
+        Self::set_non_zero_limit(non_zero_limit);
+        // Restore the preserved witness mode.
+        IN_WITNESS.with(|in_witness_cell| in_witness_cell.replace(in_witness));
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+    /// Returns the R1CS circuit and preserved environment state, resetting the circuit.
+    fn eject_r1cs_and_reset() -> EjectedR1cs<Self::BaseField> {
         CANARY_CIRCUIT.with(|circuit| {
-            // Reset the witness mode.
-            IN_WITNESS.with(|in_witness| in_witness.replace(false));
-            // Reset the variable limit.
+            // Preserve the witness mode.
+            let in_witness = IN_WITNESS.with(|in_witness| {
+                let value = in_witness.get();
+                in_witness.replace(false);
+                value
+            });
+            // Preserve the limits.
+            let variable_limit = Self::get_variable_limit();
+            let constraint_limit = Self::get_constraint_limit();
+            let non_zero_limit = Self::get_non_zero_limit();
+            // Reset the limits for the temporary environment.
             Self::set_variable_limit(None);
-            // Reset the constraint limit.
             Self::set_constraint_limit(None);
-            // Reset the density limit.
             Self::set_non_zero_limit(None);
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
@@ -335,8 +348,8 @@ impl Environment for CanaryCircuit {
             assert_eq!(0, circuit.borrow().num_private());
             assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
-            // Return the R1CS instance.
-            r1cs
+            // Return the ejected environment state.
+            EjectedR1cs::new(r1cs, variable_limit, constraint_limit, non_zero_limit, in_witness)
         })
     }
 

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -505,13 +505,18 @@ mod tests {
         assert_eq!(None, Circuit::get_constraint_limit());
         assert_eq!(Some(20), ejected.constraint_limit());
 
-        add_constraints::<Circuit>(5);
+        // Without limits, the temporary environment can synthesize beyond the preserved limit.
+        add_constraints::<Circuit>(25);
+        assert_eq!(25, Circuit::num_constraints());
+
+        // Nested execution resets the circuit before returning control to the caller.
+        Circuit::reset();
 
         Circuit::inject_r1cs(ejected);
         assert_eq!(Some(20), Circuit::get_constraint_limit());
         assert_eq!(10, Circuit::num_constraints());
 
-        let result = panic::catch_unwind(AssertUnwindSafe(|| add_constraints::<Circuit>(11)));
+        let result = panic::catch_unwind(AssertUnwindSafe(|| add_constraints::<Circuit>(12)));
         assert!(result.is_err());
     }
 }

--- a/circuit/environment/src/circuit.rs
+++ b/circuit/environment/src/circuit.rs
@@ -320,8 +320,9 @@ impl Environment for Circuit {
         panic!("{}", &error)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
+    /// Injects the ejected R1CS circuit and restores the preserved environment state.
+    fn inject_r1cs(ejected: EjectedR1cs<Self::BaseField>) {
+        let EjectedR1cs { r1cs, variable_limit, constraint_limit, non_zero_limit, in_witness } = ejected;
         CIRCUIT.with(|circuit| {
             // Ensure the circuit is empty before injecting.
             assert_eq!(0, circuit.borrow().num_constants());
@@ -337,19 +338,31 @@ impl Environment for Circuit {
             assert_eq!(0, r1cs.num_private());
             assert_eq!(1, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
-        })
+        });
+        // Restore the preserved limits.
+        Self::set_variable_limit(variable_limit);
+        Self::set_constraint_limit(constraint_limit);
+        Self::set_non_zero_limit(non_zero_limit);
+        // Restore the preserved witness mode.
+        IN_WITNESS.with(|in_witness_cell| in_witness_cell.replace(in_witness));
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+    /// Returns the R1CS circuit and preserved environment state, resetting the circuit.
+    fn eject_r1cs_and_reset() -> EjectedR1cs<Self::BaseField> {
         CIRCUIT.with(|circuit| {
-            // Reset the witness mode.
-            IN_WITNESS.with(|in_witness| in_witness.replace(false));
-            // Reset the variable limit.
+            // Preserve the witness mode.
+            let in_witness = IN_WITNESS.with(|in_witness| {
+                let value = in_witness.get();
+                in_witness.replace(false);
+                value
+            });
+            // Preserve the limits.
+            let variable_limit = Self::get_variable_limit();
+            let constraint_limit = Self::get_constraint_limit();
+            let non_zero_limit = Self::get_non_zero_limit();
+            // Reset the limits for the temporary environment.
             Self::set_variable_limit(None);
-            // Reset the constraint limit.
             Self::set_constraint_limit(None);
-            // Reset the density limit.
             Self::set_non_zero_limit(None);
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
@@ -359,8 +372,8 @@ impl Environment for Circuit {
             assert_eq!(0, circuit.borrow().num_private());
             assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
-            // Return the R1CS instance.
-            r1cs
+            // Return the ejected environment state.
+            EjectedR1cs::new(r1cs, variable_limit, constraint_limit, non_zero_limit, in_witness)
         })
     }
 
@@ -463,5 +476,42 @@ mod tests {
             assert_eq!(0, Circuit::num_private_in_scope());
             assert_eq!(0, Circuit::num_constraints_in_scope());
         })
+    }
+
+    #[test]
+    fn test_eject_inject_preserves_limits() {
+        use std::panic::{self, AssertUnwindSafe};
+
+        /// Compute 2^EXPONENT - 1, in a purposefully constraint-inefficient manner for testing.
+        fn add_constraints<E: Environment>(exponent: u64) {
+            let one = snarkvm_console_types::Field::<<E as Environment>::Network>::one();
+            let two = one + one;
+
+            let mut candidate = Field::<E>::new(Mode::Public, one);
+            let mut accumulator = Field::<E>::new(Mode::Private, two);
+            for _ in 0..exponent {
+                candidate += &accumulator;
+                accumulator *= Field::<E>::new(Mode::Private, two);
+            }
+        }
+
+        Circuit::reset();
+        Circuit::set_constraint_limit(Some(20));
+
+        add_constraints::<Circuit>(10);
+        assert_eq!(10, Circuit::num_constraints());
+
+        let ejected = Circuit::eject_r1cs_and_reset();
+        assert_eq!(None, Circuit::get_constraint_limit());
+        assert_eq!(Some(20), ejected.constraint_limit());
+
+        add_constraints::<Circuit>(5);
+
+        Circuit::inject_r1cs(ejected);
+        assert_eq!(Some(20), Circuit::get_constraint_limit());
+        assert_eq!(10, Circuit::num_constraints());
+
+        let result = panic::catch_unwind(AssertUnwindSafe(|| add_constraints::<Circuit>(11)));
+        assert!(result.is_err());
     }
 }

--- a/circuit/environment/src/environment.rs
+++ b/circuit/environment/src/environment.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Assignment, ConstraintUnsatisfied, Inject, LinearCombination, Mode, R1CS, Variable, witness_mode};
+use crate::{Assignment, ConstraintUnsatisfied, EjectedR1cs, Inject, LinearCombination, Mode, Variable, witness_mode};
 use snarkvm_curves::AffineCurve;
 use snarkvm_fields::traits::*;
 
@@ -185,11 +185,11 @@ pub trait Environment: 'static + Copy + Clone + fmt::Debug + fmt::Display + Eq +
         <Self::Network as console::Environment>::halt(message)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn inject_r1cs(r1cs: R1CS<Self::BaseField>);
+    /// Injects the ejected R1CS circuit and restores the preserved environment state.
+    fn inject_r1cs(ejected: EjectedR1cs<Self::BaseField>);
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn eject_r1cs_and_reset() -> R1CS<Self::BaseField>;
+    /// Returns the R1CS circuit and preserved environment state, resetting the circuit.
+    fn eject_r1cs_and_reset() -> EjectedR1cs<Self::BaseField>;
 
     /// Returns the R1CS assignment of the circuit, resetting the circuit.
     fn eject_assignment_and_reset() -> Assignment<<Self::Network as console::Environment>::Field>;

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -293,6 +293,12 @@ impl<F: PrimeField> EjectedR1cs<F> {
         self.constraint_limit
     }
 
+    /// Resets the constraint limit to the preserved value.
+    pub fn reset_nonzero_limit(&mut self) {
+        // TODO (Antonio) correct value?
+        self.non_zero_limit = self.non_zero_limit.map(|_| (0, 0, 0));
+    }
+
     /// Returns the preserved non-zero limit.
     pub const fn non_zero_limit(&self) -> Option<(u64, u64, u64)> {
         self.non_zero_limit

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -293,7 +293,7 @@ impl<F: PrimeField> EjectedR1cs<F> {
         self.constraint_limit
     }
 
-    /// Resets the constraint limit to the preserved value.
+    /// Resets the non-zero limits.
     pub fn reset_nonzero_limit(&mut self) {
         // TODO (Antonio) correct value?
         self.non_zero_limit = self.non_zero_limit.map(|_| (0, 0, 0));

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -294,9 +294,10 @@ impl<F: PrimeField> EjectedR1cs<F> {
     }
 
     /// Resets the non-zero limits.
-    pub fn reset_nonzero_limit(&mut self) {
-        // TODO (Antonio) correct value?
-        self.non_zero_limit = self.non_zero_limit.map(|_| (0, 0, 0));
+    // This is only used in ConsensusVersion::V18, where density limits were introduced and before
+    // re-injection limit behaviour was corrected in V19.
+    pub fn remove_nonzero_limit(&mut self) {
+        self.non_zero_limit = None;
     }
 
     /// Returns the preserved non-zero limit.

--- a/circuit/environment/src/helpers/r1cs.rs
+++ b/circuit/environment/src/helpers/r1cs.rs
@@ -266,3 +266,50 @@ impl<F: PrimeField> Display for R1CS<F> {
         write!(f, "{output}")
     }
 }
+
+/// Captures the circuit environment state preserved across a temporary R1CS ejection.
+#[derive(Debug)]
+pub struct EjectedR1cs<F: PrimeField> {
+    pub(crate) r1cs: R1CS<F>,
+    pub(crate) variable_limit: Option<u64>,
+    pub(crate) constraint_limit: Option<u64>,
+    pub(crate) non_zero_limit: Option<(u64, u64, u64)>,
+    pub(crate) in_witness: bool,
+}
+
+impl<F: PrimeField> EjectedR1cs<F> {
+    /// Returns the ejected R1CS without restoring the environment state.
+    pub fn into_r1cs(self) -> R1CS<F> {
+        self.r1cs
+    }
+
+    /// Returns the preserved variable limit.
+    pub const fn variable_limit(&self) -> Option<u64> {
+        self.variable_limit
+    }
+
+    /// Returns the preserved constraint limit.
+    pub const fn constraint_limit(&self) -> Option<u64> {
+        self.constraint_limit
+    }
+
+    /// Returns the preserved non-zero limit.
+    pub const fn non_zero_limit(&self) -> Option<(u64, u64, u64)> {
+        self.non_zero_limit
+    }
+
+    /// Returns the preserved witness mode.
+    pub const fn in_witness(&self) -> bool {
+        self.in_witness
+    }
+
+    pub(crate) fn new(
+        r1cs: R1CS<F>,
+        variable_limit: Option<u64>,
+        constraint_limit: Option<u64>,
+        non_zero_limit: Option<(u64, u64, u64)>,
+        in_witness: bool,
+    ) -> Self {
+        Self { r1cs, variable_limit, constraint_limit, non_zero_limit, in_witness }
+    }
+}

--- a/circuit/environment/src/testnet_circuit.rs
+++ b/circuit/environment/src/testnet_circuit.rs
@@ -296,8 +296,9 @@ impl Environment for TestnetCircuit {
         panic!("{}", &error)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
+    /// Injects the ejected R1CS circuit and restores the preserved environment state.
+    fn inject_r1cs(ejected: EjectedR1cs<Self::BaseField>) {
+        let EjectedR1cs { r1cs, variable_limit, constraint_limit, non_zero_limit, in_witness } = ejected;
         TESTNET_CIRCUIT.with(|circuit| {
             // Ensure the circuit is empty before injecting.
             assert_eq!(0, circuit.borrow().num_constants());
@@ -313,19 +314,31 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, r1cs.num_private());
             assert_eq!(1, r1cs.num_variables());
             assert_eq!(0, r1cs.num_constraints());
-        })
+        });
+        // Restore the preserved limits.
+        Self::set_variable_limit(variable_limit);
+        Self::set_constraint_limit(constraint_limit);
+        Self::set_non_zero_limit(non_zero_limit);
+        // Restore the preserved witness mode.
+        IN_WITNESS.with(|in_witness_cell| in_witness_cell.replace(in_witness));
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+    /// Returns the R1CS circuit and preserved environment state, resetting the circuit.
+    fn eject_r1cs_and_reset() -> EjectedR1cs<Self::BaseField> {
         TESTNET_CIRCUIT.with(|circuit| {
-            // Reset the witness mode.
-            IN_WITNESS.with(|in_witness| in_witness.replace(false));
-            // Reset the variable limit.
+            // Preserve the witness mode.
+            let in_witness = IN_WITNESS.with(|in_witness| {
+                let value = in_witness.get();
+                in_witness.replace(false);
+                value
+            });
+            // Preserve the limits.
+            let variable_limit = Self::get_variable_limit();
+            let constraint_limit = Self::get_constraint_limit();
+            let non_zero_limit = Self::get_non_zero_limit();
+            // Reset the limits for the temporary environment.
             Self::set_variable_limit(None);
-            // Reset the constraint limit.
             Self::set_constraint_limit(None);
-            // Reset the density limit.
             Self::set_non_zero_limit(None);
             // Eject the R1CS instance.
             let r1cs = circuit.replace(R1CS::<<Self as Environment>::BaseField>::new());
@@ -335,8 +348,8 @@ impl Environment for TestnetCircuit {
             assert_eq!(0, circuit.borrow().num_private());
             assert_eq!(1, circuit.borrow().num_variables());
             assert_eq!(0, circuit.borrow().num_constraints());
-            // Return the R1CS instance.
-            r1cs
+            // Return the ejected environment state.
+            EjectedR1cs::new(r1cs, variable_limit, constraint_limit, non_zero_limit, in_witness)
         })
     }
 

--- a/circuit/network/src/canary_v0.rs
+++ b/circuit/network/src/canary_v0.rs
@@ -44,7 +44,7 @@ use snarkvm_circuit_types::{
     Field,
     Group,
     Scalar,
-    environment::{Assignment, CanaryCircuit, R1CS, prelude::*},
+    environment::{Assignment, CanaryCircuit, EjectedR1cs, prelude::*},
 };
 
 use core::fmt;
@@ -538,13 +538,13 @@ impl Environment for AleoCanaryV0 {
         E::halt(message)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
-        E::inject_r1cs(r1cs)
+    /// Injects the ejected R1CS circuit and restores the preserved environment state.
+    fn inject_r1cs(ejected: EjectedR1cs<Self::BaseField>) {
+        E::inject_r1cs(ejected)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+    /// Returns the R1CS circuit and preserved environment state, resetting the circuit.
+    fn eject_r1cs_and_reset() -> EjectedR1cs<Self::BaseField> {
         E::eject_r1cs_and_reset()
     }
 

--- a/circuit/network/src/testnet_v0.rs
+++ b/circuit/network/src/testnet_v0.rs
@@ -44,7 +44,7 @@ use snarkvm_circuit_types::{
     Field,
     Group,
     Scalar,
-    environment::{Assignment, R1CS, TestnetCircuit, prelude::*},
+    environment::{Assignment, EjectedR1cs, TestnetCircuit, prelude::*},
 };
 
 use core::fmt;
@@ -538,13 +538,13 @@ impl Environment for AleoTestnetV0 {
         E::halt(message)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
-        E::inject_r1cs(r1cs)
+    /// Injects the ejected R1CS circuit and restores the preserved environment state.
+    fn inject_r1cs(ejected: EjectedR1cs<Self::BaseField>) {
+        E::inject_r1cs(ejected)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+    /// Returns the R1CS circuit and preserved environment state, resetting the circuit.
+    fn eject_r1cs_and_reset() -> EjectedR1cs<Self::BaseField> {
         E::eject_r1cs_and_reset()
     }
 

--- a/circuit/network/src/v0.rs
+++ b/circuit/network/src/v0.rs
@@ -44,7 +44,7 @@ use snarkvm_circuit_types::{
     Field,
     Group,
     Scalar,
-    environment::{Assignment, Circuit, R1CS, prelude::*},
+    environment::{Assignment, Circuit, EjectedR1cs, prelude::*},
 };
 
 use core::fmt;
@@ -538,13 +538,13 @@ impl Environment for AleoV0 {
         E::halt(message)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn inject_r1cs(r1cs: R1CS<Self::BaseField>) {
-        E::inject_r1cs(r1cs)
+    /// Injects the ejected R1CS circuit and restores the preserved environment state.
+    fn inject_r1cs(ejected: EjectedR1cs<Self::BaseField>) {
+        E::inject_r1cs(ejected)
     }
 
-    /// Returns the R1CS circuit, resetting the circuit.
-    fn eject_r1cs_and_reset() -> R1CS<Self::BaseField> {
+    /// Returns the R1CS circuit and preserved environment state, resetting the circuit.
+    fn eject_r1cs_and_reset() -> EjectedR1cs<Self::BaseField> {
         E::eject_r1cs_and_reset()
     }
 

--- a/ledger/puzzle/epoch/src/synthesis/program/to_r1cs.rs
+++ b/ledger/puzzle/epoch/src/synthesis/program/to_r1cs.rs
@@ -95,7 +95,7 @@ impl<N: Network> EpochProgram<N> {
         lap!(timer, "Ensure the circuit is satisfied");
 
         // Eject the R1CS and reset the circuit.
-        let r1cs = A::eject_r1cs_and_reset();
+        let r1cs = A::eject_r1cs_and_reset().into_r1cs();
         finish!(timer, "Eject the circuit assignment and reset the circuit");
 
         Ok(r1cs)

--- a/synthesizer/process/src/stack/call/dynamic.rs
+++ b/synthesizer/process/src/stack/call/dynamic.rs
@@ -301,7 +301,7 @@ impl<N: Network> CallTrait<N> for CallDynamic<N> {
             let mut r1cs = A::eject_r1cs_and_reset();
 
             if matches!(registers.call_stack_ref(), CallStack::CheckDeployment(_, _, _, _, _, Some((_, _, _, true)))) {
-                r1cs.reset_nonzero_limit();
+                r1cs.remove_nonzero_limit();
             }
 
             let (request, caller_response_outputs) = {

--- a/synthesizer/process/src/stack/call/dynamic.rs
+++ b/synthesizer/process/src/stack/call/dynamic.rs
@@ -298,7 +298,12 @@ impl<N: Network> CallTrait<N> for CallDynamic<N> {
             let is_root = false;
 
             // Eject the existing circuit.
-            let r1cs = A::eject_r1cs_and_reset();
+            let mut r1cs = A::eject_r1cs_and_reset();
+
+            if matches!(registers.call_stack_ref(), CallStack::CheckDeployment(_, _, _, _, _, Some((_, _, _, true)))) {
+                r1cs.reset_nonzero_limit();
+            }
+
             let (request, caller_response_outputs) = {
                 // Resolve the program and function.
                 let target = resolve_dynamic_target(

--- a/synthesizer/process/src/stack/call/standard.rs
+++ b/synthesizer/process/src/stack/call/standard.rs
@@ -293,8 +293,14 @@ impl<N: Network> CallTrait<N> for Call<N> {
             let is_root = false;
 
             use circuit::Eject;
+
             // Eject the existing circuit.
-            let r1cs = A::eject_r1cs_and_reset();
+            let mut r1cs = A::eject_r1cs_and_reset();
+
+            if matches!(registers.call_stack_ref(), CallStack::CheckDeployment(_, _, _, _, _, Some((_, _, _, true)))) {
+                r1cs.reset_nonzero_limit();
+            }
+
             let (request, response) = {
                 // Eject the circuit inputs.
                 let inputs = inputs.eject_value();

--- a/synthesizer/process/src/stack/call/standard.rs
+++ b/synthesizer/process/src/stack/call/standard.rs
@@ -298,7 +298,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             let mut r1cs = A::eject_r1cs_and_reset();
 
             if matches!(registers.call_stack_ref(), CallStack::CheckDeployment(_, _, _, _, _, Some((_, _, _, true)))) {
-                r1cs.reset_nonzero_limit();
+                r1cs.remove_nonzero_limit();
             }
 
             let (request, response) = {

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -217,6 +217,7 @@ impl<N: Network> Stack<N> {
             // If the consensus version is >= V18, set the density limit, accounting for one non-zero entry (with value 1) added to
             // each of A, B and C in order to make the Varuna zerocheck hiding.
             let non_zero_limit = if consensus_version >= ConsensusVersion::V18 {
+                // Before V19, we keep track of the fact that synthesis limits should be reset when the circuit is ejected.
                 let reset_with_eject = consensus_version < ConsensusVersion::V19;
 
                 let info = verifying_key.circuit_info;

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -217,7 +217,7 @@ impl<N: Network> Stack<N> {
             // If the consensus version is >= V18, set the density limit, accounting for one non-zero entry (with value 1) added to
             // each of A, B and C in order to make the Varuna zerocheck hiding.
             let non_zero_limit = if consensus_version >= ConsensusVersion::V18 {
-                let reset_with_eject = consensus_version >= ConsensusVersion::V19;
+                let reset_with_eject = consensus_version < ConsensusVersion::V19;
 
                 let info = verifying_key.circuit_info;
                 if info.num_non_zero_a >= 1 && info.num_non_zero_b >= 1 && info.num_non_zero_c >= 1 {

--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -217,12 +217,15 @@ impl<N: Network> Stack<N> {
             // If the consensus version is >= V18, set the density limit, accounting for one non-zero entry (with value 1) added to
             // each of A, B and C in order to make the Varuna zerocheck hiding.
             let non_zero_limit = if consensus_version >= ConsensusVersion::V18 {
+                let reset_with_eject = consensus_version >= ConsensusVersion::V19;
+
                 let info = verifying_key.circuit_info;
                 if info.num_non_zero_a >= 1 && info.num_non_zero_b >= 1 && info.num_non_zero_c >= 1 {
                     Some((
                         info.num_non_zero_a as u64 - 1,
                         info.num_non_zero_b as u64 - 1,
                         info.num_non_zero_c as u64 - 1,
+                        reset_with_eject,
                     ))
                 } else {
                     bail!(

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -210,7 +210,6 @@ impl<N: Network> Stack<N> {
         A::reset();
 
         // If in 'CheckDeployment' mode, set the constraint limit and variable limit.
-        // We do not have to reset it after function calls because `CheckDeployment` mode does not execute those.
         if let CallStack::CheckDeployment(_, _, _, constraint_limit, variable_limit, non_zero_limit) = &call_stack {
             A::set_constraint_limit(*constraint_limit);
             A::set_variable_limit(*variable_limit);

--- a/synthesizer/process/src/stack/execute.rs
+++ b/synthesizer/process/src/stack/execute.rs
@@ -213,7 +213,7 @@ impl<N: Network> Stack<N> {
         if let CallStack::CheckDeployment(_, _, _, constraint_limit, variable_limit, non_zero_limit) = &call_stack {
             A::set_constraint_limit(*constraint_limit);
             A::set_variable_limit(*variable_limit);
-            A::set_non_zero_limit(*non_zero_limit);
+            A::set_non_zero_limit(non_zero_limit.map(|(a, b, c, _)| (a, b, c)));
         }
 
         // Retrieve the next request.

--- a/synthesizer/process/src/stack/mod.rs
+++ b/synthesizer/process/src/stack/mod.rs
@@ -140,7 +140,14 @@ pub enum CallStack<N: Network> {
     /// Synthesize a function circuit before a `Deploy` transaction.
     Synthesize(Vec<Request<N>>, PrivateKey<N>, Authorization<N>),
     /// Validate a `Deploy` transaction's function circuit.
-    CheckDeployment(Vec<Request<N>>, PrivateKey<N>, Assignments<N>, Option<u64>, Option<u64>, Option<(u64, u64, u64)>),
+    CheckDeployment(
+        Vec<Request<N>>,
+        PrivateKey<N>,
+        Assignments<N>,
+        Option<u64>,
+        Option<u64>,
+        Option<(u64, u64, u64, bool)>,
+    ),
     /// Evaluate a function.
     Evaluate(Authorization<N>),
     /// Execute a function and produce a proof.

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -13,7 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{CallStack, InclusionVersion, Process, Trace, execution_cost, execution_cost_for_authorization};
+use crate::{
+    Assignments,
+    CallStack,
+    InclusionVersion,
+    Process,
+    Request,
+    Stack,
+    Trace,
+    execution_cost,
+    execution_cost_for_authorization,
+};
 use circuit::{Aleo, network::AleoV0};
 use console::{
     account::{Address, PrivateKey, ViewKey},
@@ -2984,4 +2994,237 @@ fn test_program_exceeding_transaction_spend_limit() {
     let deployment = process.deploy::<CurrentAleo, _>(&program, rng).unwrap();
     // Attempt to verify the deployment, which should fail.
     assert!(process.verify_deployment::<CurrentAleo, _>(ConsensusVersion::V8, &deployment, rng).is_ok());
+}
+
+/// Returns the number of constraints synthesized in `CheckDeployment` mode.
+fn check_deployment_num_constraints(
+    stack: &Stack<CurrentNetwork>,
+    private_key: &PrivateKey<CurrentNetwork>,
+    function_name: Identifier<CurrentNetwork>,
+    inputs: &[Value<CurrentNetwork>],
+    constraint_limit: Option<u64>,
+    variable_limit: Option<u64>,
+    non_zero_limit: Option<(u64, u64, u64)>,
+    rng: &mut TestRng,
+) -> Result<u64> {
+    use snarkvm_synthesizer_program::StackTrait;
+    use std::panic::{self, AssertUnwindSafe};
+
+    let program = stack.program();
+    let program_id = *program.id();
+    let input_types = program.get_function(&function_name)?.input_types();
+    let program_checksum = match stack.program().contains_constructor() {
+        true => Some(stack.program_checksum_as_field()?),
+        false => None,
+    };
+    let request = Request::sign(
+        private_key,
+        program_id,
+        function_name,
+        inputs.iter(),
+        &input_types,
+        None,
+        true,
+        program_checksum,
+        false,
+        rng,
+    )?;
+    let assignments = Assignments::<CurrentNetwork>::default();
+    let call_stack = CallStack::CheckDeployment(
+        vec![request],
+        *private_key,
+        assignments.clone(),
+        constraint_limit,
+        variable_limit,
+        non_zero_limit,
+    );
+
+    match panic::catch_unwind(AssertUnwindSafe(|| {
+        stack.execute_function::<CurrentAleo, _>(call_stack, None, None, rng)
+    })) {
+        Ok(Ok(_)) => Ok(assignments.read().last().unwrap().0.num_constraints()),
+        Ok(Err(err)) => bail!("{err}"),
+        Err(payload) => {
+            if let Some(message) = payload.downcast_ref::<&str>() {
+                bail!("{message}");
+            } else if let Some(message) = payload.downcast_ref::<String>() {
+                bail!("{message}");
+            }
+            bail!("Synthesis halted");
+        }
+    }
+}
+
+/// Builds a suffix of repeated field additions for synthesis limit tests.
+fn field_add_suffix(num_adds: usize) -> String {
+    let mut suffix = String::from("add r1 r1 into r2;\n");
+    for i in 2..=num_adds {
+        suffix.push_str(&format!("add r{i} r{i} into r{};\n", i + 1));
+    }
+    suffix.push_str(&format!("output r{} as field.private;", num_adds + 1));
+    suffix
+}
+
+/// Initializes a process containing the given programs.
+fn process_with_programs(programs: &[&str]) -> Process<CurrentNetwork> {
+    let process = Process::<CurrentNetwork>::load().unwrap();
+    for source in programs {
+        let (_, program) = Program::<CurrentNetwork>::parse(source).unwrap();
+        process.lock().add_program(&program).unwrap();
+    }
+    process
+}
+
+#[test]
+fn test_check_deployment_static_call_enforces_constraint_limit_after_call() {
+    let rng = &mut TestRng::default();
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let input = Value::<CurrentNetwork>::Plaintext(Plaintext::from_str("3field").unwrap());
+
+    let callee = r"
+program callee_limits.aleo;
+function noop:
+    input r0 as field.private;
+    output r0 as field.private;";
+
+    let caller_prefix = r"
+import callee_limits.aleo;
+program caller_prefix.aleo;
+function compute:
+    input r0 as field.private;
+    call callee_limits.aleo/noop r0 into r1;
+    output r1 as field.private;";
+
+    let caller_full = format!(
+        r"
+import callee_limits.aleo;
+program caller_full.aleo;
+function compute:
+    input r0 as field.private;
+    call callee_limits.aleo/noop r0 into r1;
+    {}",
+        field_add_suffix(32),
+    );
+
+    let process = process_with_programs(&[callee, caller_prefix, &caller_full]);
+    let prefix_stack = process.get_stack(ProgramID::from_str("caller_prefix.aleo").unwrap()).unwrap();
+    let full_stack = process.get_stack(ProgramID::from_str("caller_full.aleo").unwrap()).unwrap();
+    let function_name = Identifier::from_str("compute").unwrap();
+
+    let prefix_constraints = check_deployment_num_constraints(
+        &prefix_stack,
+        &private_key,
+        function_name,
+        &[input.clone()],
+        None,
+        None,
+        None,
+        rng,
+    )
+    .unwrap();
+    let full_constraints = check_deployment_num_constraints(
+        &full_stack,
+        &private_key,
+        function_name,
+        &[input.clone()],
+        None,
+        None,
+        None,
+        rng,
+    )
+    .unwrap();
+    assert!(prefix_constraints < full_constraints);
+
+    let constraint_limit = prefix_constraints + (full_constraints - prefix_constraints) / 2;
+    let result = check_deployment_num_constraints(
+        &full_stack,
+        &private_key,
+        function_name,
+        &[input],
+        Some(constraint_limit),
+        None,
+        None,
+        rng,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Surpassed the constraint limit"));
+}
+
+#[test]
+fn test_check_deployment_dynamic_call_enforces_constraint_limit_after_call() {
+    let rng = &mut TestRng::default();
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let input = Value::<CurrentNetwork>::Plaintext(Plaintext::from_str("3field").unwrap());
+
+    let network_field = Identifier::<CurrentNetwork>::from_str("aleo").unwrap().to_field().unwrap();
+    let callee_prog_field = Identifier::<CurrentNetwork>::from_str("dyn_callee").unwrap().to_field().unwrap();
+    let callee_fn_field = Identifier::<CurrentNetwork>::from_str("noop").unwrap().to_field().unwrap();
+
+    let callee = r"
+program dyn_callee.aleo;
+function noop:
+    input r0 as field.private;
+    output r0 as field.private;";
+
+    let caller_prefix = format!(
+        r"
+program dyn_caller_prefix.aleo;
+function compute:
+    input r0 as field.private;
+    call.dynamic {callee_prog_field} {network_field} {callee_fn_field} with r0 (as field.private) into r1 (as field.private);
+    output r1 as field.private;"
+    );
+
+    let caller_full = format!(
+        r"
+program dyn_caller_full.aleo;
+function compute:
+    input r0 as field.private;
+    call.dynamic {callee_prog_field} {network_field} {callee_fn_field} with r0 (as field.private) into r1 (as field.private);
+    {}",
+        field_add_suffix(32),
+    );
+
+    let process = process_with_programs(&[callee, &caller_prefix, &caller_full]);
+    let prefix_stack = process.get_stack(ProgramID::from_str("dyn_caller_prefix.aleo").unwrap()).unwrap();
+    let full_stack = process.get_stack(ProgramID::from_str("dyn_caller_full.aleo").unwrap()).unwrap();
+    let function_name = Identifier::from_str("compute").unwrap();
+
+    let prefix_constraints = check_deployment_num_constraints(
+        &prefix_stack,
+        &private_key,
+        function_name,
+        &[input.clone()],
+        None,
+        None,
+        None,
+        rng,
+    )
+    .unwrap();
+    let full_constraints = check_deployment_num_constraints(
+        &full_stack,
+        &private_key,
+        function_name,
+        &[input.clone()],
+        None,
+        None,
+        None,
+        rng,
+    )
+    .unwrap();
+    assert!(prefix_constraints < full_constraints);
+
+    let constraint_limit = prefix_constraints + (full_constraints - prefix_constraints) / 2;
+    let result = check_deployment_num_constraints(
+        &full_stack,
+        &private_key,
+        function_name,
+        &[input],
+        Some(constraint_limit),
+        None,
+        None,
+        rng,
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Surpassed the constraint limit"));
 }

--- a/synthesizer/process/src/tests/test_execute.rs
+++ b/synthesizer/process/src/tests/test_execute.rs
@@ -3004,7 +3004,7 @@ fn check_deployment_num_constraints(
     inputs: &[Value<CurrentNetwork>],
     constraint_limit: Option<u64>,
     variable_limit: Option<u64>,
-    non_zero_limit: Option<(u64, u64, u64)>,
+    non_zero_limit: Option<(u64, u64, u64, bool)>,
     rng: &mut TestRng,
 ) -> Result<u64> {
     use snarkvm_synthesizer_program::StackTrait;


### PR DESCRIPTION
## Motivation

Our synthesis limit tracking was not robust in the presence of function calls (which reset limits).

## Test Plan

Appropriate unit tests were added.

## Backwards compatibility

This PR changes transaction validity and should therefore technically be `ConsensusVersion` guarded. However, the change lives deep in the VM logic which is supposed to be stateless, which makes this quite hard to do.[1] Fortunately, only explicitly maliciously crafted transactions become invalid, which has a low probability of happening in practice at the moment so IMO we can forego this effort.

[1] From `fn verify_deployment`, we could track "limit resetting" in the `CallStack::CheckDeployment(.., limits, ..)` tuple, similar to what was argued for here: https://github.com/ProvableHQ/snarkVM/pull/3346#issuecomment-5146153686