### PR TITLE
[Feat] Align declared plaintext type sizes during deployment verification

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -69,7 +69,8 @@ pub enum ConsensusVersion {
     /// V18: Enables native credits record translation, introduces block-wide deployment limits,
     ///      and enforces canonical subDAG certificate ordering.
     V18 = 18,
-    /// V19: Adds more accurate type checking for the root call.
+    /// V19: Adds more accurate type checking for the root call, and bounds the size of every
+    /// `PlaintextType` declared in a deployed program.
     V19 = 19,
     /// V20: TBD
     V20 = 20,

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -210,6 +210,10 @@ pub trait Network:
     /// The maximum number of fields in data (must not exceed u16::MAX).
     #[allow(clippy::cast_possible_truncation)]
     const MAX_DATA_SIZE_IN_FIELDS: u32 = ((128 * 1024 * 8) / Field::<Self>::SIZE_IN_DATA_BITS) as u32;
+    /// A list of (consensus_version, size) pairs indicating the maximum size in bits of any single
+    /// `PlaintextType` declared in a program. This mirrors the runtime budget `to_fields` enforces.
+    const MAX_PLAINTEXT_TYPE_SIZE_IN_BITS: [(ConsensusVersion, usize); 1] =
+        [(ConsensusVersion::V19, Self::MAX_DATA_SIZE_IN_FIELDS as usize * Field::<Self>::SIZE_IN_DATA_BITS)];
 
     /// The minimum number of entries in a struct.
     const MIN_STRUCT_ENTRIES: usize = 1; // This ensures the struct is not empty.
@@ -354,6 +358,14 @@ pub trait Network:
     #[allow(non_snake_case)]
     fn LATEST_MAX_ARRAY_ELEMENTS() -> usize {
         Self::MAX_ARRAY_ELEMENTS.last().expect("MAX_ARRAY_ELEMENTS must have at least one entry").1
+    }
+    /// Returns the last `MAX_PLAINTEXT_TYPE_SIZE_IN_BITS` value.
+    #[allow(non_snake_case)]
+    fn LATEST_MAX_PLAINTEXT_TYPE_SIZE_IN_BITS() -> usize {
+        Self::MAX_PLAINTEXT_TYPE_SIZE_IN_BITS
+            .last()
+            .expect("MAX_PLAINTEXT_TYPE_SIZE_IN_BITS must have at least one entry")
+            .1
     }
     /// Returns the last `MAX_CERTIFICATES` value.
     #[allow(non_snake_case)]

--- a/synthesizer/src/vm/helpers/program.rs
+++ b/synthesizer/src/vm/helpers/program.rs
@@ -16,7 +16,7 @@
 use crate::Stack;
 use console::{
     prelude::{Network, cfg_iter},
-    program::{Identifier, Locator, ValueType},
+    program::{EntryType, FinalizeType, Identifier, Locator, PlaintextType, RegisterType, ValueType},
 };
 use snarkvm_synthesizer_program::{Program, StackTrait};
 
@@ -101,4 +101,102 @@ pub fn check_future_argument_bit_size<N: Network>(
             Ok(())
         })
     })
+}
+
+/// Checks that every `PlaintextType` declared in the program does not exceed the specified maximum size in bits.
+pub fn check_program_plaintext_sizes<N: Network>(
+    program: &Program<N>,
+    stack: &Stack<N>,
+    max_bits: usize,
+) -> Result<()> {
+    // Helper to get a struct declaration.
+    let get_struct = |id: &Identifier<N>| program.get_struct(id).cloned();
+
+    // Helper to get an external struct declaration.
+    let get_external_struct = |locator: &Locator<N>| {
+        stack.get_external_stack(locator.program_id())?.program().get_struct(locator.resource()).cloned()
+    };
+
+    // Check a single plaintext type against the budget.
+    let check = |pt: &PlaintextType<N>| -> Result<()> {
+        let bits = pt.size_in_bits_raw(&get_struct, &get_external_struct)?;
+        ensure!(
+            bits <= max_bits,
+            "Plaintext type '{pt}' exceeds the maximum allowed size in bits ({bits} > {max_bits})"
+        );
+        Ok(())
+    };
+
+    // Check function inputs, outputs, and finalize arguments.
+    for (_, function) in program.functions() {
+        for input in function.inputs() {
+            if let ValueType::Constant(pt) | ValueType::Public(pt) | ValueType::Private(pt) = input.value_type() {
+                check(pt)?;
+            }
+        }
+        for output in function.outputs() {
+            if let ValueType::Constant(pt) | ValueType::Public(pt) | ValueType::Private(pt) = output.value_type() {
+                check(pt)?;
+            }
+        }
+        if let Some(finalize) = function.finalize_logic() {
+            for input in finalize.inputs() {
+                if let FinalizeType::Plaintext(pt) = input.finalize_type() {
+                    check(pt)?;
+                }
+            }
+        }
+    }
+
+    // Check view inputs and outputs.
+    for (_, view) in program.views() {
+        for input in view.inputs() {
+            if let FinalizeType::Plaintext(pt) = input.finalize_type() {
+                check(pt)?;
+            }
+        }
+        for output in view.outputs() {
+            if let FinalizeType::Plaintext(pt) = output.finalize_type() {
+                check(pt)?;
+            }
+        }
+    }
+
+    // Check each struct member.
+    for (_, struct_) in program.structs() {
+        for (_, pt) in struct_.members() {
+            check(pt)?;
+        }
+    }
+
+    // Check each record entry.
+    for (_, record) in program.records() {
+        for (_, entry) in record.entries() {
+            match entry {
+                EntryType::Constant(pt) | EntryType::Public(pt) | EntryType::Private(pt) => check(pt)?,
+            }
+        }
+    }
+
+    // Check each mapping key and value.
+    for (_, mapping) in program.mappings() {
+        check(mapping.key().plaintext_type())?;
+        check(mapping.value().plaintext_type())?;
+    }
+
+    // Check closure inputs and outputs.
+    for (_, closure) in program.closures() {
+        for input in closure.inputs() {
+            if let RegisterType::Plaintext(pt) = input.register_type() {
+                check(pt)?;
+            }
+        }
+        for output in closure.outputs() {
+            if let RegisterType::Plaintext(pt) = output.register_type() {
+                check(pt)?;
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/synthesizer/src/vm/tests/test_v19/mod.rs
+++ b/synthesizer/src/vm/tests/test_v19/mod.rs
@@ -16,4 +16,7 @@
 // Tests that the translation-marked variants of Input and Output are checked correctly.
 mod translated_type_checks;
 
+// Tests for the V19 plaintext-type size bound.
+mod plaintext_size;
+
 use super::*;

--- a/synthesizer/src/vm/tests/test_v19/plaintext_size.rs
+++ b/synthesizer/src/vm/tests/test_v19/plaintext_size.rs
@@ -1,0 +1,192 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+use crate::Stack;
+
+use console::network::prelude::*;
+
+/// Builds a VM advanced to V19 height and runs `check_program_plaintext_sizes`
+/// against `program_text` using the V19 bit budget.
+fn run_check_at_v19(program_text: &str) -> Result<()> {
+    let rng = &mut TestRng::default();
+    let vm = sample_vm_at_height(CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V19).unwrap(), rng);
+
+    let program = Program::<CurrentNetwork>::from_str(program_text).unwrap();
+    let stack = Stack::new(vm.process(), &program).unwrap();
+    let max_bits = CurrentNetwork::LATEST_MAX_PLAINTEXT_TYPE_SIZE_IN_BITS();
+    check_program_plaintext_sizes(&program, &stack, max_bits)
+}
+
+/// A triply-nested 2048x2048x2048 bool array, the largest array type the element limit permits.
+/// It is rejected on the type AST, without sampling any leaf.
+#[test]
+fn test_deeply_nested_array_input_rejected() {
+    let result = run_check_at_v19(
+        r"
+program nested_array.aleo;
+
+function f:
+    input r0 as [[[boolean; 2048u32]; 2048u32]; 2048u32].private;
+    output r0 as [[[boolean; 2048u32]; 2048u32]; 2048u32].private;
+
+constructor:
+    assert.eq true true;
+",
+    );
+    let err = result.expect_err("over-cap nested array type must be rejected");
+    assert!(err.to_string().contains("exceeds the maximum allowed size in bits"), "unexpected error: {err}");
+}
+
+/// A program whose function input fits well under the cap is accepted.
+#[test]
+fn test_under_cap_function_input_accepted() {
+    run_check_at_v19(
+        r"
+program small.aleo;
+
+function f:
+    input r0 as [u64; 100u32].private;
+    output r0 as [u64; 100u32].private;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .expect("under-cap program must pass");
+}
+
+/// A struct whose member exceeds the per-type cap is rejected.
+#[test]
+fn test_over_cap_struct_member_rejected() {
+    let err = run_check_at_v19(
+        r"
+program big_struct.aleo;
+
+struct big:
+    huge as [[u64; 2048u32]; 9u32];
+
+function f:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .expect_err("over-cap struct member must be rejected");
+    assert!(err.to_string().contains("exceeds the maximum allowed size in bits"), "unexpected error: {err}");
+}
+
+/// A record entry that exceeds the per-type cap is rejected.
+#[test]
+fn test_over_cap_record_entry_rejected() {
+    let err = run_check_at_v19(
+        r"
+program big_record.aleo;
+
+record big:
+    owner as address.private;
+    huge as [[u64; 2048u32]; 9u32].private;
+
+function f:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .expect_err("over-cap record entry must be rejected");
+    assert!(err.to_string().contains("exceeds the maximum allowed size in bits"), "unexpected error: {err}");
+}
+
+/// A mapping value that exceeds the per-type cap is rejected.
+#[test]
+fn test_over_cap_mapping_value_rejected() {
+    let err = run_check_at_v19(
+        r"
+program big_mapping.aleo;
+
+mapping m:
+    key as u64.public;
+    value as [[u64; 2048u32]; 9u32].public;
+
+function f:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .expect_err("over-cap mapping value must be rejected");
+    assert!(err.to_string().contains("exceeds the maximum allowed size in bits"), "unexpected error: {err}");
+}
+
+/// A closure input that exceeds the per-type cap is rejected.
+#[test]
+fn test_over_cap_closure_input_rejected() {
+    let err = run_check_at_v19(
+        r"
+program big_closure.aleo;
+
+closure c:
+    input r0 as [[u64; 2048u32]; 9u32];
+    is.eq r0 r0 into r1;
+    output r1 as boolean;
+
+function f:
+    input r0 as u64.private;
+    output r0 as u64.private;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .expect_err("over-cap closure input must be rejected");
+    assert!(err.to_string().contains("exceeds the maximum allowed size in bits"), "unexpected error: {err}");
+}
+
+/// A finalize argument that exceeds the per-type cap is rejected.
+/// Since async arguments and finalize inputs must agree, the over-cap type also appears as
+/// a function input; the function-input check fires first, but the program is still rejected.
+/// The legacy `check_future_argument_bit_size` runs only before V14 and permits up to
+/// `u16::MAX` bits; this check applies from V19 with a tighter budget.
+#[test]
+fn test_over_cap_finalize_input_rejected() {
+    let err = run_check_at_v19(
+        r"
+program big_finalize.aleo;
+
+function f:
+    input r0 as u64.public;
+    input r1 as [[u64; 2048u32]; 9u32].public;
+    async f r0 r1 into r2;
+    output r2 as big_finalize.aleo/f.future;
+
+finalize f:
+    input r0 as u64.public;
+    input r1 as [[u64; 2048u32]; 9u32].public;
+    assert.eq r0 r0;
+
+constructor:
+    assert.eq true true;
+",
+    )
+    .expect_err("over-cap finalize input must be rejected");
+    assert!(err.to_string().contains("exceeds the maximum allowed size in bits"), "unexpected error: {err}");
+}

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -429,6 +429,17 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         }
                     }
                 }
+                if consensus_version >= ConsensusVersion::V19 {
+                    // Bound the size in bits of every plaintext type declared in the program. This runs
+                    // before deployment verification samples values, since sampling walks the leaves of
+                    // the declared type.
+                    let max_plaintext_type_bits =
+                        consensus_config_value!(N, MAX_PLAINTEXT_TYPE_SIZE_IN_BITS, current_block_height).ok_or_else(
+                            || anyhow!("Missing consensus config value: MAX_PLAINTEXT_TYPE_SIZE_IN_BITS"),
+                        )?;
+                    let stack = Stack::new(&self.process, deployment.program())?;
+                    check_program_plaintext_sizes(deployment.program(), &stack, max_plaintext_type_bits)?;
+                }
 
                 // Determine if any of the array types exceed the maximum array elements.
                 // Do not perform this check if the consensus version is beyond the latest version threshold for `MAX_ARRAY_ELEMENTS`.


### PR DESCRIPTION
Deployment verification did not bound the size of the `PlaintextType`s a program declares, while `Plaintext::to_fields` caps encoded data at `MAX_DATA_SIZE_IN_FIELDS` fields at runtime. This PR aligns them.

Gated at `V19`.