### PR TITLE
try to improve developer iteration times by turning off thin lto in test profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -677,8 +677,8 @@ lto = "off"
 incremental = true
 
 [profile.test]
-opt-level = 3
-lto = "thin"
+opt-level = 2
+lto = "off"
 incremental = true
 debug = true
 debug-assertions = true


### PR DESCRIPTION
the snarkVM version of this commit from snarkos:

https://github.com/ProvableHQ/snarkOS/pull/4376#issuecomment-5219227878

this repo is already putting target-cpu=native in the .cargo/config.toml since this commit:

https://github.com/ProvableHQ/snarkVM/commit/764617f121

so we don't bother to change that

---

it looks that the lto=thin stuff was added here:

https://github.com/ProvableHQ/snarkVM/commit/7a488f6e33

